### PR TITLE
let's reserve some more prefixes free

### DIFF
--- a/tools/tnodb_mock/tnodb.go
+++ b/tools/tnodb_mock/tnodb.go
@@ -54,7 +54,7 @@ func allocate(allocation *Allocation) (*net.IPNet, error) {
 
 	// random from 1 to subnetCount-1
 	// we never hand out the network 0 cause we keep it for the routing segment of the farm
-	nth := rand.Int63n(int64(subnetCount)-1) + 1
+	nth := rand.Int63n(int64(subnetCount)-16) + 16
 	for {
 		if !isIn(nth, allocation.SubNetUsed) {
 			allocation.SubNetUsed = append(allocation.SubNetUsed, uint64(nth))

--- a/tools/tnodb_mock/tnodb.go
+++ b/tools/tnodb_mock/tnodb.go
@@ -52,8 +52,9 @@ func allocate(allocation *Allocation) (*net.IPNet, error) {
 		return nil, fmt.Errorf("all subnets already allocated")
 	}
 
-	// random from 1 to subnetCount-1
-	// we never hand out the network 0 cause we keep it for the routing segment of the farm
+	// random from 000f to subnetCount
+	// we never hand out the network 0 to f cause we keep it for 
+	// adminstrative purposes (routing segment, mgmt, tunnel sources... )
 	nth := rand.Int63n(int64(subnetCount)-16) + 16
 	for {
 		if !isIn(nth, allocation.SubNetUsed) {


### PR DESCRIPTION
for administrative ends, (mgmt, routing , ....)
So we're not using `0000-000f`