### PR TITLE
Schema extended

### DIFF
--- a/modules/schema/generate.go
+++ b/modules/schema/generate.go
@@ -112,10 +112,19 @@ func (g *goGenerator) enum(j *jen.File, name string, typ *Type) error {
 
 func (g *goGenerator) renderType(typ *Type) (jen.Code, error) {
 	if typ == nil {
-		return nil, fmt.Errorf("type is nil")
+		return jen.Interface(), nil
 	}
 
 	switch typ.Kind {
+	case DictKind:
+		// Dicts in jumpscale do not provide an "element" type
+		// In that case (if element is not provided) a map of interface{} is
+		// used. If an element is provided, this element will be used instead
+		elem, err := g.renderType(typ.Element)
+		if err != nil {
+			return nil, err
+		}
+		return jen.Map(jen.Id("string")).Add(elem), nil
 	case ListKind:
 		elem, err := g.renderType(typ.Element)
 		if err != nil {

--- a/modules/schema/generate.go
+++ b/modules/schema/generate.go
@@ -16,13 +16,15 @@ var (
 	// in go, more types can be later added to schema modules
 	// and then mapped here to support it.
 	goKindMap = map[Kind][2]string{
-		StringKind:  {"", "string"},
-		IntegerKind: {"", "int64"},
-		FloatKind:   {"", "float64"},
-		BoolKind:    {"", "bool"},
-		DateKind:    {"github.com/threefoldtech/zosv2/modules/schema", "Date"},
-		NumericKind: {"github.com/threefoldtech/zosv2/modules/schema", "Numeric"},
-		//TODO add other types here (for example, Email, Phone, IP, etc..)
+		StringKind:    {"", "string"},
+		IntegerKind:   {"", "int64"},
+		FloatKind:     {"", "float64"},
+		BoolKind:      {"", "bool"},
+		DateKind:      {"github.com/threefoldtech/zosv2/modules/schema", "Date"},
+		NumericKind:   {"github.com/threefoldtech/zosv2/modules/schema", "Numeric"},
+		IpAddressKind: {"net", "IP"},
+		IpRangeKind:   {"github.com/threefoldtech/zosv2/modules/schema", "IPRange"},
+		//TODO add other types here (for example, Email, Phone, etc..)
 	}
 )
 

--- a/modules/schema/generate_test.go
+++ b/modules/schema/generate_test.go
@@ -89,3 +89,58 @@ creation = (D)
 	// 	return object, nil
 	// }
 }
+
+func ExampleGenerateGolang_enums() {
+	const input = `
+@url =  person
+name = "UNKNOWN" (S)    #official name of the package, there can be no overlap (can be dot notation)
+gender = "male,female,others" (E)
+	`
+
+	schema, err := New(strings.NewReader(input))
+	if err != nil {
+		panic(err)
+	}
+
+	if err := GenerateGolang(os.Stdout, "test", schema); err != nil {
+		panic(err)
+	}
+
+	// Output:
+	// package test
+	//
+	// import "encoding/json"
+	//
+	// type Person struct {
+	// 	Name   string           `json:"name"`
+	// 	Gender PersonGenderEnum `json:"gender"`
+	// }
+	//
+	// func NewPerson() (Person, error) {
+	// 	const value = "{\"name\": \"UNKNOWN\"}"
+	// 	var object Person
+	// 	if err := json.Unmarshal([]byte(value), &object); err != nil {
+	// 		return object, err
+	// 	}
+	// 	return object, nil
+	// }
+	//
+	// type PersonGenderEnum uint8
+	//
+	// const (
+	// 	PersonGenderMale PersonGenderEnum = iota
+	// 	PersonGenderFemale
+	// 	PersonGenderOthers
+	// )
+	//
+	// func (e PersonGenderEnum) String() string {
+	// 	switch e {
+	// 	case PersonGenderMale:
+	// 		return "male"
+	// 	case PersonGenderFemale:
+	// 		return "female"
+	// 	case PersonGenderOthers:
+	// 		return "others"
+	// 	}
+	// }
+}

--- a/modules/schema/generate_test.go
+++ b/modules/schema/generate_test.go
@@ -193,7 +193,7 @@ func ExampleGenerateGolang_dict() {
 	const input = `
 @url =  parent
 name = (S)    #official name of the package, there can be no overlap (can be dot notation)
-data = (dictO) ! child # dict of integers
+data = (dictO) ! child # dict of children
 tags = (M) # dict with no defined object type
 
 @url = child

--- a/modules/schema/generate_test.go
+++ b/modules/schema/generate_test.go
@@ -144,3 +144,47 @@ gender = "male,female,others" (E)
 	// 	}
 	// }
 }
+
+func ExampleGenerateGolang_ip() {
+	const input = `
+@url =  network
+name = "UNKNOWN" (S)    #official name of the package, there can be no overlap (can be dot notation)
+ip = "172.0.0.1" (ipaddr)
+net = "2001:db8::/32" (iprange)
+addresses = (Lipaddr)
+	`
+
+	schema, err := New(strings.NewReader(input))
+	if err != nil {
+		panic(err)
+	}
+
+	if err := GenerateGolang(os.Stdout, "test", schema); err != nil {
+		panic(err)
+	}
+
+	// Output:
+	// package test
+	//
+	// import (
+	// 	"encoding/json"
+	// 	schema "github.com/threefoldtech/zosv2/modules/schema"
+	// 	"net"
+	// )
+	//
+	// type Network struct {
+	// 	Name      string         `json:"name"`
+	// 	Ip        net.IP         `json:"ip"`
+	// 	Net       schema.IPRange `json:"net"`
+	// 	Addresses []net.IP       `json:"addresses"`
+	// }
+	//
+	// func NewNetwork() (Network, error) {
+	// 	const value = "{\"name\": \"UNKNOWN\", \"ip\": \"172.0.0.1\", \"net\": \"2001:db8::/32\"}"
+	// 	var object Network
+	// 	if err := json.Unmarshal([]byte(value), &object); err != nil {
+	// 		return object, err
+	// 	}
+	// 	return object, nil
+	// }
+}

--- a/modules/schema/generate_test.go
+++ b/modules/schema/generate_test.go
@@ -188,3 +188,58 @@ addresses = (Lipaddr)
 	// 	return object, nil
 	// }
 }
+
+func ExampleGenerateGolang_dict() {
+	const input = `
+@url =  parent
+name = (S)    #official name of the package, there can be no overlap (can be dot notation)
+data = (dictO) ! child # dict of integers
+tags = (M) # dict with no defined object type
+
+@url = child
+name = (S)
+	`
+
+	schema, err := New(strings.NewReader(input))
+	if err != nil {
+		panic(err)
+	}
+
+	if err := GenerateGolang(os.Stdout, "test", schema); err != nil {
+		panic(err)
+	}
+
+	// Output:
+	// package test
+	//
+	// import "encoding/json"
+	//
+	// type Parent struct {
+	// 	Name string                 `json:"name"`
+	// 	Data map[string]Child       `json:"data"`
+	// 	Tags map[string]interface{} `json:"tags"`
+	// }
+	//
+	// func NewParent() (Parent, error) {
+	// 	const value = "{}"
+	// 	var object Parent
+	// 	if err := json.Unmarshal([]byte(value), &object); err != nil {
+	// 		return object, err
+	// 	}
+	// 	return object, nil
+	// }
+	//
+	// type Child struct {
+	// 	Name string `json:"name"`
+	// }
+	//
+	// func NewChild() (Child, error) {
+	// 	const value = "{}"
+	// 	var object Child
+	// 	if err := json.Unmarshal([]byte(value), &object); err != nil {
+	// 		return object, err
+	// 	}
+	// 	return object, nil
+	// }
+
+}

--- a/modules/schema/parse.go
+++ b/modules/schema/parse.go
@@ -59,7 +59,10 @@ func (o *Object) Default() string {
 	buf.WriteRune('{')
 
 	for _, prop := range o.Properties {
-		if len(prop.Type.Default) == 0 {
+		if len(prop.Type.Default) == 0 || prop.Type.Kind == EnumKind {
+			// if default is not set OR if enum type, we don't set a default
+			// Note: we ignore enum type because enums always have defaults
+			// set to 0 (first item in the enum type)
 			continue
 		}
 
@@ -209,6 +212,7 @@ const (
 	BytesKind
 	PercentKind
 	URLKind
+	EnumKind
 )
 
 var (
@@ -226,6 +230,7 @@ var (
 		"P": PercentKind,
 		"U": URLKind,
 		"H": HashKind,
+		"E": EnumKind,
 
 		// long symbols, they must be lower case
 		"str":       StringKind,
@@ -251,6 +256,7 @@ var (
 		"percent":   PercentKind,
 		"url":       URLKind,
 		"object":    ObjectKind,
+		"enum":      EnumKind,
 	}
 )
 

--- a/modules/schema/parse.go
+++ b/modules/schema/parse.go
@@ -231,6 +231,7 @@ var (
 		"U": URLKind,
 		"H": HashKind,
 		"E": EnumKind,
+		"M": DictKind, // Map
 
 		// long symbols, they must be lower case
 		"str":       StringKind,
@@ -249,6 +250,7 @@ var (
 		"numeric":   NumericKind,
 		"guid":      GuidKind,
 		"dict":      DictKind,
+		"map":       DictKind,
 		"yaml":      YamlKind,
 		"multiline": MultilineKind,
 		"hash":      HashKind,

--- a/modules/schema/types.go
+++ b/modules/schema/types.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"regexp"
 	"strconv"
+	"strings"
 	"time"
 )
 
@@ -117,4 +118,16 @@ func (d *Date) UnmarshalJSON(bytes []byte) error {
 // MarshalJSON formats a text
 func (d Date) MarshalJSON() ([]byte, error) {
 	return []byte(d.Format("02/01/2006 15:04")), nil
+}
+
+//Enum type
+type Enum uint8
+
+func (e Enum) String(v string) string {
+	values := strings.Split(v, ",")
+	if int(e) >= len(values) {
+		panic("invalid enum value")
+	}
+
+	return values[uint8(e)]
 }

--- a/modules/schema/types.go
+++ b/modules/schema/types.go
@@ -5,7 +5,6 @@ import (
 	"fmt"
 	"regexp"
 	"strconv"
-	"strings"
 	"time"
 )
 
@@ -118,16 +117,4 @@ func (d *Date) UnmarshalJSON(bytes []byte) error {
 // MarshalJSON formats a text
 func (d Date) MarshalJSON() ([]byte, error) {
 	return []byte(d.Format("02/01/2006 15:04")), nil
-}
-
-//Enum type
-type Enum uint8
-
-func (e Enum) String(v string) string {
-	values := strings.Split(v, ",")
-	if int(e) >= len(values) {
-		panic("invalid enum value")
-	}
-
-	return values[uint8(e)]
 }

--- a/modules/schema/types.go
+++ b/modules/schema/types.go
@@ -3,6 +3,7 @@ package schema
 import (
 	"encoding/json"
 	"fmt"
+	"net"
 	"regexp"
 	"strconv"
 	"time"
@@ -117,4 +118,27 @@ func (d *Date) UnmarshalJSON(bytes []byte) error {
 // MarshalJSON formats a text
 func (d Date) MarshalJSON() ([]byte, error) {
 	return []byte(d.Format("02/01/2006 15:04")), nil
+}
+
+// IPRange type
+type IPRange struct{ net.IPNet }
+
+// UnmarshalText loads IPRange from string
+func (i *IPRange) UnmarshalText(text []byte) error {
+	_, net, err := net.ParseCIDR(string(text))
+	if err != nil {
+		return err
+	}
+
+	i.IPNet = *net
+	return nil
+}
+
+// MarshalText dumps iprange as a string
+func (i *IPRange) MarshalText() ([]byte, error) {
+	return []byte(i.String()), nil
+}
+
+func (i IPRange) String() string {
+	return i.IPNet.String()
 }


### PR DESCRIPTION
Add support for more data types in schema. This PR includes implementations for:

- IP Address (`ipaddr`)
- IP Range (`iprange`)
- Dict (`dict`)
- Enum (`enum`)

Fixes #141 