### PR TITLE
network: create portm package

### DIFF
--- a/modules/go.mod
+++ b/modules/go.mod
@@ -5,7 +5,7 @@ go 1.12
 require (
 	github.com/Microsoft/go-winio v0.4.12 // indirect
 	github.com/agl/ed25519 v0.0.0-20170116200512-5312a6153412
-	github.com/alexflint/go-filemutex v0.0.0-20171028004239-d358565f3c3f // indirect
+	github.com/alexflint/go-filemutex v0.0.0-20171028004239-d358565f3c3f
 	github.com/blang/semver v3.5.1+incompatible
 	github.com/containerd/cgroups v0.0.0-20190603164311-51b62d303d38 // indirect
 	github.com/containerd/containerd v1.2.3

--- a/modules/network/portm/allocator.go
+++ b/modules/network/portm/allocator.go
@@ -1,0 +1,77 @@
+package portm
+
+import (
+	"errors"
+
+	"github.com/threefoldtech/zosv2/modules/network/portm/backend"
+)
+
+var ErrNoFreePort = errors.New("no free port find")
+
+type PortRange struct {
+	Start int
+	End   int
+}
+
+type allocator struct {
+	pRange PortRange
+	store  backend.Store
+}
+
+var _ PortAllocator = (*allocator)(nil)
+
+func NewAllocator(pRange PortRange, store backend.Store) PortAllocator {
+	return &allocator{
+		pRange: pRange,
+		store:  store,
+	}
+}
+
+func (a *allocator) Reserve(ns string) (int, error) {
+
+	allocatedPorts, err := a.store.GetByNS(ns)
+	if err != nil {
+		return 0, err
+	}
+
+	start, err := a.store.LastReserved(ns)
+	if err != nil {
+		return 0, err
+	}
+
+	if start == -1 || start >= a.pRange.End {
+		// nothing reserve yet
+		// or we reach the end of the range
+		// then start from the start to re-use released port
+		start = a.pRange.Start
+	}
+
+	for port := start; port <= a.pRange.End; port++ {
+		if contains(allocatedPorts, port) {
+			continue
+		}
+
+		reserved, err := a.store.Reserve(ns, port)
+		if err != nil {
+			return 0, err
+		}
+		if reserved {
+			return port, nil
+		}
+	}
+
+	return 0, ErrNoFreePort
+}
+
+func (a *allocator) Release(ns string, port int) error {
+	return a.store.Release(ns, port)
+}
+
+func contains(s []int, port int) bool {
+	for i := range s {
+		if s[i] == port {
+			return true
+		}
+	}
+	return false
+}

--- a/modules/network/portm/allocator_test.go
+++ b/modules/network/portm/allocator_test.go
@@ -1,0 +1,165 @@
+package portm
+
+import (
+	"sync"
+	"testing"
+
+	mapset "github.com/deckarep/golang-set"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+type testStore struct {
+	reserved map[string]mapset.Set
+	last     map[string]int
+	sync.Mutex
+}
+
+func newTestStore() *testStore {
+	return &testStore{
+		reserved: make(map[string]mapset.Set),
+		last:     make(map[string]int, 0),
+	}
+}
+
+func (s *testStore) Lock() error {
+	s.Mutex.Lock()
+	return nil
+}
+func (s *testStore) Unlock() error {
+	s.Mutex.Unlock()
+	return nil
+}
+func (s *testStore) Reserve(ns string, port int) (bool, error) {
+	set, ok := s.reserved[ns]
+	if !ok {
+		set = mapset.NewSet()
+		s.reserved[ns] = set
+	}
+
+	if set.Contains(port) {
+		return false, nil
+	}
+
+	s.last[ns] = port
+	return set.Add(port), nil
+}
+func (s *testStore) Release(ns string, port int) error {
+	set, ok := s.reserved[ns]
+	if !ok {
+		return nil
+	}
+
+	set.Remove(port)
+	return nil
+}
+
+func (s *testStore) GetByNS(ns string) ([]int, error) {
+	set, ok := s.reserved[ns]
+	if !ok {
+		return []int{}, nil
+	}
+
+	ports := set.ToSlice()
+	output := make([]int, len(ports))
+	for i, p := range ports {
+		output[i] = p.(int)
+	}
+
+	return output, nil
+}
+
+func (s *testStore) LastReserved(ns string) (int, error) {
+	port, ok := s.last[ns]
+	if !ok {
+		return -1, nil
+	}
+	return port, nil
+}
+
+func (s *testStore) Close() error {
+	return nil
+}
+
+func TestReserve(t *testing.T) {
+	store := newTestStore()
+	pRange := PortRange{
+		Start: 1000,
+		End:   6000,
+	}
+	ns := "ns"
+	alloc := NewAllocator(pRange, store)
+
+	p1, err := alloc.Reserve(ns)
+	require.NoError(t, err)
+	assert.True(t, store.reserved[ns].Contains(p1))
+	assert.True(t, p1 >= pRange.Start)
+	assert.True(t, p1 <= pRange.End)
+
+	p2, err := alloc.Reserve(ns)
+	require.NoError(t, err)
+	assert.True(t, store.reserved[ns].Contains(p2))
+	assert.True(t, p1 != p2)
+	assert.True(t, p2 >= pRange.Start)
+	assert.True(t, p2 <= pRange.End)
+}
+
+func TestReuseReleased(t *testing.T) {
+	store := newTestStore()
+	pRange := PortRange{
+		Start: 1000,
+		End:   6000,
+	}
+	ns := "ns"
+	alloc := NewAllocator(pRange, store)
+
+	for i := 0; i <= 5000; i++ {
+		_, err := alloc.Reserve(ns)
+		require.NoError(t, err)
+	}
+
+	_, err := alloc.Reserve(ns)
+	assert.Equal(t, err, ErrNoFreePort)
+
+	err = alloc.Release(ns, 1000)
+	require.NoError(t, err)
+
+	port, err := alloc.Reserve(ns)
+	require.NoError(t, err)
+	assert.Equal(t, 1000, port)
+}
+
+func TestRelease(t *testing.T) {
+	store := newTestStore()
+	store.Reserve("ns", 1000)
+	store.Reserve("ns", 1001)
+
+	pRange := PortRange{
+		Start: 1000,
+		End:   6000,
+	}
+
+	alloc := NewAllocator(pRange, store)
+
+	err := alloc.Release("ns", 1000)
+	require.NoError(t, err)
+	assert.False(t, store.reserved["ns"].Contains(1000))
+}
+
+func BenchmarkReserve(b *testing.B) {
+	store := newTestStore()
+	pRange := PortRange{
+		Start: 1000,
+		End:   6000,
+	}
+	alloc := NewAllocator(pRange, store)
+
+	for i := 0; i < b.N; i++ {
+		port, err := alloc.Reserve("ns")
+		if err == ErrNoFreePort {
+			break
+		}
+		require.NoError(b, err)
+		_ = port
+	}
+}

--- a/modules/network/portm/backend/fs.go
+++ b/modules/network/portm/backend/fs.go
@@ -1,0 +1,105 @@
+package backend
+
+import (
+	"io/ioutil"
+	"os"
+	"path/filepath"
+	"strconv"
+)
+
+const lastPort = "last_reserved"
+const LineBreak = "\r\n"
+
+type fsStore struct {
+	*FileLock
+	root string
+}
+
+func NewFSStore(root string) (Store, error) {
+	if err := os.MkdirAll(root, 0755); err != nil {
+		return nil, err
+	}
+
+	lk, err := NewFileLock(root)
+	if err != nil {
+		return nil, err
+	}
+
+	return &fsStore{
+		FileLock: lk,
+		root:     root,
+	}, nil
+}
+
+func nsPath(root, ns string, port string) string {
+	return filepath.Join(root, ns, port)
+}
+
+func (s *fsStore) Reserve(ns string, port int) (bool, error) {
+	fname := nsPath(s.root, ns, strconv.Itoa(port))
+
+	if err := os.MkdirAll(filepath.Dir(fname), 0755); err != nil {
+		return false, err
+	}
+
+	f, err := os.OpenFile(fname, os.O_CREATE|os.O_EXCL|os.O_TRUNC, 0660)
+	if os.IsExist(err) {
+		return false, nil
+	}
+	if err != nil {
+		return false, err
+	}
+
+	if err := f.Close(); err != nil {
+		os.Remove(f.Name())
+		return false, err
+	}
+
+	// store the reserved port in lastPort file
+	lastPortFile := nsPath(s.root, ns, lastPort)
+	err = ioutil.WriteFile(lastPortFile, []byte(strconv.Itoa(port)), 0644)
+	if err != nil {
+		return false, err
+	}
+	return true, nil
+}
+
+func (s *fsStore) Release(ns string, port int) error {
+	fname := nsPath(s.root, ns, strconv.Itoa(port))
+
+	return os.Remove(fname)
+}
+
+func (s *fsStore) LastReserved(ns string) (int, error) {
+	lastPortFile := nsPath(s.root, ns, lastPort)
+	data, err := ioutil.ReadFile(lastPortFile)
+	if os.IsNotExist(err) {
+		return -1, nil
+	}
+	if err != nil {
+		return 0, err
+	}
+	return strconv.Atoi(string(data))
+}
+
+func (s *fsStore) GetByNS(ns string) ([]int, error) {
+	var ports []int
+	dir := filepath.Join(s.root, ns)
+
+	// walk through all ips in this network to get the ones which belong to a specific ID
+	_ = filepath.Walk(dir, func(path string, info os.FileInfo, err error) error {
+		if err != nil || info.IsDir() {
+			return nil
+		}
+
+		p, err := strconv.Atoi(info.Name())
+		if err != nil {
+			return err
+		}
+		ports = append(ports, p)
+
+		return nil
+	})
+
+	return ports, nil
+}

--- a/modules/network/portm/backend/fs_test.go
+++ b/modules/network/portm/backend/fs_test.go
@@ -1,0 +1,44 @@
+package backend
+
+import (
+	"io/ioutil"
+	"os"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestReserve(t *testing.T) {
+	dir, err := ioutil.TempDir("", "")
+	require.NoError(t, err)
+
+	defer func() {
+		os.RemoveAll(dir)
+	}()
+
+	ns1 := "ns"
+	ns2 := "ns2"
+
+	store, err := NewFSStore(dir)
+	require.NoError(t, err)
+
+	reserved, err := store.Reserve(ns1, 1)
+	require.NoError(t, err)
+	assert.True(t, reserved)
+
+	reserved, err = store.Reserve(ns1, 1)
+	require.NoError(t, err)
+	assert.False(t, reserved, "should not be able to reserve the same port twice")
+
+	err = store.Release(ns1, 1)
+	require.NoError(t, err)
+
+	reserved, err = store.Reserve(ns1, 1)
+	require.NoError(t, err)
+	assert.True(t, reserved, "should be able to reserve a released port")
+
+	reserved, err = store.Reserve(ns2, 1)
+	require.NoError(t, err)
+	assert.True(t, reserved, "should be able to reserve same port in difference namespace")
+}

--- a/modules/network/portm/backend/lock.go
+++ b/modules/network/portm/backend/lock.go
@@ -1,0 +1,46 @@
+package backend
+
+import (
+	"os"
+	"path"
+
+	"github.com/alexflint/go-filemutex"
+)
+
+// FileLock wraps os.File to be used as a lock using flock
+type FileLock struct {
+	f *filemutex.FileMutex
+}
+
+// NewFileLock opens file/dir at path and returns unlocked FileLock object
+func NewFileLock(lockPath string) (*FileLock, error) {
+	fi, err := os.Stat(lockPath)
+	if err != nil {
+		return nil, err
+	}
+
+	if fi.IsDir() {
+		lockPath = path.Join(lockPath, "lock")
+	}
+
+	f, err := filemutex.New(lockPath)
+	if err != nil {
+		return nil, err
+	}
+
+	return &FileLock{f}, nil
+}
+
+func (l *FileLock) Close() error {
+	return l.f.Close()
+}
+
+// Lock acquires an exclusive lock
+func (l *FileLock) Lock() error {
+	return l.f.Lock()
+}
+
+// Unlock releases the lock
+func (l *FileLock) Unlock() error {
+	return l.f.Unlock()
+}

--- a/modules/network/portm/backend/lock_test.go
+++ b/modules/network/portm/backend/lock_test.go
@@ -1,0 +1,49 @@
+package backend
+
+// import (
+// 	"io/ioutil"
+// 	"os"
+// 	"path/filepath"
+
+// 	. "github.com/onsi/ginkgo"
+// 	. "github.com/onsi/gomega"
+// )
+
+// var _ = Describe("Lock Operations", func() {
+// 	It("locks a file path", func() {
+// 		dir, err := ioutil.TempDir("", "")
+// 		Expect(err).ToNot(HaveOccurred())
+// 		defer os.RemoveAll(dir)
+
+// 		// create a dummy file to lock
+// 		path := filepath.Join(dir, "x")
+// 		f, err := os.OpenFile(path, os.O_RDONLY|os.O_CREATE, 0666)
+// 		Expect(err).ToNot(HaveOccurred())
+// 		err = f.Close()
+// 		Expect(err).ToNot(HaveOccurred())
+
+// 		// now use it to lock
+// 		m, err := NewFileLock(path)
+// 		Expect(err).ToNot(HaveOccurred())
+
+// 		err = m.Lock()
+// 		Expect(err).ToNot(HaveOccurred())
+// 		err = m.Unlock()
+// 		Expect(err).ToNot(HaveOccurred())
+// 	})
+
+// 	It("locks a folder path", func() {
+// 		dir, err := ioutil.TempDir("", "")
+// 		Expect(err).ToNot(HaveOccurred())
+// 		defer os.RemoveAll(dir)
+
+// 		// use the folder to lock
+// 		m, err := NewFileLock(dir)
+// 		Expect(err).ToNot(HaveOccurred())
+
+// 		err = m.Lock()
+// 		Expect(err).ToNot(HaveOccurred())
+// 		err = m.Unlock()
+// 		Expect(err).ToNot(HaveOccurred())
+// 	})
+// })

--- a/modules/network/portm/backend/store.go
+++ b/modules/network/portm/backend/store.go
@@ -1,0 +1,11 @@
+package backend
+
+type Store interface {
+	Lock() error
+	Unlock() error
+	Reserve(ns string, port int) (bool, error)
+	Release(ns string, port int) error
+	LastReserved(ns string) (int, error)
+	GetByNS(ns string) ([]int, error)
+	Close() error
+}

--- a/modules/network/portm/interface.go
+++ b/modules/network/portm/interface.go
@@ -1,0 +1,6 @@
+package portm
+
+type PortAllocator interface {
+	Reserve(ns string) (int, error)
+	Release(ns string, port int) error
+}


### PR DESCRIPTION
portm package implement a port manager that allows to keep
track of which port is being used in a network namespace

fixes #176