### PR TITLE
bootstrap

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,4 +12,4 @@ tools/upgradectl/upgradectl
 
 qemu/node*
 qemu/*.efi
-
+.ssh

--- a/qemu/overlay/etc/zinit/bootstrap.yaml
+++ b/qemu/overlay/etc/zinit/bootstrap.yaml
@@ -1,0 +1,6 @@
+# Override the default bootstrap procedure
+# embedded in the image if using overlay
+exec: "true"
+oneshot: true
+after:
+  - internet

--- a/qemu/overlay/etc/zinit/internet.yaml
+++ b/qemu/overlay/etc/zinit/internet.yaml
@@ -1,0 +1,1 @@
+../../../../zinit/internet.yaml

--- a/qemu/overlay/etc/zinit/provisiond.yaml
+++ b/qemu/overlay/etc/zinit/provisiond.yaml
@@ -1,0 +1,1 @@
+../../../../zinit/provisiond.yaml


### PR DESCRIPTION
- I decided to move the bootstrap code from 0-initramfs to zosv2 repo. This will make it much easier to update the bootprocess and have all related files in one repo (since bootstrap depends on `interent`) which is defined here.
- I added missing links to qemu overlay.
- 0-initramfs has another PR https://github.com/threefoldtech/0-initramfs/pull/23 that uses new make file to build an install the parts of zosv2 that need to embedded in the image (bootstrap script and internet and required config files)
- If you are using overlay, the overlay have a `bootstrap.yaml` that will override the one copied to the image and skip bootstraping via flist.