### PR TITLE
Update tfuser and provision to get resource id when creating provision

### DIFF
--- a/tools/bcdb_mock/provision.go
+++ b/tools/bcdb_mock/provision.go
@@ -36,6 +36,7 @@ func reserve(w http.ResponseWriter, r *http.Request) {
 		Reservation: res,
 		NodeID:      nodeID,
 	})
+	w.Header().Set("Location", "/reservations/"+res.ID)
 	w.WriteHeader(http.StatusCreated)
 }
 

--- a/tools/tfuser/cmds_provision.go
+++ b/tools/tfuser/cmds_provision.go
@@ -74,10 +74,13 @@ func cmdsProvision(c *cli.Context) error {
 	}
 
 	for _, nodeID := range nodeIDs {
-		if err := store.Reserve(r, modules.StrIdentifier(nodeID)); err != nil {
+		id, err := store.Reserve(r, modules.StrIdentifier(nodeID))
+		if err != nil {
 			return errors.Wrap(err, "failed to send reservation")
 		}
-		fmt.Printf("reservation for %v send to node %s\n", duration, nodeID)
+
+		fmt.Printf("Reservation for %v send to node %s\n", duration, nodeID)
+		fmt.Printf("Resource: %v\n", id)
 	}
 
 	return nil

--- a/tools/tfuser/tno.go
+++ b/tools/tfuser/tno.go
@@ -182,10 +182,12 @@ func reserveNetwork(network *modules.Network) error {
 
 	for nodeID := range nodes.Iter() {
 		nodeID := nodeID.(string)
-		if err := store.Reserve(r, modules.StrIdentifier(nodeID)); err != nil {
+		id, err := store.Reserve(r, modules.StrIdentifier(nodeID))
+		if err != nil {
 			return err
 		}
-		fmt.Printf("network reservation sent for node ID %s\n", nodeID)
+
+		fmt.Printf("network reservation sent for node ID %s (%v)\n", nodeID, id)
 	}
 
 	return nil


### PR DESCRIPTION
When requesting a provision, the id of the created resource is returned.
This implementation use `Location:` header to return the url to get information about created resource. This follow HTTP RESP implementation.

Tool `tfuser` is updated to print the resource link on creation.