### PR TITLE
Fix github actions workflow filesname

### DIFF
--- a/.github/workflows/publish-development.yaml
+++ b/.github/workflows/publish-development.yaml
@@ -40,12 +40,12 @@ jobs:
         user: tf-autobuilder
         root: archive
         token: ${{ secrets.HUB_JWT }}
-        name: zos:${{ github.sha }}.flist
+        name: zos-${{ github.sha }}.flist
 
     - name: Set name of the development build
       id: setname
       run: |
-        echo "::set-output name=build::zos-$(date +%y%m%d.%H%M%S.0)-dev.flist"
+        echo "::set-output name=build::zos:v$(date +%y%m%d.%H%M%S.0)-dev.flist"
 
     - name: Promote flist (${{ github.sha }})
       if: success()
@@ -55,7 +55,7 @@ jobs:
         user: tf-zos
         root: archive
         token: ${{ secrets.HUB_JWT }}
-        name: tf-autobuilder/zos:${{ github.sha }}.flist
+        name: tf-autobuilder/zos-${{ github.sha }}.flist
         target: ${{ steps.setname.outputs.build }}
 
     - name: Readlink of current development build

--- a/.github/workflows/publish-pre-release.yaml
+++ b/.github/workflows/publish-pre-release.yaml
@@ -49,7 +49,7 @@ jobs:
         user: tf-autobuilder
         root: archive
         token: ${{ secrets.HUB_JWT }}
-        name: zos:${{ github.sha }}.flist
+        name: zos-${{ github.sha }}.flist
 
     - name: Promote flist (${{ github.ref }})
       if: success()
@@ -58,7 +58,7 @@ jobs:
         action: promote
         user: tf-zos
         token: ${{ secrets.HUB_JWT }}
-        name: tf-autobuilder/zos:${{ github.sha }}.flist
+        name: tf-autobuilder/zos-${{ github.sha }}.flist
         target: zos:${{ github.ref }}.flist
 
     - name: Symlink flist (development)

--- a/.github/workflows/publish-release.yaml
+++ b/.github/workflows/publish-release.yaml
@@ -50,7 +50,7 @@ jobs:
         user: tf-autobuilder
         root: archive
         token: ${{ secrets.HUB_JWT }}
-        name: zos:${{ github.sha }}.flist
+        name: zos-${{ github.sha }}.flist
 
     - name: Promote flist (${{ github.ref }})
       if: success()
@@ -59,8 +59,8 @@ jobs:
         action: promote
         user: tf-zos
         token: ${{ secrets.HUB_JWT }}
-        name: tf-autobuilder/zos:${{ github.sha }}.flist
-        target: zos-${{ github.ref }}.flist
+        name: tf-autobuilder/zos-${{ github.sha }}.flist
+        target: zos:${{ github.ref }}.flist
     
     - name: Symlink flist (development)
       if: success()


### PR DESCRIPTION
This changes small things on actions workflow:
- Revert coma on tf-autobuilder (not needed, let's keep dash like all other build)
- Fix the promote filename for development build