### PR TITLE
Migration routine to reuse disks from v1

### DIFF
--- a/pkg/storage/filesystem/btrfs_test.go
+++ b/pkg/storage/filesystem/btrfs_test.go
@@ -15,6 +15,10 @@ type TestDeviceManager struct {
 	devices DeviceCache
 }
 
+func (m *TestDeviceManager) Reset() DeviceManager {
+	return m
+}
+
 func (m *TestDeviceManager) Device(ctx context.Context, path string) (*Device, error) {
 	for idx := range m.devices {
 		loop := &m.devices[idx]
@@ -38,6 +42,10 @@ func (m *TestDeviceManager) ByLabel(ctx context.Context, label string) ([]*Devic
 }
 
 func (m *TestDeviceManager) Devices(ctx context.Context) (DeviceCache, error) {
+	return m.devices, nil
+}
+
+func (m *TestDeviceManager) Raw(ctx context.Context) (DeviceCache, error) {
 	return m.devices, nil
 }
 

--- a/pkg/storage/filesystem/device_test.go
+++ b/pkg/storage/filesystem/device_test.go
@@ -40,7 +40,7 @@ func TestDeviceManagerScan(t *testing.T) {
 	exec.On("run", mock.Anything, "seektime", "-j", "/tmp/dev2").
 		Return([]byte(`{"type": "HDD", "elapsed": 5000}`), nil)
 
-	mgr, err := defaultDeviceManager(ctx, &exec)
+	mgr := defaultDeviceManager(ctx, &exec)
 	require.NoError(err)
 
 	cached, err := mgr.Devices(ctx)

--- a/pkg/storage/filesystem/migrate.go
+++ b/pkg/storage/filesystem/migrate.go
@@ -9,6 +9,10 @@ import (
 	"github.com/rs/zerolog/log"
 )
 
+const (
+	zosV1PoolPrefix = "sp_"
+)
+
 var (
 	zeros [512]byte
 )
@@ -43,13 +47,13 @@ func migrate(ctx context.Context, m DeviceManager, exe executer) (DeviceManager,
 	var destroyMe []Device
 loop:
 	for _, device := range devices {
-		if strings.HasPrefix(device.Label, "sp_") {
+		if strings.HasPrefix(device.Label, zosV1PoolPrefix) {
 			destroyMe = append(destroyMe, device)
 			continue
 		}
 
 		for _, child := range device.Children {
-			if strings.HasPrefix(child.Label, "sp_") {
+			if strings.HasPrefix(child.Label, zosV1PoolPrefix) {
 				destroyMe = append(destroyMe, device)
 				continue loop
 			}

--- a/pkg/storage/filesystem/migrate.go
+++ b/pkg/storage/filesystem/migrate.go
@@ -1,0 +1,76 @@
+package filesystem
+
+import (
+	"context"
+	"io/ioutil"
+	"strings"
+
+	"github.com/pkg/errors"
+	"github.com/rs/zerolog/log"
+)
+
+var (
+	zeros [512]byte
+)
+
+func wipe(ctx context.Context, device *Device, exe executer) error {
+	//we first make an msdos parition, because we know it's 512 bytes
+	//creating the msdos partition table also makes us validate that this
+	//is indeed a valid block device
+	if _, err := exe.run(ctx, "parted", "-s", device.Path, "mktable", "msdos"); err != nil {
+		return errors.Wrap(err, "failed to create msdos partition table")
+	}
+
+	//then we write down this exact amount to device
+	return ioutil.WriteFile(device.Path, zeros[:], 0660)
+}
+
+// Migrate is a simple migration routine that makes sure we have
+// fresh disks to use from zos v1, in case you moving
+// away from older version
+// After migration you should alway use the returned Device manager, or create
+// a new one.
+func Migrate(ctx context.Context, m DeviceManager) (DeviceManager, error) {
+	return migrate(ctx, m, executerFunc(run))
+}
+
+func migrate(ctx context.Context, m DeviceManager, exe executer) (DeviceManager, error) {
+	devices, err := m.Raw(ctx)
+	if err != nil {
+		return nil, errors.Wrap(err, "migration failed, couldn't list disks")
+	}
+
+	var destroyMe []Device
+loop:
+	for _, device := range devices {
+		if strings.HasPrefix(device.Label, "sp_") {
+			destroyMe = append(destroyMe, device)
+			continue
+		}
+
+		for _, child := range device.Children {
+			if strings.HasPrefix(child.Label, "sp_") {
+				destroyMe = append(destroyMe, device)
+				continue loop
+			}
+		}
+	}
+
+	for _, device := range destroyMe {
+		log.Warn().Str("device", device.Path).Msg("wiping device")
+		if err := wipe(ctx, &device, exe); err != nil {
+			log.Error().Err(err).Str("device", device.Path).Msg("failed to wipe disk")
+		}
+	}
+	if len(destroyMe) > 0 {
+		if out, err := exe.run(ctx, "sync"); err != nil {
+			log.Error().Err(err).Str("out", string(out)).Msg("failed sync devices")
+		}
+		if out, err := exe.run(ctx, "partprobe"); err != nil {
+			log.Error().Err(err).Str("out", string(out)).Msg("failed to partprobe")
+		}
+
+	}
+
+	return m.Reset(), nil
+}

--- a/pkg/storage/filesystem/migrate_test.go
+++ b/pkg/storage/filesystem/migrate_test.go
@@ -31,6 +31,8 @@ func TestMigrate(t *testing.T) {
 	_, err := migrate(ctx, &mgr, &exec)
 	require.NoError(err)
 
+	exec.AssertCalled(t, "run", ctx, "partprobe")
+
 	for _, fake := range []string{"/tmp/fakeb", "/tmp/fakec"} {
 		stat, err := os.Stat(fake)
 		require.NoError(err)

--- a/pkg/storage/filesystem/migrate_test.go
+++ b/pkg/storage/filesystem/migrate_test.go
@@ -1,0 +1,50 @@
+package filesystem
+
+import (
+	"context"
+	"os"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestMigrate(t *testing.T) {
+	require := require.New(t)
+	var exec TestExecuter
+	mgr := TestDeviceManager{
+		devices: DeviceCache{
+			Device{Path: "/tmp/fakea", Label: "1234"},
+			Device{Path: "/tmp/fakeb", Label: "sp_1234"},
+			Device{Path: "/tmp/fakec", Children: []Device{
+				Device{Path: "/tmp/fakec1", Label: "sp_1234"},
+			}},
+			Device{Path: "/tmp/faked", Children: []Device{
+				Device{Path: "/tmp/faked1", Label: "1234"},
+			}},
+			Device{Path: "/tmp/fakee"},
+		},
+	}
+
+	ctx := context.Background()
+	// we expect calls to wipe for /tmp/fakeb and /tmp/fakec
+	exec.On("run", ctx, "parted", "-s", "/tmp/fakeb", "mktable", "msdos").Return([]byte{}, nil)
+	exec.On("run", ctx, "parted", "-s", "/tmp/fakec", "mktable", "msdos").Return([]byte{}, nil)
+
+	exec.On("run", ctx, "sync").Return([]byte{}, nil)
+	exec.On("run", ctx, "partprobe").Return([]byte{}, nil)
+	_, err := migrate(ctx, &mgr, &exec)
+	require.NoError(err)
+
+	exec.AssertCalled(t, "run", ctx, "parted", "-s", "/tmp/fakeb", "mktable", "msdos")
+	exec.AssertCalled(t, "run", ctx, "parted", "-s", "/tmp/fakec", "mktable", "msdos")
+	exec.AssertNotCalled(t, "run", ctx, "parted", "-s", "/tmp/fakea", "mktable", "msdos")
+	exec.AssertNotCalled(t, "run", ctx, "parted", "-s", "/tmp/faked", "mktable", "msdos")
+	exec.AssertNotCalled(t, "run", ctx, "parted", "-s", "/tmp/fakee", "mktable", "msdos")
+
+	for _, fake := range []string{"/tmp/fakeb", "/tmp/fakec"} {
+		stat, err := os.Stat(fake)
+		require.NoError(err)
+		require.Equal(int64(512), stat.Size())
+		os.Remove(fake)
+	}
+}

--- a/pkg/storage/storage.go
+++ b/pkg/storage/storage.go
@@ -37,7 +37,9 @@ func New() (pkg.StorageModule, error) {
 	ctx, cancel := context.WithTimeout(context.Background(), time.Second*30)
 	defer cancel()
 
-	m, err := filesystem.DefaultDeviceManager(ctx)
+	m := filesystem.DefaultDeviceManager(ctx)
+
+	m, err := filesystem.Migrate(context.Background(), m)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
This detects if a disk is was used by zos v1
and make sure the disk is cleaned up for v2 usage

Fixes #339 