### PR TITLE
contd: remove coreX chroot hack

### DIFF
--- a/pkg/container.go
+++ b/pkg/container.go
@@ -20,10 +20,8 @@ type NetworkInfo struct {
 
 // MountInfo defines a mount point
 type MountInfo struct {
-	Source  string   // source of the mount point on the host
-	Target  string   // target of mount inside the container
-	Type    string   // mount type
-	Options []string // mount options
+	Source string // source of the mount point on the host
+	Target string // target of mount inside the container
 }
 
 //Container creation info

--- a/pkg/container/opts.go
+++ b/pkg/container/opts.go
@@ -77,7 +77,7 @@ func withCoreX() oci.SpecOpts {
 		s.Mounts = append(s.Mounts, specs.Mount{
 			Destination: "/corex",
 			Type:        "bind",
-			Source:      "/sbin/corex",
+			Source:      "/usr/bin/corex",
 			Options:     []string{"rbind", "ro"},
 		})
 		return nil

--- a/pkg/provision/container.go
+++ b/pkg/provision/container.go
@@ -153,10 +153,8 @@ func containerProvisionImpl(ctx context.Context, reservation *Reservation) (Cont
 		mounts = append(
 			mounts,
 			pkg.MountInfo{
-				Source:  source,
-				Target:  mountpoint,
-				Type:    "none",
-				Options: []string{"bind"},
+				Source: source,
+				Target: mountpoint,
 			},
 		)
 	}

--- a/pkg/provision/container_test.go
+++ b/pkg/provision/container_test.go
@@ -221,10 +221,8 @@ func TestContainerProvisionWithMounts(t *testing.T) {
 			},
 			Mounts: []pkg.MountInfo{
 				{
-					Source:  "/some/path/to/vol1",
-					Target:  "/opt",
-					Type:    "none",
-					Options: []string{"bind"},
+					Source: "/some/path/to/vol1",
+					Target: "/opt",
 				},
 			},
 		}).

--- a/pkg/provision/zdb.go
+++ b/pkg/provision/zdb.go
@@ -261,16 +261,12 @@ func createZdbContainer(ctx context.Context, name string, mode pkg.ZDBMode, volu
 			Network:     pkg.NetworkInfo{Namespace: netNsName},
 			Mounts: []pkg.MountInfo{
 				{
-					Source:  volumePath,
-					Target:  "/data",
-					Type:    "none",
-					Options: []string{"bind"},
+					Source: volumePath,
+					Target: "/data",
 				},
 				{
-					Source:  socketDir,
-					Target:  "/socket",
-					Type:    "none",
-					Options: []string{"bind"},
+					Source: socketDir,
+					Target: "/socket",
 				},
 			},
 		})

--- a/pkg/provision/zdb_test.go
+++ b/pkg/provision/zdb_test.go
@@ -180,16 +180,12 @@ func TestZDBProvisionNoMappingContainerDoesNotExists(t *testing.T) {
 			Network: pkg.NetworkInfo{Namespace: "net-ns"},
 			Mounts: []pkg.MountInfo{
 				pkg.MountInfo{
-					Source:  "/path/to/volume",
-					Target:  "/data",
-					Type:    "none",
-					Options: []string{"bind"},
+					Source: "/path/to/volume",
+					Target: "/data",
 				},
 				pkg.MountInfo{
-					Source:  "/var/run/zdb_container-id",
-					Target:  "/socket",
-					Type:    "none",
-					Options: []string{"bind"},
+					Source: "/var/run/zdb_container-id",
+					Target: "/socket",
 				},
 			},
 			Entrypoint:  "/bin/zdb --data /data --index /data --mode seq  --listen :: --port 9900 --socket /socket/zdb.sock --dualnet",


### PR DESCRIPTION
fixes #381
Now that we have coreX build staticly, we can just mount the binary into
the container. We don't need to do the chroot hack

Let's wait we have a new base image with static coreX binary before merging this.