### PR TITLE
Also send node id v1 to BCDB when registring the node

### DIFF
--- a/pkg/gedis/commands_identity.go
+++ b/pkg/gedis/commands_identity.go
@@ -25,22 +25,25 @@ import (
 func (g *Gedis) RegisterNode(nodeID pkg.Identifier, farmID pkg.FarmID, version string, location geoip.Location) (string, error) {
 
 	pk := base58.Decode(nodeID.Identity())
-
-	resp, err := Bytes(g.Send("nodes", "add", Args{
-		"node": directory.TfgridNode2{
-			NodeID:       nodeID.Identity(),
-			FarmID:       uint64(farmID),
-			OsVersion:    version,
-			PublicKeyHex: hex.EncodeToString(pk),
-			Location: directory.TfgridLocation1{
-				Longitude: location.Longitute,
-				Latitude:  location.Latitude,
-				Continent: location.Continent,
-				Country:   location.Country,
-				City:      location.City,
-			},
+	node := directory.TfgridNode2{
+		NodeID:       nodeID.Identity(),
+		FarmID:       uint64(farmID),
+		OsVersion:    version,
+		PublicKeyHex: hex.EncodeToString(pk),
+		Location: directory.TfgridLocation1{
+			Longitude: location.Longitute,
+			Latitude:  location.Latitude,
+			Continent: location.Continent,
+			Country:   location.Country,
+			City:      location.City,
 		},
-	}))
+	}
+	idv1, err := network.NodeIDv1()
+	if err == nil {
+		node.NodeIDv1 = idv1
+	}
+
+	resp, err := Bytes(g.Send("nodes", "add", Args{"node": node}))
 
 	if err != nil {
 		return "", err

--- a/pkg/gedis/types/directory/tfgrid_node_2.go
+++ b/pkg/gedis/types/directory/tfgrid_node_2.go
@@ -9,6 +9,7 @@ import (
 //TfgridNode2 jsx schema
 type TfgridNode2 struct {
 	NodeID            string                    `json:"node_id"`
+	NodeIDv1          string                    `json:"node_id_v1"`
 	FarmID            uint64                    `json:"farm_id"`
 	OsVersion         string                    `json:"os_version"`
 	Created           schema.Date               `json:"created"`

--- a/pkg/network/v1.go
+++ b/pkg/network/v1.go
@@ -1,0 +1,33 @@
+package network
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/vishvananda/netlink"
+)
+
+// NodeIDv1 returns the node ID as it was calculated in 0-OS v1
+func NodeIDv1() (string, error) {
+	zos, err := netlink.LinkByName(DefaultBridge)
+	if err != nil {
+		return "", err
+	}
+
+	links, err := netlink.LinkList()
+	if err != nil {
+		return "", err
+	}
+
+	// find the physical interface attached to the default bridge
+	for _, l := range links {
+		if l.Attrs().MasterIndex == zos.Attrs().Index {
+			return convertMac(l.Attrs().HardwareAddr.String()), nil
+		}
+	}
+	return "", fmt.Errorf("not physical interface attached to default bridge found")
+}
+
+func convertMac(mac string) string {
+	return strings.Replace(mac, ":", "", -1)
+}

--- a/pkg/network/v1_test.go
+++ b/pkg/network/v1_test.go
@@ -1,0 +1,12 @@
+package network
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestConvertMac(t *testing.T) {
+	id := convertMac("fe:44:e1:67:a8:d2")
+	assert.Equal(t, "fe44e167a8d2", id)
+}


### PR DESCRIPTION
this is required to be able to match nodes between v1 and v2.