### PR TITLE
Set mac of zos to slave (internet bootstrap)

### DIFF
--- a/pkg/network/bootstrap.go
+++ b/pkg/network/bootstrap.go
@@ -77,7 +77,7 @@ func Bootstrap() error {
 		}
 
 		log.Info().Str("interface", device.Name).Msg("attach interface to default bridge")
-		if err := bridge.AttachNic(device, br); err != nil {
+		if err := bridge.AttachNicWithMac(device, br); err != nil {
 			log.Warn().Err(err).
 				Str("device", device.Name).
 				Str("bridge", br.Name).

--- a/pkg/network/bridge/bridge.go
+++ b/pkg/network/bridge/bridge.go
@@ -87,6 +87,18 @@ func AttachNic(link netlink.Link, bridge *netlink.Bridge) error {
 	return netlink.LinkSetMaster(link, bridge)
 }
 
+// AttachNicWithMac attaches an interface to a bridge and sets
+// the MAC of the bridge to the same of the NIC
+func AttachNicWithMac(link netlink.Link, bridge *netlink.Bridge) error {
+	hwaddr := link.Attrs().HardwareAddr
+
+	err := netlink.LinkSetHardwareAddr(bridge, hwaddr)
+	if err != nil {
+		return err
+	}
+	return netlink.LinkSetMaster(link, bridge)
+}
+
 // DetachNic detaches an interface from a bridge
 func DetachNic(bridge *netlink.Bridge) error {
 	return netlink.LinkSetNoMaster(bridge)


### PR DESCRIPTION
In bootstrap (probably because of the speed of cycling), the mac addres of the zos bridge is not always the same as it's slave.
now it is ;-)
