### PR TITLE
Derive static mac for ndmz and public ns public if

### DIFF
--- a/cmds/networkd/main.go
+++ b/cmds/networkd/main.go
@@ -76,7 +76,7 @@ func main() {
 	ifaceVersion := -1
 	exitIface, err := db.GetPubIface(nodeID)
 	if err == nil {
-		if err := configurePubIface(exitIface); err != nil {
+		if err := configurePubIface(exitIface, nodeID); err != nil {
 			log.Error().Err(err).Msg("failed to configure public interface")
 			os.Exit(1)
 		}
@@ -91,14 +91,14 @@ func main() {
 		for {
 			select {
 			case iface := <-ch:
-				_ = configurePubIface(iface)
+				_ = configurePubIface(iface, nodeID)
 			case <-ctx.Done():
 				return
 			}
 		}
 	}(ctx, chIface)
 
-	if err := ndmz.Create(); err != nil {
+	if err := ndmz.Create(nodeID); err != nil {
 		log.Fatal().Err(err).Msgf("failed to create DMZ")
 	}
 

--- a/cmds/networkd/pubiface.go
+++ b/cmds/networkd/pubiface.go
@@ -56,7 +56,7 @@ func watchPubIface(ctx context.Context, nodeID pkg.Identifier, db network.TNoDB,
 	return ch
 }
 
-func configurePubIface(iface *types.PubIface) error {
+func configurePubIface(iface *types.PubIface, nodeID pkg.Identifier) error {
 	cleanup := func() error {
 		pubNs, err := namespace.GetByName(types.PublicNamespace)
 		if err != nil {
@@ -70,7 +70,7 @@ func configurePubIface(iface *types.PubIface) error {
 		return nil
 	}
 
-	if err := network.CreatePublicNS(iface); err != nil {
+	if err := network.CreatePublicNS(iface, nodeID); err != nil {
 		_ = cleanup()
 		return errors.Wrap(err, "failed to configure public namespace")
 	}

--- a/pkg/network/ndmz/ndmz.go
+++ b/pkg/network/ndmz/ndmz.go
@@ -107,7 +107,7 @@ func Create(nodeID pkg.Identifier) error {
 			return err
 		}
 		if !received {
-			return errors.Errorf("public interface in ndmz didn't received an IP. make sure dhcp is working")
+			return errors.Errorf("public interface in ndmz did not received an IP. make sure dhcp is working")
 		}
 		return nil
 	})

--- a/pkg/network/ndmz/ndmz.go
+++ b/pkg/network/ndmz/ndmz.go
@@ -6,6 +6,7 @@ import (
 	"net"
 	"os"
 
+	"github.com/threefoldtech/zos/pkg"
 	"github.com/threefoldtech/zos/pkg/network/ifaceutil"
 
 	"github.com/threefoldtech/zos/pkg/network/nr"
@@ -34,10 +35,12 @@ const (
 
 	vethGWSide = "ipv4-rt"
 	vethBrSide = "to-gw"
+
+	ndmzNsMACDerivationSuffix = "-ndmz"
 )
 
 //Create create the NDMZ network namespace and configure its default routes and addresses
-func Create() error {
+func Create(nodeID pkg.Identifier) error {
 
 	os.RemoveAll("/var/cache/modules/networkd/lease/dmz/")
 
@@ -88,7 +91,7 @@ func Create() error {
 		Str("mac", mac.String()).
 		Msg("public iface found")
 
-	mac = ifaceutil.HardwareAddrFromInputBytes(mac[:])
+	mac = ifaceutil.HardwareAddrFromInputBytes([]byte(nodeID.Identity() + ndmzNsMACDerivationSuffix))
 	log.Debug().
 		Str("mac", mac.String()).
 		Msg("set mac on public iface")
@@ -104,7 +107,7 @@ func Create() error {
 			return err
 		}
 		if !received {
-			return errors.Errorf("public interface in ndmz didn't not received an IP. make sure dhcp is working")
+			return errors.Errorf("public interface in ndmz didn't received an IP. make sure dhcp is working")
 		}
 		return nil
 	})

--- a/pkg/network/public.go
+++ b/pkg/network/public.go
@@ -7,14 +7,20 @@ import (
 	"github.com/containernetworking/plugins/pkg/ns"
 	"github.com/pkg/errors"
 	"github.com/rs/zerolog/log"
+	"github.com/threefoldtech/zos/pkg"
+	"github.com/threefoldtech/zos/pkg/network/ifaceutil"
 	"github.com/threefoldtech/zos/pkg/network/macvlan"
 	"github.com/threefoldtech/zos/pkg/network/namespace"
 	"github.com/threefoldtech/zos/pkg/network/types"
 	"github.com/vishvananda/netlink"
 )
 
+const (
+	publicNsMACDerivationSuffix = "-public"
+)
+
 // CreatePublicNS creates a public namespace in a node
-func CreatePublicNS(iface *types.PubIface) error {
+func CreatePublicNS(iface *types.PubIface, nodeID pkg.Identifier) error {
 	var (
 		pubNS    ns.NetNS
 		pubIface *netlink.Macvlan
@@ -37,6 +43,11 @@ func CreatePublicNS(iface *types.PubIface) error {
 			if err != nil {
 				return errors.Wrap(err, "failed to create public mac vlan interface")
 			}
+			mac := ifaceutil.HardwareAddrFromInputBytes([]byte(nodeID.Identity() + publicNsMACDerivationSuffix))
+			if err = ifaceutil.SetMAC(types.PublicIface, mac, pubNS); err != nil {
+				return errors.Wrap(err, "failed to set mac address on public mac vlan interface")
+			}
+			log.Debug().Str("mac", mac.String()).Msg("Set mac address on public mac vlan interface")
 		default:
 			return fmt.Errorf("unsupported public interface type %s", iface.Type)
 		}

--- a/pkg/network/public_test.go
+++ b/pkg/network/public_test.go
@@ -5,6 +5,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/require"
+	"github.com/threefoldtech/zos/pkg"
 	"github.com/threefoldtech/zos/pkg/network/namespace"
 	"github.com/threefoldtech/zos/pkg/network/types"
 )
@@ -26,6 +27,6 @@ func TestCreatePublicNS(t *testing.T) {
 		require.NoError(t, err)
 	}()
 
-	err := CreatePublicNS(iface)
+	err := CreatePublicNS(iface, pkg.StrIdentifier(""))
 	require.NoError(t, err)
 }


### PR DESCRIPTION
Derive a static mac address for the public interace in both the ndmz and public namespace (if available), based on the node ID and a static prefix. This ensures these interfaces always have the same MAC.

Fixes #316 