### PR TITLE
provisiond: avoid to try to decommission reservation that are not provisioned

### DIFF
--- a/pkg/network/ndmz/ndmz.go
+++ b/pkg/network/ndmz/ndmz.go
@@ -155,7 +155,7 @@ func createPublicIface(netNS ns.NetNS) error {
 		// find which interface to use as master for the macvlan
 		if namespace.Exists(types.PublicNamespace) {
 			pubNS, err := namespace.GetByName(types.PublicNamespace)
-			if err != nil{
+			if err != nil {
 				return err
 			}
 			defer pubNS.Close()

--- a/pkg/provision/crypto_test.go
+++ b/pkg/provision/crypto_test.go
@@ -1,6 +1,7 @@
 package provision
 
 import (
+	"crypto/rand"
 	"encoding/json"
 	"testing"
 
@@ -33,14 +34,19 @@ func TestVerifySignature(t *testing.T) {
 	err = Verify(r)
 	assert.NoError(t, err)
 
+	validSignature := make([]byte, len(r.Signature))
+	copy(validSignature, r.Signature)
+
 	// corrupt the signature
-	validByte := r.Signature[0]
-	r.Signature[0] = 'a'
+	_, err = rand.Read(r.Signature)
+	require.NoError(t, err)
+
 	err = Verify(r)
 	assert.Error(t, err)
 
 	// restore signature
-	r.Signature[0] = validByte
+	copy(r.Signature, validSignature)
+
 	// sanity test
 	err = Verify(r)
 	require.NoError(t, err)

--- a/pkg/provision/local_store.go
+++ b/pkg/provision/local_store.go
@@ -213,6 +213,22 @@ func (s *FSStore) Get(id string) (*Reservation, error) {
 	return s.get(id)
 }
 
+// Exists checks if the reservation ID is in the store
+func (s *FSStore) Exists(id string) (bool, error) {
+	s.RLock()
+	defer s.RUnlock()
+
+	path := filepath.Join(s.root, id)
+	_, err := os.Stat(path)
+	if err == nil {
+		return true, nil
+	}
+	if os.IsNotExist(err) {
+		return false, nil
+	}
+	return false, err
+}
+
 func (s *FSStore) get(id string) (*Reservation, error) {
 	path := filepath.Join(s.root, id)
 	f, err := os.Open(path)

--- a/tools/tfuser/cmds_provision.go
+++ b/tools/tfuser/cmds_provision.go
@@ -117,6 +117,10 @@ func cmdsProvision(c *cli.Context) error {
 			return errors.Wrap(err, "failed to sign the reservation")
 		}
 
+		if err := output(path, r); err != nil {
+			return errors.Wrapf(err, "failed to write provision schema to %s after signature", path)
+		}
+
 		id, err := client.Reserve(r)
 		if err != nil {
 			return errors.Wrap(err, "failed to send reservation")
@@ -124,10 +128,6 @@ func cmdsProvision(c *cli.Context) error {
 
 		fmt.Printf("Reservation for %v send to node %s\n", duration, r.NodeID)
 		fmt.Printf("Resource: %v\n", id)
-	}
-
-	if err := output(path, r); err != nil {
-		return errors.Wrapf(err, "failed to write provision schema to %s after signature", path)
 	}
 
 	return nil


### PR DESCRIPTION
This is specially important for node booting cause the first time they
ask for reservation they get the full list of reservation for a node.
Skipping not provisioned reservation makes this process nearly a no-op.