### PR TITLE
Fix #494: Allow public IP4 network endpoints

### DIFF
--- a/tools/tfuser/cmds_network.go
+++ b/tools/tfuser/cmds_network.go
@@ -571,6 +571,16 @@ func generatePeers(n *Network) error {
 						break
 					}
 				}
+
+				// as a fallback assign IPv4
+				if endpoint == "" {
+					for _, pep := range onr.PubEndpoints {
+						if pep.To4() != nil {
+							endpoint = fmt.Sprintf("%s:%d", pep.String(), onr.WGListenPort)
+							break
+						}
+					}
+				}
 			}
 
 			// Add subnets for external access


### PR DESCRIPTION
If the IP6 address is not manually set in the public config, but the IP4
is, use this address when generating the network schema. We still
maintain the assumption that this node has a public IP6 address, and
other nodes which do have IP6 public endpoints configured will be
reached over IP6 by the node