### PR TITLE
networkd: allow container to choose to have a public ipv6

### DIFF
--- a/docs/provision/provision.md
+++ b/docs/provision/provision.md
@@ -73,6 +73,8 @@ type Network struct {
 	NetworkID pkg.NetID `json:"network_id"`
 	// IP to give to the container
 	IPs []net.IP `json:"ips"`
+	// If true, the container will receive a public IPv6 address
+	PublicIP6 bool     `json:"public_ip6"`
 }
 
 // Mount defines a container volume mounted inside the container

--- a/pkg/container/opts.go
+++ b/pkg/container/opts.go
@@ -161,8 +161,8 @@ func WithCPUCount(cru uint) oci.SpecOpts {
 
 func cruToLimit(cru uint, totalCPU int) (quota int64, period uint64) {
 	var (
-		required float64 = float64(cru)
-		total    float64 = float64(totalCPU)
+		required = float64(cru)
+		total    = float64(totalCPU)
 		p        float64
 	)
 	quota = int64(1000000) // 1 sec

--- a/pkg/gedis/commands_provision.go
+++ b/pkg/gedis/commands_provision.go
@@ -353,6 +353,7 @@ func containerReservation(i interface{}, nodeID string) types.TfgridReservationC
 			{
 				NetworkID: string(c.Network.NetworkID),
 				Ipaddress: c.Network.IPs[0],
+				PublicIP6: c.Network.PublicIP6,
 			},
 		},
 		// StatsAggregator:   c.StatsAggregator,

--- a/pkg/gedis/types/provision/tfgrid_reservation_container_1.go
+++ b/pkg/gedis/types/provision/tfgrid_reservation_container_1.go
@@ -58,4 +58,5 @@ type TfgridReservationContainerMount1 struct {
 type TfgridReservationNetworkConnection1 struct {
 	NetworkID string `json:"network_id"`
 	Ipaddress net.IP `json:"ipaddress"`
+	PublicIP6 bool   `json:"public_ip6"`
 }

--- a/pkg/network.go
+++ b/pkg/network.go
@@ -31,7 +31,7 @@ type Networker interface {
 	// name.
 	// The member name specifies the name of the member, and must be unique
 	// The NetID is the network id to join
-	Join(networkdID NetID, containerID string, addrs []string) (join Member, err error)
+	Join(networkdID NetID, containerID string, addrs []string, publicIP6 bool) (join Member, err error)
 	// Leave delete a container nameapce created by Join
 	Leave(networkdID NetID, containerID string) (err error)
 

--- a/pkg/provision/container_test.go
+++ b/pkg/provision/container_test.go
@@ -74,6 +74,7 @@ func TestContainerProvisionNew(t *testing.T) {
 			IPs: []net.IP{
 				net.ParseIP("192.168.1.1"),
 			},
+			PublicIP6: false,
 		},
 	}
 
@@ -100,7 +101,7 @@ func TestContainerProvisionNew(t *testing.T) {
 	client.On("Request",
 		"network", zbus.ObjectID{Name: "network", Version: "0.0.1"},
 		"Join",
-		netID, reservation.ID, []string{"192.168.1.1"}).
+		netID, reservation.ID, []string{"192.168.1.1"}, false).
 		Return(pkg.Member{
 			Namespace: "net-ns",
 			IPv4:      net.ParseIP("192.168.1.1"),
@@ -142,9 +143,6 @@ func TestContainerProvisionWithMounts(t *testing.T) {
 	ctx = WithZBus(ctx, &client)
 	ctx = WithOwnerCache(ctx, &cache)
 
-	// const module = "network"
-	// version := zbus.ObjectID{Name: "network", Version: "0.0.1"}
-
 	container := Container{
 		FList: "https://hub.grid.tf/thabet/redis.flist",
 		Network: Network{
@@ -152,6 +150,7 @@ func TestContainerProvisionWithMounts(t *testing.T) {
 			IPs: []net.IP{
 				net.ParseIP("192.168.1.1"),
 			},
+			PublicIP6: false,
 		},
 		Mounts: []Mount{
 			{
@@ -188,7 +187,7 @@ func TestContainerProvisionWithMounts(t *testing.T) {
 	client.On("Request",
 		"network", zbus.ObjectID{Name: "network", Version: "0.0.1"},
 		"Join",
-		netID, reservation.ID, []string{"192.168.1.1"}).
+		netID, reservation.ID, []string{"192.168.1.1"}, false).
 		Return(pkg.Member{
 			Namespace: "net-ns",
 			IPv4:      net.ParseIP("192.168.1.1"),

--- a/pkg/provision/zdb.go
+++ b/pkg/provision/zdb.go
@@ -101,7 +101,7 @@ func zdbProvisionImpl(ctx context.Context, reservation *Reservation) (ZDBResult,
 		return ZDBResult{}, err
 	}
 
-	containerIP, err = getZDBIP(ctx, cont)
+	containerIP, err = getIfaceIP(ctx, nwmod.ZDBIface, cont.Network.Namespace)
 	if err != nil {
 		return ZDBResult{}, err
 	}
@@ -238,23 +238,21 @@ func createZdbContainer(ctx context.Context, allocation pkg.Allocation, mode pkg
 	return nil
 }
 
-func getZDBIP(ctx context.Context, container pkg.Container) (containerIP net.IP, err error) {
+func getIfaceIP(ctx context.Context, ifaceName, namespace string) (containerIP net.IP, err error) {
 	var (
 		client  = GetZBus(ctx)
 		network = stubs.NewNetworkerStub(client)
-
-		slog = log.With().Str("containerID", container.Name).Logger()
 	)
 
 	getIP := func() error {
-		ips, err := network.Addrs(nwmod.ZDBIface, container.Network.Namespace)
+		ips, err := network.Addrs(ifaceName, namespace)
 		if err != nil {
-			slog.Debug().Err(err).Msg("not ip public found, waiting")
+			log.Debug().Err(err).Msg("not ip public found, waiting")
 			return err
 		}
 		for _, ip := range ips {
 			if isPublic(ip) {
-				slog.Debug().IPAddr("ip", ip).Msg("0-db container public ip found")
+				log.Debug().IPAddr("ip", ip).Msg("0-db container public ip found")
 				containerIP = ip
 				return nil
 			}
@@ -269,12 +267,12 @@ func getZDBIP(ctx context.Context, container pkg.Container) (containerIP net.IP,
 	if err := backoff.RetryNotify(getIP, bo, func(err error, d time.Duration) {
 		log.Debug().Err(err).Str("duration", d.String()).Msg("failed to get zdb public IP")
 	}); err != nil {
-		return nil, errors.Wrapf(err, "failed to get an IP for 0-db container %s", container.Name)
+		return nil, errors.Wrapf(err, "failed to get an IP for interface %s", ifaceName)
 	}
 
-	slog.Info().
+	log.Info().
 		IPAddr("container IP", containerIP).
-		Str("name", container.Name).
+		Str("iface", ifaceName).
 		Msgf("0-db container created")
 	return containerIP, nil
 }

--- a/pkg/stubs/network_stub.go
+++ b/pkg/stubs/network_stub.go
@@ -120,8 +120,8 @@ func (s *NetworkerStub) GetSubnet(arg0 pkg.NetID) (ret0 net.IPNet, ret1 error) {
 	return
 }
 
-func (s *NetworkerStub) Join(arg0 pkg.NetID, arg1 string, arg2 []string) (ret0 pkg.Member, ret1 error) {
-	args := []interface{}{arg0, arg1, arg2}
+func (s *NetworkerStub) Join(arg0 pkg.NetID, arg1 string, arg2 []string, arg3 bool) (ret0 pkg.Member, ret1 error) {
+	args := []interface{}{arg0, arg1, arg2, arg3}
 	result, err := s.client.Request(s.module, s.object, "Join", args...)
 	if err != nil {
 		panic(err)

--- a/tools/tfuser/cmds_container.go
+++ b/tools/tfuser/cmds_container.go
@@ -40,6 +40,7 @@ func generateContainer(c *cli.Context) error {
 			IPs: []net.IP{
 				net.ParseIP(c.String("ip")),
 			},
+			PublicIP6: c.Bool("public6"),
 		},
 		Capacity: cap,
 	}

--- a/tools/tfuser/main.go
+++ b/tools/tfuser/main.go
@@ -209,6 +209,10 @@ func main() {
 							Name:  "memory",
 							Usage: "limit the amount of memory a container can allocate",
 						},
+						cli.BoolFlag{
+							Name:  "public6",
+							Usage: "when enabled, the container will have a public IPv6 interface",
+						},
 					},
 					Action: generateContainer,
 				},


### PR DESCRIPTION
We now have 2 mode for container networking.
- normal mode, the container is only accessible over the user overlay
  network.
- public 6 mode, the container has 2 networks, one for the user overlay
  network and one for public IPv6