### PR TITLE
Updated docs Case2 run VM command

### DIFF
--- a/qemu/README.md
+++ b/qemu/README.md
@@ -141,7 +141,7 @@ sudo ip link set forzos up
 1. Now run your vm
 
 ```bash
-./vm.sh -n myzos-01 -c farmer_id=2 printk.devmsg=on runmode=dev
+./vm.sh -n myzos-01 -b zos0 -c farmer_id=2 printk.devmsg=on runmode=dev
 ```
 
 where `runmode` is one of `dev` , `test`  or `prod`, 

--- a/qemu/README.md
+++ b/qemu/README.md
@@ -141,7 +141,7 @@ sudo ip link set forzos up
 1. Now run your vm
 
 ```bash
-./vm.sh -n myzos-01 -b zos0 -c farmer_id=2 printk.devmsg=on runmode=dev
+./vm.sh -n myzos-01 -c farmer_id=2 printk.devmsg=on runmode=dev
 ```
 
 where `runmode` is one of `dev` , `test`  or `prod`, 

--- a/qemu/vm.sh
+++ b/qemu/vm.sh
@@ -5,7 +5,7 @@ debug=0
 reset=0
 image=zos.efi
 kernelargs=""
-bridge=zos
+bridge=zos0
 graphics="-nographic -nodefaults"
 smp=1
 


### PR DESCRIPTION
Documentation command did not specify what the name of the bridge should be. Changed the command to run the VM so it's in line with the rest of the documentation.


Added `-b zos0` in case 2, step 2
`./vm.sh -n myzos-01 -b zos0 -c farmer_id=2 printk.devmsg=on runmode=dev`


EDIT: thanks to Christophe de Carvalho