### PR TITLE
Proxy_arp on a non_ipv4 holding iface is a bad idea

### DIFF
--- a/pkg/network/bootstrap/bootstrap.go
+++ b/pkg/network/bootstrap/bootstrap.go
@@ -117,7 +117,7 @@ func analyseLink(cAddrs chan IfaceConfig, link netlink.Link) error {
 
 		log.Info().Str("interface", name).Msg("start DHCP probe")
 
-		probe := dhcp.NewPrope()
+		probe := dhcp.NewProbe()
 		if err := probe.Start(name); err != nil {
 			return errors.Wrap(err, "error duging DHCP probe")
 		}

--- a/pkg/network/dhcp/dhcp.go
+++ b/pkg/network/dhcp/dhcp.go
@@ -11,8 +11,8 @@ type Probe struct {
 	cmd *exec.Cmd
 }
 
-// NewPrope returns a Probe
-func NewPrope() *Probe {
+// NewProbe returns a Probe
+func NewProbe() *Probe {
 	return &Probe{}
 }
 

--- a/pkg/network/macvlan/macvlan.go
+++ b/pkg/network/macvlan/macvlan.go
@@ -49,8 +49,12 @@ func Create(name string, master string, netns ns.NetNS) (*netlink.Macvlan, error
 
 	err = netns.Do(func(_ ns.NetNS) error {
 		// TODO: duplicate following lines for ipv6 support, when it will be added in other places
+
+		// containernetworking sets it up in some ref code somewhere, we copied it. we were stoopit
+		// disable proxy_arp, as it is ony useful in some very distinct cases, and otherwise can wreak
+		// havoc in networks -> 0!
 		ipv4SysctlValueName := fmt.Sprintf(ipv4InterfaceArpProxySysctlTemplate, tmpName)
-		if _, err := sysctl.Sysctl(ipv4SysctlValueName, "1"); err != nil {
+		if _, err := sysctl.Sysctl(ipv4SysctlValueName, "0"); err != nil {
 			// remove the newly added link and ignore errors, because we already are in a failed state
 			_ = netlink.LinkDel(mv)
 			return fmt.Errorf("failed to set proxy_arp on newly added interface %q: %v", tmpName, err)

--- a/pkg/network/ndmz/ndmz.go
+++ b/pkg/network/ndmz/ndmz.go
@@ -136,7 +136,6 @@ func Create(nodeID pkg.Identifier) error {
 		}
 		// ipv4InterfaceArpProxySysctlTemple sets proxy_arp by default, not sure if that's a good idea
 		// but we disable only here because the rest works.
-		// TODO: test whether it can be removed in macvlan.go
 		if _, err := sysctl.Sysctl(fmt.Sprintf("net.ipv4.conf.%s.proxy_arp", DMZPub6), "0"); err != nil {
 			return errors.Wrapf(err, "ndmz: couldn't disable proxy-arp on %s in ndmz namespace", DMZPub6)
 		}

--- a/pkg/network/ndmz/ndmz.go
+++ b/pkg/network/ndmz/ndmz.go
@@ -134,8 +134,14 @@ func Create(nodeID pkg.Identifier) error {
 		if _, err := sysctl.Sysctl(fmt.Sprintf("net.ipv6.conf.%s.accept_ra_defrtr", DMZPub6), "1"); err != nil {
 			return errors.Wrapf(err, "ndmz: failed to enable enable_defrtr=1 in ndmz namespace")
 		}
+		// ipv4InterfaceArpProxySysctlTemple sets proxy_arp by default, not sure if that's a good idea
+		// but we disable only here because the rest works.
+		// TODO: test whether it can be removed in macvlan.go
+		if _, err := sysctl.Sysctl(fmt.Sprintf("net.ipv4.conf.%s.proxy_arp", DMZPub6), "0"); err != nil {
+			return errors.Wrapf(err, "ndmz: couldn't disable proxy-arp on %s in ndmz namespace", DMZPub6)
+		}
 		// run DHCP to interface public in ndmz
-		probe := dhcp.NewPrope()
+		probe := dhcp.NewProbe()
 
 		if err := probe.Start(DMZPub4); err != nil {
 			return err


### PR DESCRIPTION
when an interface is brought up without an ipv4 address and proxy_arp=1 for an NR that effectively has ipv4 proxy_arp replies for __all__ arp requests, poisoning the upstream's router neighbour table.
Need to test whether we should just remove thet whole proxy_arp entry in macvlan.go