### PR TITLE
Always append zinit logs to the end of logfile

### DIFF
--- a/etc/zinit/logger.yaml
+++ b/etc/zinit/logger.yaml
@@ -1,3 +1,3 @@
-exec: sh -c 'mkdir -p /var/cache/log/ && zinit log > /var/cache/log/system.log'
+exec: sh -c 'mkdir -p /var/cache/log/ && zinit log >> /var/cache/log/system.log'
 after:
   - boot


### PR DESCRIPTION
When using > to redirect logs, target file offset will be kept even if
file is truncated. This result by incoherent/invalid log filesize.

Using >> will always append to the end of the file and if logfile is
truncated, size will be reset.