### PR TITLE
removed symlink to same file

### DIFF
--- a/qemu/Makefile
+++ b/qemu/Makefile
@@ -9,10 +9,8 @@ zinit:
 kernel:
 	@echo "Download 0-OS kernel"
 	wget https://bootstrap.grid.tf/kernel/zero-os-development-zos-v2-generic.efi -O zos.efi
-	ln -sf zos.efi zos.efi
 
 start:
 	bash vm.sh -n node1 -c "runmode=dev farmer_id=$(FARMERID)"
-
 test:
 	bash vm.sh -n node1 -c "runmode=test farmer_id=$(FARMERID)"


### PR DESCRIPTION
removed a symbolic link from 'zos.efi' pointing to the same file. 