### PR TITLE
networkd: make sure a network resource is deleted before releasing the

### DIFF
--- a/pkg/network/networker.go
+++ b/pkg/network/networker.go
@@ -444,11 +444,11 @@ func (n *networker) CreateNR(network pkg.Network) (string, error) {
 
 	cleanup := func() {
 		log.Error().Msg("clean up network resource")
-		if err := n.releasePort(netNR.WGListenPort); err != nil {
-			log.Error().Err(err).Msg("release wireguard port failed")
-		}
 		if err := netr.Delete(); err != nil {
 			log.Error().Err(err).Msg("error during deletion of network resource after failed deployment")
+		}
+		if err := n.releasePort(netNR.WGListenPort); err != nil {
+			log.Error().Err(err).Msg("release wireguard port failed")
 		}
 	}
 


### PR DESCRIPTION
associated wg porta

fixes #556