### PR TITLE
networkd: make reserved wireguard port persistent between network restart

### DIFF
--- a/cmds/networkd/main.go
+++ b/cmds/networkd/main.go
@@ -55,21 +55,12 @@ func main() {
 		log.Fatal().Err(err).Msg("failed to connect to zbus broker")
 	}
 
-	if err := os.MkdirAll(root, 0750); err != nil {
-		log.Fatal().Err(err).Msgf("fail to create module root")
-	}
-
 	db, err := bcdbClient()
 	if err != nil {
 		log.Fatal().Err(err).Msg("failed to connect to BCDB")
 	}
 
 	identity := stubs.NewIdentityManagerStub(client)
-	networker, err := network.NewNetworker(identity, db, root)
-	if err != nil {
-		log.Fatal().Err(err).Msg("error creating network manager")
-	}
-
 	nodeID := identity.NodeID()
 
 	ctx, cancel := context.WithCancel(context.Background())
@@ -137,6 +128,15 @@ func main() {
 	go startAddrWatch(ctx, nodeID, db, ifaces)
 
 	log.Info().Msg("start zbus server")
+	if err := os.MkdirAll(root, 0750); err != nil {
+		log.Fatal().Err(err).Msgf("fail to create module root")
+	}
+
+	networker, err := network.NewNetworker(identity, db, root)
+	if err != nil {
+		log.Fatal().Err(err).Msg("error creating network manager")
+	}
+
 	if err := startServer(ctx, broker, networker); err != nil {
 		log.Fatal().Err(err).Msg("unexpected error")
 	}

--- a/cmds/networkd/main.go
+++ b/cmds/networkd/main.go
@@ -65,7 +65,11 @@ func main() {
 	}
 
 	identity := stubs.NewIdentityManagerStub(client)
-	networker := network.NewNetworker(identity, db, root)
+	networker, err := network.NewNetworker(identity, db, root)
+	if err != nil {
+		log.Fatal().Err(err).Msg("error creating network manager")
+	}
+
 	nodeID := identity.NodeID()
 
 	ctx, cancel := context.WithCancel(context.Background())

--- a/pkg/cache/cache.go
+++ b/pkg/cache/cache.go
@@ -1,0 +1,36 @@
+package cache
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"syscall"
+
+	"github.com/threefoldtech/zos/pkg/storage"
+)
+
+// ForeverDir creates a new cache directory that is stored on the persistent cache.
+// This means data stored in this directory will survive reboot
+// It is the caller's responsibility to remove the directory when no longer needed.
+func ForeverDir(name string) (string, error) {
+	name = filepath.Join(storage.CacheTarget, "cache", name)
+	return name, os.MkdirAll(name, 0700)
+}
+
+// VolatileDir creates a new cache directory that is stored on a tmpfs.
+// This means data stored in this directory will NOT survive a reboot.
+// Use this when you need to store data that needs to survice deamon reboot but not between reboots
+// It is the caller's responsibility to remove the directory when no longer needed.
+// If the directory already exist, the the function does nothing and return successfully
+func VolatileDir(name string, size uint64) (string, error) {
+	const volatileBaseDir = "/var/run/cache"
+	name = filepath.Join(volatileBaseDir, name)
+	if err := os.MkdirAll(volatileBaseDir, 0700); err != nil {
+		return name, err
+	}
+
+	if err := os.Mkdir(name, 0700); err != nil {
+		return "", err
+	}
+	return name, syscall.Mount("", name, "tmpfs", 0, fmt.Sprintf("size=%d", size))
+}

--- a/pkg/gedis/converter.go
+++ b/pkg/gedis/converter.go
@@ -103,7 +103,7 @@ func networkReservation(i interface{}) types.TfgridReservationNetwork1 {
 
 		for y, peer := range nr.Peers {
 			network.NetworkResources[i].Peers[y] = types.WireguardPeer1{
-				IPRange:    nr.Subnet.ToSchema(),
+				IPRange:    peer.Subnet.ToSchema(),
 				Endpoint:   peer.Endpoint,
 				PublicKey:  peer.WGPublicKey,
 				AllowedIPs: make([]string, len(peer.AllowedIPs)),

--- a/pkg/network/ndmz/ipam.go
+++ b/pkg/network/ndmz/ipam.go
@@ -10,9 +10,8 @@ import (
 
 // allocateIPv4 allocates a unique IPv4 for the entity defines by the given id (for example container id, or a vm).
 // in the network with netID, and NetResource.
-func allocateIPv4(networkID string) (*net.IPNet, error) {
-	// FIXME: path to the cache disk shouldn't be hardcoded here
-	store, err := disk.New("ndmz", ipamPath)
+func allocateIPv4(networkID, leaseDir string) (*net.IPNet, error) {
+	store, err := disk.New("ndmz", leaseDir)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/set/uint.go
+++ b/pkg/set/uint.go
@@ -1,8 +1,15 @@
 package set
 
 import (
+	"errors"
 	"fmt"
+	"io/ioutil"
+	"os"
+	"path/filepath"
+	"strconv"
 	"sync"
+
+	"github.com/rs/zerolog/log"
 )
 
 // ErrConflict is return when trying to add a port
@@ -18,14 +25,20 @@ func (e ErrConflict) Error() string {
 // UintSet is a set containing uint
 type UintSet struct {
 	sync.RWMutex
-	m map[uint]struct{}
+	root string
 }
 
 // NewUint creates a new set for uint
-func NewUint() *UintSet {
+// path if the directory where to store the set on disk
+// the directory pointed by path must exists already
+func NewUint(path string) *UintSet {
 	return &UintSet{
-		m: make(map[uint]struct{}),
+		root: path,
 	}
+}
+
+func (p *UintSet) path(i uint) string {
+	return filepath.Join(p.root, fmt.Sprintf("%d", i))
 }
 
 // Add tries to add port to the set. If port is already
@@ -34,11 +47,15 @@ func (p *UintSet) Add(i uint) error {
 	p.Lock()
 	defer p.Unlock()
 
-	_, exists := p.m[i]
-	if exists {
-		return ErrConflict{i}
+	f, err := os.OpenFile(p.path(i), os.O_CREATE|os.O_EXCL|os.O_WRONLY, 0440)
+	if err != nil {
+		if errors.Is(err, os.ErrExist) {
+			return ErrConflict{Port: i}
+		}
+		return err
 	}
-	p.m[i] = struct{}{}
+
+	f.Close()
 	return nil
 }
 
@@ -49,20 +66,28 @@ func (p *UintSet) Remove(i uint) {
 	p.Lock()
 	defer p.Unlock()
 
-	_, exists := p.m[i]
-	if exists {
-		delete(p.m, i)
-	}
+	_ = os.RemoveAll(p.path(i))
 }
 
 // List returns a list of uint present in the set
-func (p *UintSet) List() []uint {
+func (p *UintSet) List() ([]uint, error) {
 	p.RLock()
 	defer p.RUnlock()
 
-	l := make([]uint, 0, len(p.m))
-	for i := range p.m {
-		l = append(l, i)
+	infos, err := ioutil.ReadDir(p.root)
+	if err != nil {
+		return nil, err
 	}
-	return l
+	l := make([]uint, 0, len(infos))
+
+	for _, info := range infos {
+		s := filepath.Base(info.Name())
+		i, err := strconv.Atoi(s)
+		if err != nil {
+			log.Warn().Err(err).Msg("file with wrong formatted name found in reserved wireguard port cache")
+			continue
+		}
+		l = append(l, uint(i))
+	}
+	return l, nil
 }

--- a/pkg/set/uint_test.go
+++ b/pkg/set/uint_test.go
@@ -2,36 +2,57 @@ package set
 
 import (
 	"errors"
+	"io/ioutil"
+	"os"
+	"path/filepath"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
+func testDir(t *testing.T) string {
+	td, err := ioutil.TempDir("", "")
+	require.NoError(t, err)
+
+	path := filepath.Join(td, "wireguard_ports")
+	err = os.MkdirAll(path, 0770)
+	require.NoError(t, err)
+
+	return path
+}
+
 func TestNew(t *testing.T) {
-	s := NewUint()
-	assert.NotNil(t, s.m)
+	td := testDir(t)
+
+	s := NewUint(td)
+	assert.Equal(t, td, s.root)
 }
 
 func TestAdd(t *testing.T) {
-	s := NewUint()
+	td := testDir(t)
+
+	s := NewUint(td)
 
 	for i := 0; i < 10; i++ {
 		err := s.Add(uint(i))
 		assert.NoError(t, err)
 	}
 
-	for i := 0; i < 10; i++ {
-		_, ok := s.m[uint(i)]
-		assert.True(t, ok, "%d should be present in the map", i)
-	}
+	infos, err := ioutil.ReadDir(s.root)
+	require.NoError(t, err)
 
-	err := s.Add(0)
+	assert.EqualValues(t, 10, len(infos))
+
+	err = s.Add(0)
 	assert.Error(t, err, "adding already present number should return an error")
 	assert.True(t, errors.Is(err, ErrConflict{}))
 }
 
 func TestRemove(t *testing.T) {
-	s := NewUint()
+	td := testDir(t)
+
+	s := NewUint(td)
 
 	for i := 0; i < 10; i++ {
 		err := s.Add(uint(i))
@@ -42,13 +63,18 @@ func TestRemove(t *testing.T) {
 		s.Remove(uint(i))
 	}
 
-	assert.EqualValues(t, 0, len(s.m))
+	infos, err := ioutil.ReadDir(s.root)
+	require.NoError(t, err)
+
+	assert.EqualValues(t, 0, len(infos))
 
 	s.Remove(99999) //ensure remove never panics
 }
 
 func TestList(t *testing.T) {
-	s := NewUint()
+	td := testDir(t)
+
+	s := NewUint(td)
 
 	err := s.Add(1)
 	assert.NoError(t, err)
@@ -57,12 +83,10 @@ func TestList(t *testing.T) {
 	err = s.Add(3)
 	assert.NoError(t, err)
 
-	l := s.List()
+	l, err := s.List()
+	require.NoError(t, err)
+
 	expected := []uint{1, 2, 3}
 	assert.Equal(t, len(expected), len(l))
 	assert.Subset(t, expected, l)
-}
-
-func TestConcurent(t *testing.T) {
-	// TODO
 }

--- a/pkg/storage/storage.go
+++ b/pkg/storage/storage.go
@@ -18,7 +18,8 @@ import (
 )
 
 const (
-	cacheTarget = "/var/cache"
+	// CacheTarget is the path where the cache disk is mounted
+	CacheTarget = "/var/cache"
 	cacheLabel  = "zos-cache"
 	cacheSize   = 20 * 1024 * 1024 * 1024 // 20GB
 )
@@ -396,11 +397,11 @@ func (s *storageModule) ensureCache() error {
 		cacheFs = fs
 	}
 
-	if !filesystem.IsMountPoint(cacheTarget) {
-		log.Debug().Msgf("Mounting cache partition in %s", cacheTarget)
-		return filesystem.BindMount(cacheFs, cacheTarget)
+	if !filesystem.IsMountPoint(CacheTarget) {
+		log.Debug().Msgf("Mounting cache partition in %s", CacheTarget)
+		return filesystem.BindMount(cacheFs, CacheTarget)
 	}
-	log.Debug().Msgf("Cache partition already mounted in %s", cacheTarget)
+	log.Debug().Msgf("Cache partition already mounted in %s", CacheTarget)
 	return nil
 }
 


### PR DESCRIPTION
fixes #556

Before this commit networkd would loose all the reserved port after
a restart and thus publish a wrong list of reserved ports on BCDB.

We now keep this list of reserved port on cache disk so it survive
a restart.

We still do clean up after a reboot since all the network resources are
also going to be re-created so the list of reserved port will be rebuild
from scratch