### PR TITLE
gedis: allow to re-use connections from the pool

### DIFF
--- a/pkg/gedis/gedis.go
+++ b/pkg/gedis/gedis.go
@@ -122,7 +122,8 @@ func newRedisPool(address string) (*redis.Pool, error) {
 
 			return nil
 		},
-		MaxActive:   10,
+		MaxActive:   5,
+		MaxIdle:     5,
 		IdleTimeout: 1 * time.Minute,
 		Wait:        true,
 	}, nil


### PR DESCRIPTION
It turns out that if the MaxIdle is 0, then the connection pool
doesn't allow to keep open connection around. Which mean before this
change, any time we sent a command, we were creating a new connection
from scratch