### PR TITLE
boostrap: don't use error log when skipping symlink

### DIFF
--- a/bootstrap/bootstrap/src/zfs.rs
+++ b/bootstrap/bootstrap/src/zfs.rs
@@ -75,7 +75,7 @@ impl Zfs {
                 debug!("installing file {:?}", dst);
                 std::fs::copy(&src, &dst)?;
             } else {
-                error!("skipping: ({:?}): {:?}", src, typ)
+                debug!("skipping: ({:?}): {:?}", src, typ)
             }
         }
 

--- a/bootstrap/bootstrap/src/zfs.rs
+++ b/bootstrap/bootstrap/src/zfs.rs
@@ -75,7 +75,7 @@ impl Zfs {
                 debug!("installing file {:?}", dst);
                 std::fs::copy(&src, &dst)?;
             } else {
-                error!("unsupported file type: ({:?}): {:?}", src, typ)
+                error!("skipping: ({:?}): {:?}", src, typ)
             }
         }
 


### PR DESCRIPTION
fixes #596