### PR TITLE
Support correct .startup.toml format

### DIFF
--- a/pkg/container/startup.go
+++ b/pkg/container/startup.go
@@ -17,14 +17,26 @@ type entry struct {
 type args struct {
 	Name string
 	Dir  string
+	Args []string
 	Env  map[string]string
 }
 
 func (e entry) Entrypoint() string {
 	if e.Name == "core.system" ||
 		e.Name == "core.base" && e.Args.Name != "" {
-		return e.Args.Name
+		var buf strings.Builder
+		buf.WriteString(e.Args.Name)
+		for _, arg := range e.Args.Args {
+			buf.WriteRune(' ')
+			arg = strings.Replace(arg, "\"", "\\\"", -1)
+			buf.WriteRune('"')
+			buf.WriteString(arg)
+			buf.WriteRune('"')
+		}
+
+		return buf.String()
 	}
+
 	return ""
 }
 

--- a/pkg/container/startup_test.go
+++ b/pkg/container/startup_test.go
@@ -22,7 +22,8 @@ name = "/start"
 dir = "/data"
 args = [
 	"extra",
-	"argument with spaces"
+	"argument with spaces",
+	"with \"skip\"",
 ]
 
 [startup.entry.args.env]
@@ -42,7 +43,7 @@ func TestParseStartup(t *testing.T) {
 	assert.Equal(t, "core.system", entry.Name)
 	assert.Equal(t, "/start", entry.Args.Name)
 	assert.Equal(t, "/data", entry.Args.Dir)
-	assert.Equal(t, []string{"extra", "argument with spaces"}, entry.Args.Args)
+	assert.Equal(t, []string{"extra", "argument with spaces", "with \"skip\""}, entry.Args.Args)
 
 	assert.Equal(t, map[string]string{
 		"DIFFICULTY":  "easy",
@@ -59,12 +60,12 @@ func TestStartupEntrypoint(t *testing.T) {
 
 	entry, ok := e.Entries["entry"]
 	require.True(t, ok)
-	assert.Equal(t, entry.Entrypoint(), `/start "extra" "argument with spaces"`)
+	assert.Equal(t, entry.Entrypoint(), `/start "extra" "argument with spaces" "with \"skip\""`)
 
 	parts, err := shlex.Split(entry.Entrypoint())
 	require.NoError(t, err)
 
-	assert.Equal(t, []string{"/start", "extra", "argument with spaces"}, parts)
+	assert.Equal(t, []string{"/start", "extra", "argument with spaces", "with \"skip\""}, parts)
 }
 
 func TestStartupEnvs(t *testing.T) {

--- a/pkg/container/startup_test.go
+++ b/pkg/container/startup_test.go
@@ -5,6 +5,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/google/shlex"
 	"github.com/stretchr/testify/assert"
 
 	"github.com/BurntSushi/toml"
@@ -19,6 +20,10 @@ name = "core.system"
 [startup.entry.args]
 name = "/start"
 dir = "/data"
+args = [
+	"extra",
+	"argument with spaces"
+]
 
 [startup.entry.args.env]
 DIFFICULTY = "easy"
@@ -37,6 +42,8 @@ func TestParseStartup(t *testing.T) {
 	assert.Equal(t, "core.system", entry.Name)
 	assert.Equal(t, "/start", entry.Args.Name)
 	assert.Equal(t, "/data", entry.Args.Dir)
+	assert.Equal(t, []string{"extra", "argument with spaces"}, entry.Args.Args)
+
 	assert.Equal(t, map[string]string{
 		"DIFFICULTY":  "easy",
 		"LEVEL":       "world",
@@ -52,7 +59,12 @@ func TestStartupEntrypoint(t *testing.T) {
 
 	entry, ok := e.Entries["entry"]
 	require.True(t, ok)
-	assert.Equal(t, entry.Entrypoint(), "/start")
+	assert.Equal(t, entry.Entrypoint(), `/start "extra" "argument with spaces"`)
+
+	parts, err := shlex.Split(entry.Entrypoint())
+	require.NoError(t, err)
+
+	assert.Equal(t, []string{"/start", "extra", "argument with spaces"}, parts)
 }
 
 func TestStartupEnvs(t *testing.T) {


### PR DESCRIPTION
the real .startup.toml format supports args
which must be appeneded in a way that works with
shlex parsing
