### PR TITLE
output clearer error message when farm ID is wrong

### DIFF
--- a/pkg/environment/environment.go
+++ b/pkg/environment/environment.go
@@ -4,6 +4,7 @@ import (
 	"os"
 	"strconv"
 
+	"github.com/pkg/errors"
 	"github.com/threefoldtech/zos/pkg"
 
 	"github.com/threefoldtech/zos/pkg/kernel"
@@ -130,7 +131,7 @@ func getEnvironmentFromParams(params kernel.Params) (Environment, error) {
 		env.Orphan = false
 		id, err := strconv.ParseUint(farmerID[0], 10, 64)
 		if err != nil {
-			return env, err
+			return env, errors.Wrap(err, "wrong format for farm ID")
 		}
 		env.FarmerID = pkg.FarmID(id)
 	}

--- a/tools/bcdb_mock/pkg/directory/node_handlers.go
+++ b/tools/bcdb_mock/pkg/directory/node_handlers.go
@@ -2,10 +2,12 @@ package directory
 
 import (
 	"encoding/json"
+	"errors"
 	"fmt"
 	"net/http"
 
 	"github.com/rs/zerolog/log"
+	"go.mongodb.org/mongo-driver/mongo"
 
 	"github.com/threefoldtech/zos/pkg/capacity"
 	"github.com/threefoldtech/zos/tools/bcdb_mock/models"
@@ -31,6 +33,9 @@ func (s *NodeAPI) registerNode(r *http.Request) (interface{}, mw.Response) {
 	n.PublicConfig = nil
 	db := mw.Database(r)
 	if _, err := s.Add(r.Context(), db, n); err != nil {
+		if errors.Is(err, mongo.ErrNoDocuments) {
+			return nil, mw.NotFound(fmt.Errorf("farm with id:%d does not exists", n.FarmId))
+		}
 		return nil, mw.Error(err)
 	}
 

--- a/tools/client/http.go
+++ b/tools/client/http.go
@@ -67,7 +67,7 @@ func (c *httpClient) process(response *http.Response, output interface{}, expect
 		}
 
 		if err := dec.Decode(&output); err != nil {
-			return errors.Wrapf(err, "failed to load error while processing invalid return code of: %s", response.StatusCode)
+			return errors.Wrapf(err, "failed to load error while processing invalid return code of: %s", response.Status)
 		}
 
 		return fmt.Errorf("%s: %s", response.Status, output.E)

--- a/tools/tfuser/cmds_container.go
+++ b/tools/tfuser/cmds_container.go
@@ -89,7 +89,7 @@ func generateContainer(c *cli.Context) error {
 		return err
 	}
 
-	return output(c.GlobalString("output"), p)
+	return writeWorkload(c.GlobalString("output"), p)
 }
 
 func validateContainer(c provision.Container) error {

--- a/tools/tfuser/cmds_debug.go
+++ b/tools/tfuser/cmds_debug.go
@@ -31,5 +31,5 @@ func generateDebug(c *cli.Context) error {
 		return err
 	}
 
-	return output(c.GlobalString("output"), r)
+	return writeWorkload(c.GlobalString("output"), r)
 }

--- a/tools/tfuser/cmds_kubernetes.go
+++ b/tools/tfuser/cmds_kubernetes.go
@@ -73,5 +73,5 @@ func generateKubernetes(c *cli.Context) error {
 		return errors.Wrap(err, "could not generate reservation schema")
 	}
 
-	return output(c.GlobalString("schema"), p)
+	return writeWorkload(c.GlobalString("schema"), p)
 }

--- a/tools/tfuser/cmds_live.go
+++ b/tools/tfuser/cmds_live.go
@@ -43,13 +43,13 @@ func cmdsLive(c *cli.Context) error {
 	return nil
 }
 
-type O map[string]interface{}
+type m map[string]interface{}
 
 const timeLayout = "02-Jan-2006 15:04:05"
 
 func printResult(r workloads.Reservation) {
 	expire := r.DataReservation.ExpirationReservation
-	output := O{}
+	output := m{}
 	fmt.Printf("ID: %d Expires: %s\n", r.ID, expire.Format(timeLayout))
 
 	resultPerID := make(map[int64][]workloads.Result, len(r.Results))
@@ -65,16 +65,16 @@ func printResult(r workloads.Reservation) {
 		resultPerID[wid] = results
 	}
 
-	resultData := func(in json.RawMessage) O {
-		var o O
+	resultData := func(in json.RawMessage) m {
+		var o m
 		if err := json.Unmarshal(in, &o); err != nil {
 			panic("invalid json")
 		}
 		return o
 	}
 
-	allResults := func(in []workloads.Result) []O {
-		var o []O
+	allResults := func(in []workloads.Result) []m {
+		var o []m
 		for _, i := range in {
 			r := resultData(i.DataJson)
 			r["node"] = i.NodeId
@@ -85,7 +85,7 @@ func printResult(r workloads.Reservation) {
 	}
 
 	for _, n := range r.DataReservation.Networks {
-		d := O{
+		d := m{
 			"kind":    "network",
 			"name":    n.Name,
 			"results": allResults(resultPerID[n.WorkloadId]),
@@ -100,7 +100,7 @@ func printResult(r workloads.Reservation) {
 			ips = append(ips, ip.Ipaddress.String())
 		}
 
-		d := O{
+		d := m{
 			"kind":    "container",
 			"flist":   c.Flist,
 			"ip":      ips,
@@ -111,7 +111,7 @@ func printResult(r workloads.Reservation) {
 	}
 
 	for _, v := range r.DataReservation.Volumes {
-		d := O{
+		d := m{
 			"kind":    "volume",
 			"size":    v.Size,
 			"type":    v.Type.String(),
@@ -123,7 +123,7 @@ func printResult(r workloads.Reservation) {
 	}
 
 	for _, z := range r.DataReservation.Zdbs {
-		d := O{
+		d := m{
 			"kind":    "zdb",
 			"size":    z.Size,
 			"mode":    z.Mode.String(),
@@ -134,7 +134,7 @@ func printResult(r workloads.Reservation) {
 	}
 
 	for _, k := range r.DataReservation.Kubernetes {
-		d := O{
+		d := m{
 			"kind":    "kubernetes",
 			"size":    k.Size,
 			"network": k.NetworkId,

--- a/tools/tfuser/cmds_network.go
+++ b/tools/tfuser/cmds_network.go
@@ -74,7 +74,7 @@ func cmdCreateNetwork(c *cli.Context) error {
 		return err
 	}
 
-	return output(c.GlobalString("schema"), r)
+	return writeWorkload(c.GlobalString("schema"), r)
 }
 
 func cmdsAddNode(c *cli.Context) error {
@@ -163,7 +163,7 @@ func cmdsAddNode(c *cli.Context) error {
 		return err
 	}
 
-	return output(schema, r)
+	return writeWorkload(schema, r)
 }
 
 func cmdsAddAccess(c *cli.Context) error {
@@ -273,7 +273,7 @@ func cmdsAddAccess(c *cli.Context) error {
 		return err
 	}
 
-	return output(schema, r)
+	return writeWorkload(schema, r)
 }
 
 func cmdsRemoveNode(c *cli.Context) error {
@@ -316,7 +316,7 @@ func cmdsRemoveNode(c *cli.Context) error {
 	//	return err
 	// }
 
-	return output(schema, r)
+	return writeWorkload(schema, r)
 }
 
 func loadNetwork(name string) (*Network, error) {

--- a/tools/tfuser/cmds_volumes.go
+++ b/tools/tfuser/cmds_volumes.go
@@ -32,5 +32,5 @@ func generateVolume(c *cli.Context) error {
 		return err
 	}
 
-	return output(c.GlobalString("output"), p)
+	return writeWorkload(c.GlobalString("output"), p)
 }

--- a/tools/tfuser/cmds_zdb.go
+++ b/tools/tfuser/cmds_zdb.go
@@ -43,5 +43,5 @@ func generateZDB(c *cli.Context) error {
 		return err
 	}
 
-	return output(c.GlobalString("output"), p)
+	return writeWorkload(c.GlobalString("output"), p)
 }

--- a/tools/tfuser/ui.go
+++ b/tools/tfuser/ui.go
@@ -6,7 +6,7 @@ import (
 	"os"
 )
 
-func output(name string, workload interface{}) (err error) {
+func writeWorkload(name string, workload interface{}) (err error) {
 	var w io.Writer = os.Stdout
 	if name != "" {
 		w, err = os.OpenFile(name, os.O_CREATE|os.O_WRONLY|os.O_TRUNC, 0660)


### PR DESCRIPTION
we handle case when farm ID has a wronf formaat or when the farm ID does
not exists

Here are the new error message outputted by identityd:
```
[+] identityd: 2020-03-24T16:14:28Z fatal failed to create identity manager error="failed to parse node environment: wrong format for farm ID: strconv.ParseUint: parsing \"123,123\": invalid syntax"
```
```
[+] identityd: 2020-03-24T16:11:31Z error  error="farmer with ID 123123123 does not exists"
```

fixes #580