### PR TITLE
renames json tag of reservation create response

### DIFF
--- a/tools/explorer/pkg/workloads/reservation.go
+++ b/tools/explorer/pkg/workloads/reservation.go
@@ -36,7 +36,7 @@ type API struct {
 
 // ReservationCreateResponse wraps reservation create response
 type ReservationCreateResponse struct {
-	ID                schema.ID                  `json:"id"`
+	ID                schema.ID                  `json:"reservation_id"`
 	EscrowInformation []escrowtypes.EscrowDetail `json:"escrow_information"`
 }
 


### PR DESCRIPTION
renamed id because the field `id` is a reserved keyword for a model in jsx threebot.