### PR TITLE
Close #674: Rework escrow address usage

### DIFF
--- a/tools/explorer/pkg/escrow/escrow.go
+++ b/tools/explorer/pkg/escrow/escrow.go
@@ -8,6 +8,7 @@ import (
 	"github.com/pkg/errors"
 	"github.com/rs/zerolog"
 	"github.com/rs/zerolog/log"
+	"github.com/stellar/go/xdr"
 	"github.com/threefoldtech/zos/pkg/schema"
 	"github.com/threefoldtech/zos/tools/explorer/config"
 	gdirectory "github.com/threefoldtech/zos/tools/explorer/models/generated/directory"
@@ -54,7 +55,7 @@ type (
 	}
 
 	reservationRegisterJobResponse struct {
-		data []types.EscrowDetail
+		data types.CustomerEscrowInformation
 		err  error
 	}
 )
@@ -147,7 +148,10 @@ func (e *Escrow) refundExpiredReservations() error {
 		return errors.Wrap(err, "failed to load active reservations from escrow")
 	}
 	for _, escrowInfo := range reservationEscrows {
-		e.refundEscrow(escrowInfo)
+		if err := e.refundEscrow(escrowInfo); err != nil {
+			log.Error().Err(err).Msgf("failed to refund reservation escrow")
+			continue
+		}
 		escrowInfo.Canceled = true
 		if err = types.ReservationPaymentInfoUpdate(e.ctx, e.db, escrowInfo); err != nil {
 			log.Error().Err(err).Msgf("failed to mark expired reservation escrow info as cancelled")
@@ -169,57 +173,58 @@ func (e *Escrow) checkReservations() error {
 	var slog zerolog.Logger
 
 	for _, escrowInfo := range reservationEscrows {
-		allPaid := true
-		for _, escrowAccount := range escrowInfo.Infos {
-			slog = log.With().
-				Str("address", escrowAccount.EscrowAddress).
-				Int64("farmer", int64(escrowAccount.FarmerID)).
-				Int64("reservation_id", int64(escrowInfo.ReservationID)).
-				Logger()
+		slog = log.With().
+			Str("address", escrowInfo.Address).
+			Int64("reservation_id", int64(escrowInfo.ReservationID)).
+			Logger()
 
-			balance, _, err := e.wallet.GetBalance(escrowAccount.EscrowAddress, escrowInfo.ReservationID)
-			if err != nil {
-				allPaid = false
-				slog.Error().Err(err).Msgf("failed to verify escrow account balance")
-				break
-			}
-			if balance < escrowAccount.TotalAmount {
-				allPaid = false
-				slog.Info().Msgf("escrow account is not funded yet")
-				break
-			}
+		requiredValue := xdr.Int64(0)
+		// calculate total amount needed for reservation
+		for _, escrowAccount := range escrowInfo.Infos {
+			requiredValue += escrowAccount.TotalAmount
 		}
 
-		if allPaid {
-			reservation, err := workloadtypes.ReservationFilter{}.WithID(escrowInfo.ReservationID).Get(e.ctx, e.db)
-			if err != nil {
-				slog.Error().Err(err).Msgf("failed to load reservation")
-			}
+		balance, _, err := e.wallet.GetBalance(escrowInfo.Address, escrowInfo.ReservationID)
+		if err != nil {
+			slog.Error().Err(err).Msgf("failed to verify escrow account balance")
+			continue
+		}
 
-			pl, err := workloadtypes.NewPipeline(reservation)
-			if err != nil {
-				slog.Error().Err(err).Msgf("failed to process reservation in pipeline")
-			}
+		if balance < requiredValue {
+			slog.Debug().Msgf("required balance %d not reached yet (%d)", requiredValue, balance)
+			continue
+		}
 
-			reservation, _ = pl.Next()
-			if !reservation.IsAny(workloadtypes.Pay) {
-				// Do not continue, but also take no action to drive the reservation
-				// as much as possible from the main explorer part.
-				slog.Warn().Msgf("reservation is paid, but no longer in pay state")
-				continue
-			}
+		slog.Debug().Msgf("required balance %d funded (%d), continue reservation", requiredValue, balance)
 
-			slog.Info().Msg("all farmer are paid, trying to move to deploy state")
-			// update reservation
-			if err = workloadtypes.ReservationSetNextAction(e.ctx, e.db, escrowInfo.ReservationID, workloadtypes.Deploy); err != nil {
-				slog.Error().Err(err).Msgf("failed to set reservation in deploy state")
-				// FIXME: we do nothing with the error ?
-			}
+		reservation, err := workloadtypes.ReservationFilter{}.WithID(escrowInfo.ReservationID).Get(e.ctx, e.db)
+		if err != nil {
+			slog.Error().Err(err).Msgf("failed to load reservation")
+		}
 
-			escrowInfo.Paid = true
-			if err = types.ReservationPaymentInfoUpdate(e.ctx, e.db, escrowInfo); err != nil {
-				slog.Error().Err(err).Msgf("failed to mark reservation escrow info as paid")
-			}
+		pl, err := workloadtypes.NewPipeline(reservation)
+		if err != nil {
+			slog.Error().Err(err).Msgf("failed to process reservation in pipeline")
+		}
+
+		reservation, _ = pl.Next()
+		if !reservation.IsAny(workloadtypes.Pay) {
+			// Do not continue, but also take no action to drive the reservation
+			// as much as possible from the main explorer part.
+			slog.Warn().Msgf("reservation is paid, but no longer in pay state")
+			continue
+		}
+
+		slog.Info().Msg("all farmer are paid, trying to move to deploy state")
+		// update reservation
+		if err = workloadtypes.ReservationSetNextAction(e.ctx, e.db, escrowInfo.ReservationID, workloadtypes.Deploy); err != nil {
+			slog.Error().Err(err).Msgf("failed to set reservation in deploy state")
+			continue
+		}
+
+		escrowInfo.Paid = true
+		if err = types.ReservationPaymentInfoUpdate(e.ctx, e.db, escrowInfo); err != nil {
+			slog.Error().Err(err).Msgf("failed to mark reservation escrow info as paid")
 		}
 	}
 	return nil
@@ -227,42 +232,50 @@ func (e *Escrow) checkReservations() error {
 
 // processReservation processes a single reservation
 // calculates resources and their costs
-func (e *Escrow) processReservation(reservation workloads.Reservation) ([]types.EscrowDetail, error) {
+func (e *Escrow) processReservation(reservation workloads.Reservation) (types.CustomerEscrowInformation, error) {
+	var customerInfo types.CustomerEscrowInformation
 	rsuPerFarmer, err := e.processReservationResources(reservation.DataReservation)
 	if err != nil {
-		return nil, errors.Wrap(err, "failed to process reservation resources")
+		return customerInfo, errors.Wrap(err, "failed to process reservation resources")
 	}
 
 	res, err := e.calculateReservationCost(rsuPerFarmer)
 	if err != nil {
-		return nil, errors.Wrap(err, "failed to process reservation resources costs")
+		return customerInfo, errors.Wrap(err, "failed to process reservation resources costs")
+	}
+
+	address, err := e.createOrLoadAccount(reservation.CustomerTid)
+	if err != nil {
+		return customerInfo, errors.Wrap(err, "failed to get escrow address for customer")
 	}
 
 	details := make([]types.EscrowDetail, 0, len(res))
 	for farmer, value := range res {
-		var address string
-		address, err = e.createOrLoadAccount(farmer, reservation.CustomerTid)
 		if err != nil {
-			return nil, errors.Wrap(err, "failed to create or load account")
+			return customerInfo, errors.Wrap(err, "failed to create or load account")
 		}
 		details = append(details, types.EscrowDetail{
-			FarmerID:      schema.ID(farmer),
-			EscrowAddress: address,
-			TotalAmount:   value,
+			FarmerID:    schema.ID(farmer),
+			TotalAmount: value,
 		})
 	}
 	reservationPaymentInfo := types.ReservationPaymentInformation{
 		Infos:         details,
+		Address:       address,
 		ReservationID: reservation.ID,
 		Expiration:    reservation.DataReservation.ExpirationProvisioning,
 		Paid:          false,
+		Canceled:      false,
+		Released:      false,
 	}
 	err = types.ReservationPaymentInfoCreate(e.ctx, e.db, reservationPaymentInfo)
 	if err != nil {
-		return nil, errors.Wrap(err, "failed to create reservation payment information")
+		return customerInfo, errors.Wrap(err, "failed to create reservation payment information")
 	}
 	log.Info().Int64("id", int64(reservation.ID)).Msg("processed reservation and created payment information")
-	return details, nil
+	customerInfo.Address = address
+	customerInfo.Details = details
+	return customerInfo, nil
 }
 
 // refundClients refunds clients if the reservation is cancelled
@@ -275,7 +288,10 @@ func (e *Escrow) refundClients(id schema.ID) error {
 		// already paid
 		return nil
 	}
-	e.refundEscrow(rpi)
+	if err := e.refundEscrow(rpi); err != nil {
+		log.Error().Err(err).Msg("failed to refund escrow")
+		return errors.Wrap(err, "could not refund escrow")
+	}
 	rpi.Canceled = true
 	if err = types.ReservationPaymentInfoUpdate(e.ctx, e.db, rpi); err != nil {
 		return errors.Wrapf(err, "could not mark escrows for %d as canceled", rpi.ReservationID)
@@ -294,7 +310,10 @@ func (e *Escrow) payoutFarmers(id schema.ID) error {
 		// already paid
 		return nil
 	}
-	// we already verified we have enough balance on every escrow for this reservation
+
+	// collect the farmer addresses and amount they should receive, we already
+	// have sufficient balance on the escrow to cover this
+	paymentInfo := make([]stellar.PayoutInfo, 0, len(rpi.Infos))
 	for _, escrowDetails := range rpi.Infos {
 		// in case of an error in this flow we continue, so we try to pay as much
 		// farmers as possible even if one fails
@@ -311,31 +330,38 @@ func (e *Escrow) payoutFarmers(id schema.ID) error {
 			continue
 		}
 
-		addressInfo, err := types.GetByAddress(e.ctx, e.db, escrowDetails.EscrowAddress)
-		if err != nil {
-			log.Error().Msgf("failed to load escrow address info: %s", err)
-			continue
-		}
-		kp, err := e.wallet.KeyPairFromSeed(addressInfo.Secret)
-		if err != nil {
-			log.Error().Msgf("failed to parse escrow address secret: %s", err)
-			continue
-		}
-		if err = e.wallet.PayoutFarmer(*kp, destination, escrowDetails.TotalAmount, id); err != nil {
-			log.Error().Msgf("failed to pay farmer: %s for reservation %d", err, id)
-			continue
-		}
-		// now refund any possible overpayment
-		if err = e.wallet.Refund(*kp, id); err != nil {
-			log.Error().Msgf("failed to refund overpayment farmer: %s", err)
-			continue
-		}
-		log.Info().
-			Int64("farmer ID", int64(escrowDetails.FarmerID)).
-			Str("escrow address", escrowDetails.EscrowAddress).
-			Int64("amount", int64(escrowDetails.TotalAmount)).
-			Msgf("paid farmer")
+		paymentInfo = append(paymentInfo,
+			stellar.PayoutInfo{
+				Address: destination,
+				Amount:  escrowDetails.TotalAmount,
+			},
+		)
 	}
+
+	addressInfo, err := types.CustomerAddressByAddress(e.ctx, e.db, rpi.Address)
+	if err != nil {
+		log.Error().Msgf("failed to load escrow address info: %s", err)
+		return errors.Wrap(err, "could not load escrow address info")
+	}
+	kp, err := e.wallet.KeyPairFromSeed(addressInfo.Secret)
+	if err != nil {
+		log.Error().Msgf("failed to parse escrow address secret: %s", err)
+		return errors.Wrap(err, "could not load escrow address info")
+	}
+	if err = e.wallet.PayoutFarmers(*kp, paymentInfo, id); err != nil {
+		log.Error().Msgf("failed to pay farmer: %s for reservation %d", err, id)
+		return errors.Wrap(err, "could not pay farmer")
+	}
+	// now refund any possible overpayment
+	if err = e.wallet.Refund(*kp, id); err != nil {
+		log.Error().Msgf("failed to refund overpayment farmer: %s", err)
+		return errors.Wrap(err, "could not refund overpayment")
+	}
+	log.Info().
+		Str("escrow address", rpi.Address).
+		Int64("reservation id", int64(rpi.ReservationID)).
+		Msgf("paid farmer")
+
 	rpi.Released = true
 	if err = types.ReservationPaymentInfoUpdate(e.ctx, e.db, rpi); err != nil {
 		return errors.Wrapf(err, "could not mark escrows for %d as released", rpi.ReservationID)
@@ -343,40 +369,34 @@ func (e *Escrow) payoutFarmers(id schema.ID) error {
 	return nil
 }
 
-func (e *Escrow) refundEscrow(escrowInfo types.ReservationPaymentInformation) {
-	for _, info := range escrowInfo.Infos {
-		slog := log.With().
-			Str("address", info.EscrowAddress).
-			Int64("farmer", int64(info.FarmerID)).
-			Int64("reservation_id", int64(escrowInfo.ReservationID)).
-			Logger()
+func (e *Escrow) refundEscrow(escrowInfo types.ReservationPaymentInformation) error {
+	slog := log.With().
+		Str("address", escrowInfo.Address).
+		Int64("reservation_id", int64(escrowInfo.ReservationID)).
+		Logger()
 
-		slog.Info().Msgf("try to refund client for escrow")
+	slog.Info().Msgf("try to refund client for escrow")
 
-		// in case of an error in this flow we continue, so we try to refund as much
-		// client as possible even if one fails
-		addressInfo, err := types.GetByAddress(e.ctx, e.db, info.EscrowAddress)
-		if err != nil {
-			slog.Error().Err(err).Msgf("failed to load escrow address info")
-			continue
-		}
-
-		kp, err := e.wallet.KeyPairFromSeed(addressInfo.Secret)
-		if err != nil {
-			slog.Error().Err(err).Msgf("failed to parse escrow address secret")
-			continue
-		}
-
-		if err = e.wallet.Refund(*kp, escrowInfo.ReservationID); err != nil {
-			slog.Error().Err(err).Msgf("failed to refund clients")
-			continue
-		}
-		slog.Info().Msgf("refunded client for escrow")
+	addressInfo, err := types.CustomerAddressByAddress(e.ctx, e.db, escrowInfo.Address)
+	if err != nil {
+		return errors.Wrap(err, "failed to load escrow info")
 	}
+
+	kp, err := e.wallet.KeyPairFromSeed(addressInfo.Secret)
+	if err != nil {
+		return errors.Wrap(err, "failed to parse escrow address secret")
+	}
+
+	if err = e.wallet.Refund(*kp, escrowInfo.ReservationID); err != nil {
+		return errors.Wrap(err, "failed to refund clients")
+	}
+
+	slog.Info().Msgf("refunded client for escrow")
+	return nil
 }
 
 // RegisterReservation registers a workload reservation
-func (e *Escrow) RegisterReservation(reservation workloads.Reservation) ([]types.EscrowDetail, error) {
+func (e *Escrow) RegisterReservation(reservation workloads.Reservation) (types.CustomerEscrowInformation, error) {
 	job := reservationRegisterJob{
 		reservation:  reservation,
 		responseChan: make(chan reservationRegisterJobResponse),
@@ -401,25 +421,23 @@ func (e *Escrow) ReservationCanceled(reservationID schema.ID) {
 }
 
 // createOrLoadAccount creates or loads account based on farmer - customer id
-func (e *Escrow) createOrLoadAccount(farmerID int64, customerTID int64) (string, error) {
-	res, err := types.Get(context.Background(), e.db, farmerID, customerTID)
+func (e *Escrow) createOrLoadAccount(customerTID int64) (string, error) {
+	res, err := types.CustomerAddressGet(context.Background(), e.db, customerTID)
 	if err != nil {
 		if err == types.ErrAddressNotFound {
 			keypair, err := e.wallet.CreateAccount()
 			if err != nil {
-				return "", errors.Wrapf(err, "failed to create a new account for farmer %d - customer %d", farmerID, customerTID)
+				return "", errors.Wrapf(err, "failed to create a new account for customer %d", customerTID)
 			}
-			err = types.FarmerCustomerAddressCreate(context.Background(), e.db, types.FarmerCustomerAddress{
+			err = types.CustomerAddressCreate(context.Background(), e.db, types.CustomerAddress{
 				CustomerTID: customerTID,
 				Address:     keypair.Address(),
-				FarmerID:    farmerID,
 				Secret:      keypair.Seed(),
 			})
 			if err != nil {
-				return "", errors.Wrapf(err, "failed to save a new account for farmer %d - customer %d", farmerID, customerTID)
+				return "", errors.Wrapf(err, "failed to save a new account for customer %d", customerTID)
 			}
 			log.Debug().
-				Int64("farmer", int64(farmerID)).
 				Int64("customer", int64(customerTID)).
 				Str("address", keypair.Address()).
 				Msgf("created new escrow address for farmer-customer")
@@ -428,10 +446,9 @@ func (e *Escrow) createOrLoadAccount(farmerID int64, customerTID int64) (string,
 		return "", errors.Wrap(err, "failed to get farmer - customer address")
 	}
 	log.Debug().
-		Int64("farmer", int64(farmerID)).
 		Int64("customer", int64(customerTID)).
 		Str("address", res.Address).
-		Msgf("escrow address found for farmer-customer")
+		Msgf("escrow address found for customer")
 
 	return res.Address, nil
 }

--- a/tools/explorer/pkg/escrow/types/address.go
+++ b/tools/explorer/pkg/escrow/types/address.go
@@ -22,19 +22,18 @@ var (
 )
 
 type (
-	// FarmerCustomerAddress holds the farmer - customer key
-	FarmerCustomerAddress struct {
-		FarmerID    int64  `bson:"farmer_id" json:"farmer_id"`
+	// CustomerAddress holds the customer escrow address and key
+	CustomerAddress struct {
 		CustomerTID int64  `bson:"customer_tid" json:"customer_tid"`
 		Address     string `bson:"address" json:"address"`
 		Secret      string `bson:"secret" json:"secret"`
 	}
 )
 
-// FarmerCustomerAddressCreate creates the reservation payment information
-func FarmerCustomerAddressCreate(ctx context.Context, db *mongo.Database, fckAddress FarmerCustomerAddress) error {
+// CustomerAddressCreate creates the reservation payment information
+func CustomerAddressCreate(ctx context.Context, db *mongo.Database, cAddress CustomerAddress) error {
 	col := db.Collection(AddressCollection)
-	_, err := col.InsertOne(ctx, fckAddress)
+	_, err := col.InsertOne(ctx, cAddress)
 	if err != nil {
 		if merr, ok := err.(mongo.WriteException); ok {
 			errCode := merr.WriteErrors[0].Code
@@ -47,24 +46,24 @@ func FarmerCustomerAddressCreate(ctx context.Context, db *mongo.Database, fckAdd
 	return nil
 }
 
-// Get gets one address by farmerID and customerTID
-func Get(ctx context.Context, db *mongo.Database, farmerID int64, customerTID int64) (FarmerCustomerAddress, error) {
-	var farmerCustomerAddress FarmerCustomerAddress
-	doc := db.Collection(AddressCollection).FindOne(ctx, bson.M{"farmer_id": farmerID, "customer_tid": customerTID})
+// CustomerAddressGet one address bycustomerTID
+func CustomerAddressGet(ctx context.Context, db *mongo.Database, customerTID int64) (CustomerAddress, error) {
+	var customerAddress CustomerAddress
+	doc := db.Collection(AddressCollection).FindOne(ctx, bson.M{"customer_tid": customerTID})
 	if errors.Is(doc.Err(), mongo.ErrNoDocuments) {
-		return FarmerCustomerAddress{}, ErrAddressNotFound
+		return CustomerAddress{}, ErrAddressNotFound
 	}
-	err := doc.Decode(&farmerCustomerAddress)
-	return farmerCustomerAddress, err
+	err := doc.Decode(&customerAddress)
+	return customerAddress, err
 }
 
-// GetByAddress gets one address using the address
-func GetByAddress(ctx context.Context, db *mongo.Database, address string) (FarmerCustomerAddress, error) {
-	var farmerCustomerAddress FarmerCustomerAddress
+// CustomerAddressByAddress gets one address using the address
+func CustomerAddressByAddress(ctx context.Context, db *mongo.Database, address string) (CustomerAddress, error) {
+	var customerAddress CustomerAddress
 	doc := db.Collection(AddressCollection).FindOne(ctx, bson.M{"address": address})
 	if errors.Is(doc.Err(), mongo.ErrNoDocuments) {
-		return FarmerCustomerAddress{}, ErrAddressNotFound
+		return CustomerAddress{}, ErrAddressNotFound
 	}
-	err := doc.Decode(&farmerCustomerAddress)
-	return farmerCustomerAddress, err
+	err := doc.Decode(&customerAddress)
+	return customerAddress, err
 }

--- a/tools/explorer/pkg/escrow/types/escrow.go
+++ b/tools/explorer/pkg/escrow/types/escrow.go
@@ -29,6 +29,7 @@ type (
 	// ReservationPaymentInformation stores the reservation payment information
 	ReservationPaymentInformation struct {
 		ReservationID schema.ID      `bson:"_id"`
+		Address       string         `bson:"address"`
 		Expiration    schema.Date    `bson:"expiration"`
 		Infos         []EscrowDetail `bson:"infos"`
 		// Paid indicates the reservation escrows have been fully funded, and
@@ -51,9 +52,15 @@ type (
 
 	// EscrowDetail hold the details of an escrow address
 	EscrowDetail struct {
-		FarmerID      schema.ID `bson:"farmer_id" json:"farmer_id"`
-		TotalAmount   xdr.Int64 `bson:"total_amount" json:"total_amount"`
-		EscrowAddress string    `bson:"escrow_address" json:"escrow_address"`
+		FarmerID    schema.ID `bson:"farmer_id" json:"farmer_id"`
+		TotalAmount xdr.Int64 `bson:"total_amount" json:"total_amount"`
+	}
+
+	// CustomerEscrowInformation is the escrow information which will get exposed
+	// to the customer once he creates a reservation
+	CustomerEscrowInformation struct {
+		Address string         `json:"address"`
+		Details []EscrowDetail `json:"details"`
 	}
 )
 

--- a/tools/explorer/pkg/escrow/types/setup.go
+++ b/tools/explorer/pkg/escrow/types/setup.go
@@ -26,7 +26,7 @@ func Setup(ctx context.Context, db *mongo.Database) error {
 	addresses := db.Collection(AddressCollection)
 	_, err = addresses.Indexes().CreateMany(ctx, []mongo.IndexModel{
 		{
-			Keys:    bson.M{"farmer_id": 1, "customer_tid": 1},
+			Keys:    bson.M{"customer_tid": 1},
 			Options: options.Index().SetUnique(true),
 		},
 		{

--- a/tools/explorer/pkg/workloads/reservation.go
+++ b/tools/explorer/pkg/workloads/reservation.go
@@ -36,8 +36,8 @@ type API struct {
 
 // ReservationCreateResponse wraps reservation create response
 type ReservationCreateResponse struct {
-	ID                schema.ID                  `json:"reservation_id"`
-	EscrowInformation []escrowtypes.EscrowDetail `json:"escrow_information"`
+	ID                schema.ID                             `json:"reservation_id"`
+	EscrowInformation escrowtypes.CustomerEscrowInformation `json:"escrow_information"`
 }
 
 func (a *API) validAddresses(ctx context.Context, db *mongo.Database, res *types.Reservation) error {

--- a/tools/tfuser/cmds_provision.go
+++ b/tools/tfuser/cmds_provision.go
@@ -178,16 +178,22 @@ func cmdsProvision(c *cli.Context) error {
 		return errors.Wrap(err, "failed to send reservation")
 	}
 
+	totalAmount := xdr.Int64(0)
+	for _, detail := range response.EscrowInformation.Details {
+		totalAmount += detail.TotalAmount
+	}
+
 	fmt.Printf("Reservation for %v send to node bcdb\n", duration)
 	fmt.Printf("Resource: /reservations/%v\n", response.ID)
 	fmt.Println()
 
 	fmt.Printf("Reservation id: %d \n", response.ID)
+	fmt.Printf("Reservation escrow address: %s \n", response.EscrowInformation.Address)
+	fmt.Printf("Reservation amount: %s \n", formatCurrency(totalAmount))
 
-	for _, detail := range response.EscrowInformation {
+	for _, detail := range response.EscrowInformation.Details {
 		fmt.Println()
 		fmt.Printf("FarmerID: %v\n", detail.FarmerID)
-		fmt.Printf("Escrow address: %s\n", detail.EscrowAddress)
 		fmt.Printf("Amount: %s\n", formatCurrency(detail.TotalAmount))
 	}
 


### PR DESCRIPTION
Generate 1 escrow address for a user, which is used to fund all
reservations for all farmers. We later split the payment, so that each
farmer gets the correct cut, in the explorer itself.