### PR TITLE
explorer: handle the duration_provision field better in reservation flow

### DIFF
--- a/tools/explorer/pkg/escrow/escrow.go
+++ b/tools/explorer/pkg/escrow/escrow.go
@@ -95,7 +95,7 @@ func (e *Escrow) Run(ctx context.Context) error {
 			return nil
 
 		case <-ticker.C:
-			// log.Info().Msg("scanning active escrow accounts balance")
+			log.Info().Msg("scanning active escrow accounts balance")
 			if err := e.checkReservations(); err != nil {
 				log.Error().Err(err).Msgf("failed to check reservations")
 			}
@@ -147,10 +147,13 @@ func (e *Escrow) refundExpiredReservations() error {
 		return errors.Wrap(err, "failed to load active reservations from escrow")
 	}
 	for _, escrowInfo := range reservationEscrows {
+		log.Info().Int64("id", int64(escrowInfo.ReservationID)).Msg("expired escrow")
+
 		if err := e.refundEscrow(escrowInfo); err != nil {
 			log.Error().Err(err).Msgf("failed to refund reservation escrow")
 			continue
 		}
+
 		escrowInfo.Canceled = true
 		if err = types.ReservationPaymentInfoUpdate(e.ctx, e.db, escrowInfo); err != nil {
 			log.Error().Err(err).Msgf("failed to mark expired reservation escrow info as cancelled")

--- a/tools/explorer/pkg/escrow/types/escrow.go
+++ b/tools/explorer/pkg/escrow/types/escrow.go
@@ -124,7 +124,7 @@ func GetAllActiveReservationPaymentInfos(ctx context.Context, db *mongo.Database
 
 // GetAllExpiredReservationPaymentInfos get all active reservation payment information
 func GetAllExpiredReservationPaymentInfos(ctx context.Context, db *mongo.Database) ([]ReservationPaymentInformation, error) {
-	filter := bson.M{"paid": false, "released": false, "canceled": false, "expiration": bson.M{"$lte": schema.Date{Time: time.Now()}}}
+	filter := bson.M{"released": false, "canceled": false, "expiration": bson.M{"$lte": schema.Date{Time: time.Now()}}}
 	cursor, err := db.Collection(EscrowCollection).Find(ctx, filter)
 	if err != nil {
 		return nil, errors.Wrap(err, "failed to get cursor over expired payment infos")

--- a/tools/explorer/pkg/stellar/stellar.go
+++ b/tools/explorer/pkg/stellar/stellar.go
@@ -298,6 +298,7 @@ func (w *Wallet) Refund(keypair keypair.Full, id schema.ID) error {
 		return errors.Wrap(err, "failed to fund transaction")
 	}
 
+	log.Debug().Int64("amount", int64(amount)).Str("destination", destination).Msg("refund")
 	err = w.signAndSubmitTx(&keypair, fundedTx)
 	if err != nil {
 		return errors.Wrap(err, "failed to sign and submit transaction")

--- a/tools/explorer/pkg/workloads/types/reservation.go
+++ b/tools/explorer/pkg/workloads/types/reservation.go
@@ -410,6 +410,22 @@ func (r *Reservation) Workloads(nodeID string) []Workload {
 	return workloads
 }
 
+// isSuccessfullyDeployed check if all the workloads defined in the reservation
+// have sent a positive result
+func (r *Reservation) IsSuccessfullyDeployed() bool {
+	succeeded := false
+	if len(r.Results) >= len(r.Workloads("")) {
+		succeeded = true
+		for _, result := range r.Results {
+			if result.State != generated.ResultStateOK {
+				succeeded = false
+				break
+			}
+		}
+	}
+	return succeeded
+}
+
 // ReservationCreate save new reservation to database.
 // NOTE: use reservations only that are returned from calling Pipeline.Next()
 // no validation is done here, this is just a CRUD operation


### PR DESCRIPTION
a reservation is now cancelled if it is not deployed before the
duration_provision time.
a paid reservation that is cancelled is refunded

fixes #686 