### PR TITLE
storaged: does not crash when lsblk response is empty

### DIFF
--- a/etc/zinit/init/node-ready.sh
+++ b/etc/zinit/init/node-ready.sh
@@ -9,10 +9,26 @@ setup_loopback() {
     ip link set lo up
 }
 
+disable_overlay() {
+    set -x
+
+    rmmod ata_piix
+    rmmod pata_acpi
+    rmmod ata_generic
+    rmmod libata
+
+    partprobe
+    lsblk
+
+    set +x
+}
+
 main() {
     # bring the loop back interface up
     setup_loopback
 
+    # does not expose qemu overlay to the system
+    disable_overlay
 }
 
 main

--- a/etc/zinit/init/node-ready.sh
+++ b/etc/zinit/init/node-ready.sh
@@ -10,17 +10,11 @@ setup_loopback() {
 }
 
 disable_overlay() {
-    set -x
-
     rmmod ata_piix
     rmmod pata_acpi
     rmmod ata_generic
     rmmod libata
-
     partprobe
-    lsblk
-
-    set +x
 }
 
 main() {

--- a/pkg/storage/filesystem/device.go
+++ b/pkg/storage/filesystem/device.go
@@ -143,6 +143,13 @@ func (l *lsblkDeviceManager) Raw(ctx context.Context) (DeviceCache, error) {
 		BlockDevices []Device `json:"blockdevices"`
 	}
 
+	// skipping unmarshal when lsblk response is empty
+	if len(bytes) == 0 {
+		log.Warn().Msg("no disks found on the system")
+		return DeviceCache(devices.BlockDevices), nil
+	}
+
+	// parsing lsblk response
 	if err := json.Unmarshal(bytes, &devices); err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
If system have no disks at all, `lsblk` (even in json) returns an empty string, which fails to be parsed as json.

This fixes prevent `storaged` to crash on empty response and let  starts with limited-cache feature.

In addition, this changes contains code which disable (unexpose) qemu overlay disk when system boots (after files have been copied).

This fixes #675 