### PR TITLE
provisiond: cath network error when polling the explorer

### DIFF
--- a/pkg/provision/provision.go
+++ b/pkg/provision/provision.go
@@ -54,33 +54,3 @@ var (
 		KubernetesReservation: kubernetesDecomission,
 	}
 )
-
-// ErrTemporary is return when a reservation source failed to contact the BCDB
-// user usually want to retry after getting this error
-type ErrTemporary struct {
-	err error
-}
-
-// NewErrTemporary wrap an error and mark it as temporary
-func NewErrTemporary(err error) error {
-	return ErrTemporary{err: err}
-}
-
-// Error implements the errors.Error interface
-func (e ErrTemporary) Error() string {
-	if e.err == nil {
-		return ""
-	}
-	return e.err.Error()
-}
-
-// Is implements errors.Is interface
-func (e ErrTemporary) Is(target error) bool {
-	_, ok := target.(ErrTemporary)
-	return ok
-}
-
-// Unwrap implements errors.Unwrap interface
-func (e ErrTemporary) Unwrap() error {
-	return e.err
-}

--- a/pkg/provision/provision_test.go
+++ b/pkg/provision/provision_test.go
@@ -3,11 +3,8 @@ package provision
 import (
 	"context"
 	"encoding/json"
-	"fmt"
 	"testing"
 
-	"github.com/pkg/errors"
-	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
 	"github.com/threefoldtech/zbus"
@@ -66,20 +63,4 @@ type TestOwnerCache struct {
 func (t *TestOwnerCache) OwnerOf(id string) (string, error) {
 	result := t.Called(id)
 	return result.String(0), result.Error(1)
-}
-
-func TestErrTemporary(t *testing.T) {
-	err := fmt.Errorf("base error")
-	wrap1 := NewErrTemporary(err)
-	wrap2 := fmt.Errorf("upper err: %w", wrap1)
-
-	assert.True(t, errors.Is(wrap1, ErrTemporary{}))
-	assert.True(t, errors.Is(wrap2, ErrTemporary{}))
-	assert.Equal(t, err.Error(), wrap1.Error())
-}
-
-func TestErrTemporaryNil(t *testing.T) {
-	wrap1 := NewErrTemporary(nil)
-	assert.Equal(t, wrap1.Error(), "")
-	assert.True(t, errors.Is(wrap1, ErrTemporary{}))
 }


### PR DESCRIPTION
when we detect a network error we don't skip the reservation and just
wait and retry