### PR TITLE
review how an identity is passed to the explorer client

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -4,8 +4,6 @@ go 1.13
 
 require (
 	github.com/BurntSushi/toml v0.3.1
-	github.com/FactomProject/basen v0.0.0-20150613233007-fe3947df716e // indirect
-	github.com/FactomProject/btcutilecc v0.0.0-20130527213604-d3a63a5752ec // indirect
 	github.com/StackExchange/wmi v0.0.0-20190523213315-cbe66965904d // indirect
 	github.com/agl/ed25519 v0.0.0-20170116200512-5312a6153412
 	github.com/alexflint/go-filemutex v0.0.0-20171028004239-d358565f3c3f
@@ -66,7 +64,6 @@ require (
 	github.com/syndtr/gocapability v0.0.0-20180916011248-d98352740cb2 // indirect
 	github.com/termie/go-shutil v0.0.0-20140729215957-bcacb06fecae
 	github.com/threefoldtech/zbus v0.1.3
-	github.com/tyler-smith/go-bip32 v0.0.0-20170922074101-2c9cfd177564 // indirect
 	github.com/tyler-smith/go-bip39 v1.0.2
 	github.com/urfave/cli v1.22.3
 	github.com/vishvananda/netlink v1.0.0
@@ -79,7 +76,6 @@ require (
 	go.mongodb.org/mongo-driver v1.3.0
 	golang.org/x/crypto v0.0.0-20200311171314-f7b00557c8c4
 	golang.org/x/net v0.0.0-20200301022130-244492dfa37a // indirect
-	golang.org/x/sync v0.0.0-20190911185100-cd5d95a43a6e // indirect
 	golang.org/x/sys v0.0.0-20200302150141-5c8b2ff67527
 	golang.zx2c4.com/wireguard/wgctrl v0.0.0-20191219145116-fa6499c8e75f
 	google.golang.org/appengine v1.6.5 // indirect

--- a/go.sum
+++ b/go.sum
@@ -6,10 +6,6 @@ code.cloudfoundry.org/bytefmt v0.0.0-20200131002437-cf55d5288a48/go.mod h1:wN/zk
 firebase.google.com/go v3.12.0+incompatible/go.mod h1:xlah6XbEyW6tbfSklcfe5FHJIwjt8toICdV5Wh9ptHs=
 github.com/BurntSushi/toml v0.3.1 h1:WXkYYl6Yr3qBf1K79EBnL4mak0OimBfB0XUf9Vl28OQ=
 github.com/BurntSushi/toml v0.3.1/go.mod h1:xHWCNGjB5oqiDr8zfno3MHue2Ht5sIBksp03qcyfWMU=
-github.com/FactomProject/basen v0.0.0-20150613233007-fe3947df716e h1:ahyvB3q25YnZWly5Gq1ekg6jcmWaGj/vG/MhF4aisoc=
-github.com/FactomProject/basen v0.0.0-20150613233007-fe3947df716e/go.mod h1:kGUqhHd//musdITWjFvNTHn90WG9bMLBEPQZ17Cmlpw=
-github.com/FactomProject/btcutilecc v0.0.0-20130527213604-d3a63a5752ec h1:1Qb69mGp/UtRPn422BH4/Y4Q3SLUrD9KHuDkm8iodFc=
-github.com/FactomProject/btcutilecc v0.0.0-20130527213604-d3a63a5752ec/go.mod h1:CD8UlnlLDiqb36L110uqiP2iSflVjx9g/3U9hCI4q2U=
 github.com/Masterminds/squirrel v0.0.0-20161115235646-20f192218cf5/go.mod h1:xnKTFzjGUiZtiOagBsfnvomW+nJg2usB1ZpordQWqNM=
 github.com/Microsoft/go-winio v0.4.11 h1:zoIOcVf0xPN1tnMVbTtEdI+P8OofVk3NObnwOQ6nK2Q=
 github.com/Microsoft/go-winio v0.4.11/go.mod h1:VhR8bwka0BXejwEJY73c50VrPtXAaKcyvVC4A4RozmA=
@@ -305,8 +301,6 @@ github.com/gorilla/context v1.1.1/go.mod h1:kBGZzfjB9CEq2AlWe17Uuf7NDRt0dE0s8S51
 github.com/gorilla/handlers v1.4.2 h1:0QniY0USkHQ1RGCLfKxeNHK9bkDHGRYGNDFBCS+YARg=
 github.com/gorilla/handlers v1.4.2/go.mod h1:Qkdc/uu4tH4g6mTK6auzZ766c4CA0Ng8+o/OAirnOIQ=
 github.com/gorilla/mux v1.6.2/go.mod h1:1lud6UwP+6orDFRuTfBEV8e9/aOM/c4fVVCaMa2zaAs=
-github.com/gorilla/mux v1.7.3 h1:gnP5JzjVOuiZD07fKKToCAOjS0yOpj/qPETTXCCS6hw=
-github.com/gorilla/mux v1.7.3/go.mod h1:1lud6UwP+6orDFRuTfBEV8e9/aOM/c4fVVCaMa2zaAs=
 github.com/gorilla/mux v1.7.4 h1:VuZ8uybHlWmqV03+zRzdwKL4tUnIp1MAQtp1mIFE1bc=
 github.com/gorilla/mux v1.7.4/go.mod h1:DVbg23sWSpFRCP0SfiEN6jmj59UnW/n46BH5rLB71So=
 github.com/gorilla/schema v1.1.0 h1:CamqUDOFUBqzrvxuz2vEwo8+SUdwsluFh7IlzJh30LY=
@@ -562,8 +556,6 @@ github.com/threefoldtech/zbus v0.1.3 h1:18DnIzximRbATle5ZdZz0i84n/bCYB8k/gkhr2dX
 github.com/threefoldtech/zbus v0.1.3/go.mod h1:ZtiRpcqzEBJetVQDsEbw0p48h/AF3O1kf0tvd30I0BU=
 github.com/tidwall/pretty v1.0.0 h1:HsD+QiTn7sK6flMKIvNmpqz1qrpP3Ps6jOKIKMooyg4=
 github.com/tidwall/pretty v1.0.0/go.mod h1:XNkn88O1ChpSDQmQeStsy+sBenx6DDtFZJxhVysOjyk=
-github.com/tyler-smith/go-bip32 v0.0.0-20170922074101-2c9cfd177564 h1:NXXyQVeRVLK8Xu27/hkkjwVOZLk5v4ZBEvvMtqMqznM=
-github.com/tyler-smith/go-bip32 v0.0.0-20170922074101-2c9cfd177564/go.mod h1:0/YuQQF676+d4CMNclTqGUam1EDwz0B8o03K9pQqA3c=
 github.com/tyler-smith/go-bip39 v0.0.0-20180618194314-52158e4697b8 h1:g3yQGZK+G6dfF/mw/SOwsTMzUVkpT4hB8pHxpbTXkKw=
 github.com/tyler-smith/go-bip39 v0.0.0-20180618194314-52158e4697b8/go.mod h1:sJ5fKU0s6JVwZjjcUEX2zFOnvq0ASQ2K9Zr6cf67kNs=
 github.com/tyler-smith/go-bip39 v1.0.2 h1:+t3w+KwLXO6154GNJY+qUtIxLTmFjfUmpguQT1OlOT8=
@@ -605,8 +597,6 @@ github.com/yudai/golcs v0.0.0-20150405163532-d1c525dea8ce h1:888GrqRxabUce7lj4Oa
 github.com/yudai/golcs v0.0.0-20150405163532-d1c525dea8ce/go.mod h1:lgjkn3NuSvDfVJdfcVVdX+jpBxNmX4rDAzaS45IcYoM=
 github.com/yudai/pp v2.0.1+incompatible h1:Q4//iY4pNF6yPLZIigmvcl7k/bPgrcTPIFIcmawg5bI=
 github.com/yudai/pp v2.0.1+incompatible/go.mod h1:PuxR/8QJ7cyCkFp/aUDS+JY727OFEZkTdatxwunjIkc=
-github.com/zaibon/httpsig v0.0.0-20200401095359-2d1b87fa0e9b h1:x0NqD3GsYLNVVzvjsJrJm/S0EI5L1QuVtgCwaSrsxYE=
-github.com/zaibon/httpsig v0.0.0-20200401095359-2d1b87fa0e9b/go.mod h1:T2e9wAAQHKLB08ONx+0xxxrlAfUnRbwLOpO0WodNbQ4=
 github.com/zaibon/httpsig v0.0.0-20200401133919-ea9cb57b0946 h1:s12kADbuUVEJkYxqUojKvFR5JUpib9PCzARL1YR2ZDU=
 github.com/zaibon/httpsig v0.0.0-20200401133919-ea9cb57b0946/go.mod h1:T2e9wAAQHKLB08ONx+0xxxrlAfUnRbwLOpO0WodNbQ4=
 github.com/zenazn/goji v0.9.0/go.mod h1:7S9M489iMyHBNxwZnk9/EHS098H4/F6TATF2mIxtB1Q=

--- a/pkg/app/explorer.go
+++ b/pkg/app/explorer.go
@@ -1,6 +1,8 @@
 package app
 
 import (
+	"crypto/ed25519"
+
 	"github.com/pkg/errors"
 	"github.com/threefoldtech/zos/pkg/environment"
 	"github.com/threefoldtech/zos/pkg/identity"
@@ -22,10 +24,24 @@ func ExplorerClient() (*client.Client, error) {
 		return nil, err
 	}
 
-	cl, err := client.NewClient(env.BcdbURL, kp)
+	cl, err := client.NewClient(env.BcdbURL, nodeIdentity{
+		kp: kp,
+	})
 	if err != nil {
 		return nil, err
 	}
 
 	return cl, nil
+}
+
+type nodeIdentity struct {
+	kp identity.KeyPair
+}
+
+func (n nodeIdentity) PrivateKey() ed25519.PrivateKey {
+	return n.kp.PrivateKey
+}
+
+func (n nodeIdentity) Identity() string {
+	return n.kp.Identity()
 }

--- a/pkg/identity/userid.go
+++ b/pkg/identity/userid.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/rs/zerolog/log"
 	"github.com/tyler-smith/go-bip39"
+	"golang.org/x/crypto/ed25519"
 
 	"github.com/threefoldtech/zos/pkg/versioned"
 )
@@ -95,4 +96,14 @@ func (u *UserIdentity) Save(path string) error {
 	versioned.WriteFile(path, seedVersion11, buf, 0400)
 
 	return nil
+}
+
+// PrivateKey implements the client.Identity interface
+func (u *UserIdentity) PrivateKey() ed25519.PrivateKey {
+	return u.Key().PrivateKey
+}
+
+// Identity implements the Identifier interface
+func (u *UserIdentity) Identity() string {
+	return fmt.Sprintf("%d", u.ThreebotID)
 }

--- a/tools/client/client.go
+++ b/tools/client/client.go
@@ -1,12 +1,12 @@
 package client
 
 import (
+	"crypto/ed25519"
 	"fmt"
 	"net/url"
 
 	"github.com/threefoldtech/zos/pkg/capacity"
 	"github.com/threefoldtech/zos/pkg/capacity/dmi"
-	"github.com/threefoldtech/zos/pkg/identity"
 	"github.com/threefoldtech/zos/pkg/schema"
 	"github.com/threefoldtech/zos/tools/explorer/models/generated/directory"
 	"github.com/threefoldtech/zos/tools/explorer/models/generated/phonebook"
@@ -73,6 +73,14 @@ type Workloads interface {
 	WorkloadPutDeleted(nodeID, gwid string) error
 }
 
+// Identity is used by the client to authenticate to the explorer API
+type Identity interface {
+	// The unique ID as known by the explorer
+	Identity() string
+	// PrivateKey used to sign the requests
+	PrivateKey() ed25519.PrivateKey
+}
+
 // Pager for listing
 type Pager struct {
 	p int
@@ -101,9 +109,10 @@ func Page(page, size int) *Pager {
 	return &Pager{p: page, s: size}
 }
 
-// NewClient creates a new client
-func NewClient(u string, kp identity.KeyPair) (*Client, error) {
-	h, err := newHTTPClient(u, kp)
+// NewClient creates a new client, if identity is not nil, it will be used
+// to authenticate requests against the server
+func NewClient(u string, id Identity) (*Client, error) {
+	h, err := newHTTPClient(u, id)
 	if err != nil {
 		return nil, err
 	}

--- a/tools/tffarmer/main.go
+++ b/tools/tffarmer/main.go
@@ -14,7 +14,7 @@ import (
 
 var (
 	db     client.Directory
-	userid identity.UserIdentity
+	userid *identity.UserIdentity
 )
 
 func main() {
@@ -36,7 +36,7 @@ func main() {
 		cli.StringFlag{
 			Name:   "bcdb, b",
 			Usage:  "URL of the BCDB",
-			Value:  "https://explorer.devnet.grid.tf",
+			Value:  "https://explorer.devnet.grid.tf/explorer",
 			EnvVar: "BCDB_URL",
 		},
 	}
@@ -56,7 +56,7 @@ func main() {
 		}
 
 		url := c.String("bcdb")
-		cl, err := client.NewClient(url, userid.Key())
+		cl, err := client.NewClient(url, userid)
 		if err != nil {
 			return errors.Wrap(err, "failed to create client to bcdb")
 		}

--- a/tools/tfuser/cmds_identity.go
+++ b/tools/tfuser/cmds_identity.go
@@ -56,7 +56,7 @@ func cmdsGenerateID(c *cli.Context) error {
 	}
 
 	log.Debug().Msg("initializing client with created key")
-	bcdb, err = client.NewClient(bcdbAddr, ui.Key())
+	bcdb, err = client.NewClient(bcdbAddr, ui)
 	if err != nil {
 		return err
 	}
@@ -120,6 +120,31 @@ func cmdsConvertID(c *cli.Context) error {
 	}
 
 	return nil
+}
+
+func cmdsImportID(c *cli.Context) error {
+	tid := c.Uint64("tid")
+	mnemonic := c.String("mnemonic")
+	ui := &identity.UserIdentity{ThreebotID: tid}
+
+	log.Info().Msgf("building key using existing mnemonic '%s'", mnemonic)
+
+	if err := ui.FromMnemonic(mnemonic); err != nil {
+		return err
+	}
+
+	// Saving new seed struct
+	output := c.String("output")
+	if err := ui.Save(output); err != nil {
+		return errors.Wrap(err, "failed to save seed")
+	}
+
+	fmt.Printf("ThreeBot ID  : %d\n", ui.ThreebotID)
+	fmt.Printf("Public Key   : %s\n", hex.EncodeToString(ui.Key().PublicKey))
+	fmt.Printf("Mnemonic     : %s\n", ui.Mnemonic)
+	fmt.Printf("Seed saved to: %s\n", output)
+	return nil
+
 }
 
 func cmdsShowID(c *cli.Context) error {

--- a/tools/tfuser/cmds_live.go
+++ b/tools/tfuser/cmds_live.go
@@ -24,11 +24,6 @@ func cmdsLive(c *cli.Context) error {
 		deleted = c.Bool("deleted")
 	)
 
-	// keypair, err := identity.LoadKeyPair(seedPath)
-	// if err != nil {
-	// 	return errors.Wrapf(err, "could not find seed file at %s", seedPath)
-	// }
-
 	s := scraper{
 		poolSize: 10,
 		start:    start,

--- a/tools/tfuser/main.go
+++ b/tools/tfuser/main.go
@@ -14,7 +14,7 @@ import (
 
 var (
 	bcdb     *client.Client
-	mainui   identity.UserIdentity
+	mainui   *identity.UserIdentity
 	bcdbAddr string
 	mainSeed string
 )
@@ -41,7 +41,7 @@ func main() {
 		cli.StringFlag{
 			Name:   "bcdb, u",
 			Usage:  "URL of the BCDB",
-			Value:  "https://explorer.devnet.grid.tf",
+			Value:  "https://explorer.devnet.grid.tf/explorer",
 			EnvVar: "BCDB_URL",
 		},
 
@@ -70,7 +70,7 @@ func main() {
 				return err
 			}
 
-			bcdb, err = client.NewClient(bcdbAddr, mainui.Key())
+			bcdb, err = client.NewClient(bcdbAddr, mainui)
 			if err != nil {
 				return err
 			}
@@ -137,6 +137,27 @@ func main() {
 						},
 					},
 					Action: cmdsConvertID,
+				},
+				{
+					Name:  "import",
+					Usage: "import an key using a mnemonic seed",
+					Flags: []cli.Flag{
+						cli.StringFlag{
+							Name:  "mnemonic",
+							Usage: "generate a key from given mnemonic",
+						},
+						cli.StringFlag{
+							Name:  "output,o",
+							Usage: "output path of the identity seed",
+							Value: "user.seed",
+						},
+						cli.IntFlag{
+							Name:  "tid",
+							Usage: "threebot id",
+							Value: 0,
+						},
+					},
+					Action: cmdsImportID,
 				},
 				{
 					Name:   "show",


### PR DESCRIPTION
since we now need to authenticate 2 type of actor, nodes and users,
the client define an Identity interface whihc must be provided to the
constructor if the client need to authenticate the requests

2 type implement this interface, one for the nodes and one for the user.

This keep the http client generic

This PR also add a 'id import' command to tffuser