### PR TITLE
restructure stellar code to reduce calls to horizon

### DIFF
--- a/tools/explorer/pkg/stellar/stellar.go
+++ b/tools/explorer/pkg/stellar/stellar.go
@@ -292,6 +292,7 @@ func (w *Wallet) GetBalance(address string, id schema.ID, asset Asset) (xdr.Int6
 	txReq := horizonclient.TransactionRequest{
 		ForAccount: address,
 		Cursor:     cursor,
+		Limit:      200,
 	}
 
 	log.Info().Str("address", address).Msg("fetching balance for address")
@@ -384,10 +385,7 @@ func (w *Wallet) Refund(encryptedSeed string, id schema.ID, asset Asset) error {
 	if err != nil {
 		return errors.Wrap(err, "could not get keypair from encrypted seed")
 	}
-	sourceAccount, err := w.GetAccountDetails(keypair.Address())
-	if err != nil {
-		return errors.Wrap(err, "failed to get source account")
-	}
+
 	amount, funders, err := w.GetBalance(keypair.Address(), id, asset)
 	if err != nil {
 		return errors.Wrap(err, "failed to get balance")
@@ -396,6 +394,12 @@ func (w *Wallet) Refund(encryptedSeed string, id schema.ID, asset Asset) error {
 	if amount == 0 {
 		return nil
 	}
+
+	sourceAccount, err := w.GetAccountDetails(keypair.Address())
+	if err != nil {
+		return errors.Wrap(err, "failed to get source account")
+	}
+
 	destination := funders[0]
 
 	paymentOP := txnbuild.Payment{
@@ -440,17 +444,6 @@ func (w *Wallet) PayoutFarmers(encryptedSeed string, destinations []PayoutInfo, 
 	sourceAccount, err := w.GetAccountDetails(keypair.Address())
 	if err != nil {
 		return errors.Wrap(err, "failed to get source account")
-	}
-	balance, _, err := w.GetBalance(keypair.Address(), id, asset)
-	if err != nil {
-		return errors.Wrap(err, "failed to get balance")
-	}
-	requiredAmount := xdr.Int64(0)
-	for _, pi := range destinations {
-		requiredAmount += pi.Amount
-	}
-	if balance < requiredAmount {
-		return ErrInsuficientBalance
 	}
 
 	paymentOps := make([]txnbuild.Operation, 0, len(destinations)+1)

--- a/tools/explorer/pkg/stellar/stellar.go
+++ b/tools/explorer/pkg/stellar/stellar.go
@@ -42,6 +42,7 @@ type (
 const (
 	stellarPrecision       = 1e7
 	stellarPrecisionDigits = 7
+	stellarPageLimit       = 200
 
 	// NetworkProduction uses stellar production network
 	NetworkProduction = "production"
@@ -292,7 +293,7 @@ func (w *Wallet) GetBalance(address string, id schema.ID, asset Asset) (xdr.Int6
 	txReq := horizonclient.TransactionRequest{
 		ForAccount: address,
 		Cursor:     cursor,
-		Limit:      200,
+		Limit:      stellarPageLimit,
 	}
 
 	log.Info().Str("address", address).Msg("fetching balance for address")
@@ -302,7 +303,7 @@ func (w *Wallet) GetBalance(address string, id schema.ID, asset Asset) (xdr.Int6
 	}
 
 	donors := make(map[string]struct{})
-	for len(txes.Embedded.Records) != 0 {
+	for len(txes.Embedded.Records) < stellarPageLimit {
 		for _, tx := range txes.Embedded.Records {
 			if tx.Memo == strconv.FormatInt(int64(id), 10) {
 				effectsReq := horizonclient.EffectRequest{


### PR DESCRIPTION
closes #690 

Increased the transactions per page when we fetch the balance to 200, this will reduce the number of calls to fetch balance on a heavily used escrow address.