### PR TITLE
networkd: send ifaces information as soon as possible in the boot process

### DIFF
--- a/cmds/networkd/main.go
+++ b/cmds/networkd/main.go
@@ -68,6 +68,16 @@ func main() {
 		log.Info().Msg("shutting down")
 	})
 
+	// already sends all the interfaces detail we find
+	// this won't contains the ndmz IP yet, but this is OK.
+	ifaces, err := getLocalInterfaces()
+	if err != nil {
+		log.Fatal().Err(err).Msg("failed to read local network interfaces")
+	}
+	if err := publishIfaces(ifaces, nodeID, dir); err != nil {
+		log.Fatal().Err(err).Msg("failed to publish network interfaces to BCDB")
+	}
+
 	ifaceVersion := -1
 
 	exitIface, err := getPubIface(dir, nodeID.Identity())
@@ -115,16 +125,10 @@ func main() {
 		}
 	}(ctx, chIface)
 
-	ifaces, err := getLocalInterfaces()
-	if err != nil {
-		log.Fatal().Err(err).Msg("failed to read local network interfaces")
-	}
-
 	ndmzIfaces, err := getNdmzInterfaces()
 	if err != nil {
 		log.Fatal().Err(err).Msg("failed to read ndmz network interfaces")
 	}
-
 	ifaces = append(ifaces, ndmzIfaces...)
 
 	if err := publishIfaces(ifaces, nodeID, dir); err != nil {


### PR DESCRIPTION
fix a bug introduced in https://github.com/threefoldtech/zos/commit/e1a8692dce83f76bbd30e85a504de54b561a9a86#diff-cb6a758eace8d4732038725e48d7beadL71
which delay the report of the network intefaces configuration after the
ndmz is created. This leads to no interfaces reported at all in the case
the ndmz failed to be created.

Since ifaces informartion are used by farmer to identity a node, having
no iface inforamtion at all was a problem.

networkd now tries to send iface info as soon as possible and another
time after ndmz is created.