### PR TITLE
Update zdb containers when they are outdated

### DIFF
--- a/cmds/provisiond/main.go
+++ b/cmds/provisiond/main.go
@@ -150,6 +150,9 @@ func main() {
 		log.Info().Msg("shutting down")
 	})
 
+	// call the runtime upgrade before running engine
+	provisioner.RuntimeUpgrade(ctx)
+
 	go func() {
 		if err := server.Run(ctx); err != nil && err != context.Canceled {
 			log.Fatal().Err(err).Msg("unexpected error")

--- a/pkg/container/container.go
+++ b/pkg/container/container.go
@@ -288,8 +288,13 @@ func (c *containerModule) Inspect(ns string, id pkg.ContainerID) (result pkg.Con
 	return
 }
 
+// List returns running containers IDs for a specific namespace
 func (c *containerModule) List(ns string) ([]pkg.ContainerID, error) {
 	client, err := containerd.New(c.containerd)
+	if err != nil {
+		return nil, err
+	}
+
 	ctx := namespaces.WithNamespace(context.Background(), ns)
 
 	containers, err := client.Containers(ctx, "")

--- a/pkg/container/container.go
+++ b/pkg/container/container.go
@@ -288,6 +288,25 @@ func (c *containerModule) Inspect(ns string, id pkg.ContainerID) (result pkg.Con
 	return
 }
 
+func (c *containerModule) List(ns string) ([]pkg.ContainerID, error) {
+	client, err := containerd.New(c.containerd)
+	ctx := namespaces.WithNamespace(context.Background(), ns)
+
+	containers, err := client.Containers(ctx, "")
+	if err != nil {
+		return nil, err
+	}
+
+	var ids []pkg.ContainerID
+	ids = make([]pkg.ContainerID, len(containers))
+
+	for _, c := range containers {
+		ids = append(ids, pkg.ContainerID(c.ID()))
+	}
+
+	return ids, nil
+}
+
 // Deletes stops and remove a container
 func (c *containerModule) Delete(ns string, id pkg.ContainerID) error {
 	client, err := containerd.New(c.containerd)

--- a/pkg/flist/flist.go
+++ b/pkg/flist/flist.go
@@ -262,6 +262,26 @@ func (f *flistModule) getMountOptions(pidPath string) (options, error) {
 	return result, nil
 }
 
+func (f *flistModule) HashFromRootPath(name string) (string, error) {
+	base := filepath.Base(name)
+	pidPath := filepath.Join(f.pid, base) + ".pid"
+
+	opts, err := f.getMountOptions(pidPath)
+	if err != nil {
+		return "", err
+	}
+
+	for _, opt := range opts {
+		// if option start with the flist meta path
+		if strings.HasPrefix(opt, f.flist) {
+			// extracting hash (dirname) from argument
+			return filepath.Base(opt), nil
+		}
+	}
+
+	return "", fmt.Errorf("could not find rootfs hash name")
+}
+
 // NamedUmount implements the Flister.NamedUmount interface
 func (f *flistModule) NamedUmount(name string) error {
 	return f.Umount(filepath.Join(f.mountpoint, name))

--- a/pkg/provision/engine.go
+++ b/pkg/provision/engine.go
@@ -73,7 +73,6 @@ func New(opts EngineOps) *Engine {
 
 // Run starts reader reservation from the Source and handle them
 func (e *Engine) Run(ctx context.Context) error {
-
 	if err := e.cache.Sync(e.statser); err != nil {
 		return fmt.Errorf("failed to synchronize statser: %w", err)
 	}

--- a/pkg/provision/primitives/provisioner.go
+++ b/pkg/provision/primitives/provisioner.go
@@ -1,6 +1,7 @@
 package primitives
 
 import (
+	"context"
 	"github.com/threefoldtech/zbus"
 	"github.com/threefoldtech/zos/pkg/provision"
 )
@@ -39,4 +40,9 @@ func NewProvisioner(cache provision.ReservationCache, zbus zbus.Client) *Provisi
 	}
 
 	return p
+}
+
+// RuntimeUpgrade runs upgrade needed when provision daemon starts
+func (p *Provisioner) RuntimeUpgrade(ctx context.Context) {
+	p.upgradeRunningZdb(ctx)
 }

--- a/pkg/provision/primitives/zdb.go
+++ b/pkg/provision/primitives/zdb.go
@@ -403,11 +403,16 @@ func (p *Provisioner) upgradeRunningZdb(ctx context.Context) error {
 	// Listing running zdb containers
 	containers, err := contmod.List(zdbContainerNS)
 	if err != nil {
+		log.Error().Err(err).Msg("could not load containers list")
 		return err
 	}
 
 	// fetching extected hash
-	expected := "abcd"
+	expected, err := flistmod.FlistHash(zdbFlistURL)
+	if err != nil {
+		log.Error().Err(err).Msg("could not load expected flist hash")
+		return err
+	}
 
 	// Checking if containers are running latest zdb version
 	for _, c := range containers {

--- a/pkg/provision/primitives/zdb.go
+++ b/pkg/provision/primitives/zdb.go
@@ -504,6 +504,10 @@ func (p *Provisioner) upgradeRunningZdb(ctx context.Context) error {
 			err = p.zdbRun(volumeid, rootfs, zdbcmd, netns, volumepath, socketdir)
 			if err != nil {
 				log.Error().Err(err).Msg("could not restart zdb container")
+
+				if err = flistmod.Umount(rootfs); err != nil {
+					log.Error().Err(err).Str("path", rootfs).Msgf("failed to unmount zdb container")
+				}
 			}
 		}
 	}

--- a/pkg/provision/primitives/zdb.go
+++ b/pkg/provision/primitives/zdb.go
@@ -422,14 +422,14 @@ func (p *Provisioner) upgradeRunningZdb(ctx context.Context) error {
 
 		log.Debug().Str("id", string(c)).Msg("inspecting container")
 
-		value, err := contmod.Inspect(zdbContainerNS, c)
+		continfo, err := contmod.Inspect(zdbContainerNS, c)
 
 		if err != nil {
 			log.Error().Err(err).Msg("could not inspect container")
 			continue
 		}
 
-		hash, err := flistmod.HashFromRootPath(value.RootFS)
+		hash, err := flistmod.HashFromRootPath(continfo.RootFS)
 		if err != nil {
 			log.Error().Err(err).Msg("could not find container running flist hash")
 			continue
@@ -439,7 +439,16 @@ func (p *Provisioner) upgradeRunningZdb(ctx context.Context) error {
 
 		if expected != hash {
 			log.Info().Str("id", string(c)).Msg("restarting container, update found")
-			// TODO: restart container
+
+			// stopping running zdb
+			err := contmod.Delete(zdbContainerNS, c)
+			if err != nil {
+				log.Error().Err(err).Msg("could not stop running zdb container")
+				continue
+			}
+
+			// restarting zdb
+			// TODO
 		}
 	}
 

--- a/pkg/provision/primitives/zdb.go
+++ b/pkg/provision/primitives/zdb.go
@@ -22,8 +22,9 @@ import (
 )
 
 const (
-	// TODO: make this configurable
-	zdbFlistURL    = "https://hub.grid.tf/tf-autobuilder/threefoldtech-0-db-development.flist"
+	// https://hub.grid.tf/api/flist/tf-autobuilder/threefoldtech-0-db-development.flist/light
+	// To get the latest symlink pointer
+	zdbFlistURL    = "https://hub.grid.tf/tf-autobuilder/threefoldtech-0-db-development-b5155357d5.flist"
 	zdbContainerNS = "zdb"
 	zdbPort        = 9900
 )

--- a/pkg/provision/primitives/zdb.go
+++ b/pkg/provision/primitives/zdb.go
@@ -491,6 +491,11 @@ func (p *Provisioner) upgradeRunningZdb(ctx context.Context) error {
 				continue
 			}
 
+			// cleanup old containers rootfs
+			if err = flistmod.Umount(continfo.RootFS); err != nil {
+				log.Error().Err(err).Str("path", continfo.RootFS).Msgf("failed to unmount old zdb container")
+			}
+
 			// restarting zdb
 
 			// mount the new flist

--- a/pkg/stubs/container_stub.go
+++ b/pkg/stubs/container_stub.go
@@ -51,6 +51,22 @@ func (s *ContainerModuleStub) Inspect(arg0 string, arg1 pkg.ContainerID) (ret0 p
 	return
 }
 
+func (s *ContainerModuleStub) List(arg0 string) (ret0 []pkg.ContainerID, ret1 error) {
+	args := []interface{}{arg0}
+	result, err := s.client.Request(s.module, s.object, "List", args...)
+	if err != nil {
+		panic(err)
+	}
+	if err := result.Unmarshal(0, &ret0); err != nil {
+		panic(err)
+	}
+	ret1 = new(zbus.RemoteError)
+	if err := result.Unmarshal(1, &ret1); err != nil {
+		panic(err)
+	}
+	return
+}
+
 func (s *ContainerModuleStub) Run(arg0 string, arg1 pkg.Container) (ret0 pkg.ContainerID, ret1 error) {
 	args := []interface{}{arg0, arg1}
 	result, err := s.client.Request(s.module, s.object, "Run", args...)

--- a/pkg/stubs/flist_stub.go
+++ b/pkg/stubs/flist_stub.go
@@ -79,3 +79,19 @@ func (s *FlisterStub) Umount(arg0 string) (ret0 error) {
 	}
 	return
 }
+
+func (s *FlisterStub) HashFromRootPath(arg0 string) (ret0 string, ret1 error) {
+	args := []interface{}{arg0}
+	result, err := s.client.Request(s.module, s.object, "HashFromRootPath", args...)
+	if err != nil {
+		panic(err)
+	}
+	if err := result.Unmarshal(0, &ret0); err != nil {
+		panic(err)
+	}
+	ret1 = new(zbus.RemoteError)
+	if err := result.Unmarshal(1, &ret1); err != nil {
+		panic(err)
+	}
+	return
+}

--- a/pkg/stubs/flist_stub.go
+++ b/pkg/stubs/flist_stub.go
@@ -95,3 +95,19 @@ func (s *FlisterStub) HashFromRootPath(arg0 string) (ret0 string, ret1 error) {
 	}
 	return
 }
+
+func (s *FlisterStub) FlistHash(arg0 string) (ret0 string, ret1 error) {
+	args := []interface{}{arg0}
+	result, err := s.client.Request(s.module, s.object, "FlistHash", args...)
+	if err != nil {
+		panic(err)
+	}
+	if err := result.Unmarshal(0, &ret0); err != nil {
+		panic(err)
+	}
+	ret1 = new(zbus.RemoteError)
+	if err := result.Unmarshal(1, &ret1); err != nil {
+		panic(err)
+	}
+	return
+}


### PR DESCRIPTION
When `provisiond` starts, it will check if any running zdb container are outdated. If they are, it will restart theses containers using latest version.

Some changes occures:
- The zdb url is now hardcoded and doesn't follow a symlink anymore
- When provisiond starts, it will check for running zdb
- When provisiond starts, it will loads the flist expected hash from the hub
- Container module contains a new function to list containers based on a namespace
- Flist module contains a way to grab md5 from url directly
- Flist module contains a function to returns flist hash from a running g8ufs

This fixes #780, when provisiond will be updated on nodes, if there is a 0-db update (and there will be one, we can force it), all zdb will restart and new shim will be applied.