### PR TITLE
networkd: close zinit connection after yggdrasil is stopped

### DIFF
--- a/cmds/networkd/main.go
+++ b/cmds/networkd/main.go
@@ -222,8 +222,13 @@ func startYggdrasil(ctx context.Context, privateKey ed25519.PrivateKey, dmz ndmz
 	go func() {
 		select {
 		case <-ctx.Done():
-			z.Close()
-			server.Stop()
+			if err := server.Stop(); err != nil {
+				log.Error().Err(err).Msg("error while stopping yggdrasil")
+			}
+			if err := z.Close(); err != nil {
+				log.Error().Err(err).Msg("error while closing zinit client")
+			}
+			log.Info().Msg("yggdrasil stopped")
 		}
 	}()
 

--- a/pkg/network/yggdrasil/yygdrasil.go
+++ b/pkg/network/yggdrasil/yygdrasil.go
@@ -82,7 +82,7 @@ func (s *Server) Stop() error {
 		return nil
 	}
 
-	return s.zinit.Stop(zinitService)
+	return s.zinit.StopWait(time.Second*5, zinitService)
 }
 
 // NodeID returns the yggdrasil node ID of s


### PR DESCRIPTION
this fix a bug where the yggsrasil service wasn't properly stopped cause
the zinit client was closed before the stop signal was sent