### PR TITLE
make corex only listen on the private overlay network interface of the container

### DIFF
--- a/pkg/container/opts.go
+++ b/pkg/container/opts.go
@@ -51,7 +51,7 @@ func withCoreX() oci.SpecOpts {
 		return nil
 	}
 
-	return oci.Compose(withMount, oci.WithProcessArgs("/corex", "--ipv6", "-d", "7"))
+	return oci.Compose(withMount, oci.WithProcessArgs("/corex", "--ipv6", "-d", "7", "--interface", "eth0"))
 }
 
 func withMounts(mounts []pkg.MountInfo) oci.SpecOpts {


### PR DESCRIPTION
container

fixes #850

this allow container with public IPv6 to NOT expose coreX