### PR TITLE
flistd cleanup

### DIFF
--- a/cmds/networkd/main.go
+++ b/cmds/networkd/main.go
@@ -329,8 +329,8 @@ func buildNDMZ(nodeID string) (ndmz.DMZ, error) {
 
 	bo := backoff.NewExponentialBackOff()
 	// wait for 2 minute for public ipv6
-	bo.MaxElapsedTime = time.Minute * 2
-	bo.MaxInterval = time.Second * 10
+	bo.MaxElapsedTime = time.Second * 10
+	bo.MaxInterval = time.Second * 3
 	err := backoff.RetryNotify(findMaster, bo, notify)
 
 	// if ipv6 found, use dual stack ndmz

--- a/cmds/networkd/main.go
+++ b/cmds/networkd/main.go
@@ -329,8 +329,8 @@ func buildNDMZ(nodeID string) (ndmz.DMZ, error) {
 
 	bo := backoff.NewExponentialBackOff()
 	// wait for 2 minute for public ipv6
-	bo.MaxElapsedTime = time.Second * 10
-	bo.MaxInterval = time.Second * 3
+	bo.MaxElapsedTime = time.Minute * 2
+	bo.MaxInterval = time.Second * 10
 	err := backoff.RetryNotify(findMaster, bo, notify)
 
 	// if ipv6 found, use dual stack ndmz

--- a/pkg/flist/cleanup.go
+++ b/pkg/flist/cleanup.go
@@ -1,0 +1,122 @@
+package flist
+
+import (
+	"context"
+	"fmt"
+	"io/ioutil"
+	"os"
+	"path/filepath"
+	"strings"
+	"syscall"
+	"time"
+
+	"github.com/pkg/errors"
+	"github.com/rs/zerolog/log"
+)
+
+// Cleaner interface, implementer of this interface
+// can start a cleaner job
+type Cleaner interface {
+	// Cleaner runs the clean process, Cleaner should be
+	// blocking. Caller then can do `go Cleaner()` to run it in the background
+	Cleaner(ctx context.Context, every time.Duration)
+}
+
+var _ Cleaner = (*flistModule)(nil)
+
+func (f *flistModule) listMounts() (map[string]int64, error) {
+	infos, err := ioutil.ReadDir(f.run)
+	if err != nil {
+		return nil, errors.Wrapf(err, "failed to list g8ufs proccess pids: {}", f.pid)
+	}
+
+	data := make(map[string]int64)
+	for _, info := range infos {
+		if info.IsDir() {
+			// what is that doing here?
+			continue
+		}
+
+		if !strings.HasSuffix(info.Name(), ".pid") {
+			// also what is that doing here!
+			continue
+		}
+
+		path := filepath.Join(f.run, info.Name())
+		pid, err := f.getPid(path)
+		if err != nil {
+			log.Error().Err(err).Str("pid-file", path).Msg("invalid pid file")
+		}
+
+		data[strings.TrimSuffix(info.Name(), ".pid")] = pid
+	}
+
+	return data, nil
+}
+
+// cleanupMount forces clean up of a mount point
+func (f *flistModule) cleanupMount(name string) error {
+	path, err := f.mountpath(name)
+	if err != nil {
+		return err
+	}
+
+	// the following procedure will ignore errors
+	// because the only point of this is to force
+	// clean the entire mount.
+	// so no checks or error checking is done
+
+	if err := syscall.Unmount(path, syscall.MNT_DETACH); err != nil {
+		log.Warn().Err(err).Str("path", path).Msg("fail to unmount flist")
+	}
+
+	// we don't know if this even exists, but if it does, it need to be deleted
+	// so we try to delete it and just log a warning.
+	if err := f.storage.ReleaseFilesystem(name); err != nil {
+		log.Warn().Err(err).Str("subvolume", name).Msg("failed to clean up subvolume")
+	}
+
+	return nil
+}
+
+func (f *flistModule) cleanupAll() error {
+	mounts, err := f.listMounts()
+	if err != nil {
+		return errors.Wrap(err, "failed to list current possible mounts")
+	}
+
+	for name, pid := range mounts {
+		_, err := f.getMountOptionsForPID(pid)
+		if err != nil {
+			// this is only possible if process does not exist.
+			// hence we need to clean up.
+			log.Debug().Str("name", name).Int64("pid", pid).Msg("attempt to clean up mount")
+
+			f.cleanupMount(name)
+			for _, file := range []string{
+				filepath.Join(f.pid, fmt.Sprintf("%s.pid", name)),
+				filepath.Join(f.run, name),
+				filepath.Join(f.log, fmt.Sprintf("%s.log", name)),
+			} {
+				if err := os.Remove(file); err != nil {
+					log.Error().Err(err).Str("file", file).Msg("failed to delete pid file")
+				}
+			}
+		}
+	}
+
+	return nil
+}
+
+func (f *flistModule) Cleaner(ctx context.Context, every time.Duration) {
+	for {
+		select {
+		case <-ctx.Done():
+		case <-time.After(every):
+			log.Debug().Msg("running cleaner job")
+			if err := f.cleanupAll(); err != nil {
+				log.Error().Err(err).Msg("failed to cleanup stall mounts")
+			}
+		}
+	}
+}

--- a/pkg/flist/cleanup.go
+++ b/pkg/flist/cleanup.go
@@ -26,7 +26,7 @@ var _ Cleaner = (*flistModule)(nil)
 func (f *flistModule) listMounts() (map[string]int64, error) {
 	infos, err := ioutil.ReadDir(f.run)
 	if err != nil {
-		return nil, errors.Wrapf(err, "failed to list g8ufs proccess pids: {}", f.pid)
+		return nil, errors.Wrapf(err, "failed to list g8ufs process pids: %s", f.pid)
 	}
 
 	data := make(map[string]int64)
@@ -117,6 +117,8 @@ func (f *flistModule) cleanupAll() error {
 	return nil
 }
 
+// Cleaner runs forever, checks the tracker files for filesystem processes
+// that requires cleanup
 func (f *flistModule) Cleaner(ctx context.Context, every time.Duration) {
 	for {
 		select {

--- a/pkg/flist/flist.go
+++ b/pkg/flist/flist.go
@@ -172,6 +172,13 @@ func (f *flistModule) mount(name, url, storage string, opts pkg.MountOptions) (s
 		return "", err
 	}
 
+	err = f.valid(mountpoint)
+	if errors.Is(err, ErrAlreadyMounted) {
+		// if everything is already in place, just early return
+		log.Info().Msgf("flist is already mounted at %s, nothing more to do", mountpoint)
+		return mountpoint, nil
+	}
+
 	env, err := environment.Get()
 	if err != nil {
 		return "", errors.Wrap(err, "failed to parse node environment")
@@ -220,13 +227,6 @@ func (f *flistModule) mount(name, url, storage string, opts pkg.MountOptions) (s
 		}()
 	} else {
 		args = append(args, "-ro")
-	}
-
-	err = f.valid(mountpoint)
-	if errors.Is(err, ErrAlreadyMounted) {
-		// if everything is already in place, just early return
-		log.Info().Msgf("flist is already mounted at %s, nothing more to do", mountpoint)
-		return mountpoint, nil
 	}
 
 	if err != nil {

--- a/pkg/flist/flist.go
+++ b/pkg/flist/flist.go
@@ -257,13 +257,6 @@ func (f *flistModule) mount(name, url, storage string, opts pkg.MountOptions) (s
 		return "", err
 	}
 
-	// wait for the daemon to be ready
-	// we check the pid file is created
-	if err = waitPidFile(time.Second*5, pidPath, true); err != nil {
-		sublog.Error().Err(err).Msg("pid file of 0-fs daemon not created")
-		return "", err
-	}
-
 	// the track file is a symlink to the process pid
 	// if the link is broken, then the fs has exited gracefully
 	// otherwise we can get the fs pid from the track path
@@ -272,12 +265,6 @@ func (f *flistModule) mount(name, url, storage string, opts pkg.MountOptions) (s
 	trackPath := filepath.Join(f.run, name)
 	if err = os.Symlink(pidPath, trackPath); err != nil {
 		sublog.Error().Err(err).Msg("failed track fs pid")
-	}
-
-	// and scan the logs after "mount ready"
-	if err = waitMountedLog(time.Second*5, logPath); err != nil {
-		sublog.Error().Err(err).Msg("0-fs daemon did not start properly")
-		return "", err
 	}
 
 	return mountpoint, nil


### PR DESCRIPTION
Fixes #864

- We make sure that mounted flists names are  tracked 
- We can't use pid files because they are deleted if the g8ufs process exited gracefully
- We do the tracking by creating a symlink to the pid file
- A go routine is running (every minute) that does the following
  - list all tracking symlinks
  - if link target is missing (graceful shutdown) the clean up is run anyway just to be sure
  - if link target is there, the PID is loaded
  - we check the PID that is actually a g8ufs process
  - If process exists, nothing is done
  - Otherwise we run the clean up
- The clean up process includes
  - force unmount the target location
  - drop the storage volume used for backend
  - delete all pid, tracking and log files.