### PR TITLE
provisiond: harden container provisioning 

### DIFF
--- a/pkg/network/nr/container.go
+++ b/pkg/network/nr/container.go
@@ -30,13 +30,7 @@ func (nr *NetResource) Join(containerID string, addrs []net.IP, publicIP6 bool) 
 	}
 
 	join.Namespace = containerID
-
-	var netspace ns.NetNS
-	if namespace.Exists(containerID) {
-		netspace, err = namespace.GetByName(containerID)
-	} else {
-		netspace, err = namespace.Create(containerID)
-	}
+	netspace, err := namespace.Create(containerID)
 	if err != nil {
 		return join, err
 	}


### PR DESCRIPTION
move all the sanity checks early on in the provision flow so we have
less things to cleanup in case something goes wrong

also add some extra validation in the container workload definition
itself

fixes #887