### PR TITLE
Handle zdb namespace and macvlan cleanly 

### DIFF
--- a/pkg/network/macvlan/macvlan.go
+++ b/pkg/network/macvlan/macvlan.go
@@ -96,7 +96,7 @@ func Install(link *netlink.Macvlan, hw net.HardwareAddr, ips []*net.IPNet, route
 	f := func(_ ns.NetNS) error {
 		if hw != nil && len(hw) != 0 {
 			if err := netlink.LinkSetHardwareAddr(link, hw); err != nil {
-				return err
+				return fmt.Errorf("failed to set MAC address on interface %s: %w", link.Attrs().Name, err)
 			}
 		}
 

--- a/pkg/network/namespace/namespace.go
+++ b/pkg/network/namespace/namespace.go
@@ -159,7 +159,7 @@ func Exists(name string) bool {
 
 	if !mounted {
 		//the file shouldn't be there
-		os.Remove(nsPath)
+		_ = os.Remove(nsPath)
 	}
 
 	return mounted

--- a/pkg/network/networker.go
+++ b/pkg/network/networker.go
@@ -327,6 +327,10 @@ func (n networker) createMacVlan(iface string, hw net.HardwareAddr, ips []*net.I
 
 	if _, ok := err.(netlink.LinkNotFoundError); ok {
 		macVlan, err = macvlan.Create(iface, n.ndmz.IP6PublicIface(), netNs)
+
+		if err != nil {
+			return err
+		}
 	} else if err != nil {
 		return err
 	}

--- a/pkg/network/networker.go
+++ b/pkg/network/networker.go
@@ -286,7 +286,7 @@ func (n networker) ZDBPrepare(hw net.HardwareAddr) (string, error) {
 	if n.ygg != nil {
 		ip, err := n.ygg.SubnetFor(hw)
 		if err != nil {
-			return "", err
+			return "", fmt.Errorf("failed to generate ygg subnet IP: %w", err)
 		}
 
 		ips = []*net.IPNet{
@@ -298,7 +298,7 @@ func (n networker) ZDBPrepare(hw net.HardwareAddr) (string, error) {
 
 		gw, err := n.ygg.Gateway()
 		if err != nil {
-			return "", err
+			return "", fmt.Errorf("failed to get ygg gateway IP: %w", err)
 		}
 
 		routes = []*netlink.Route{
@@ -865,7 +865,7 @@ func createNetNS(name string) (ns.NetNS, error) {
 	}
 
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("fail to create network namespace %s: %w", name, err)
 	}
 
 	err = netNs.Do(func(_ ns.NetNS) error {
@@ -874,7 +874,7 @@ func createNetNS(name string) (ns.NetNS, error) {
 
 	if err != nil {
 		namespace.Delete(netNs)
-		return nil, err
+		return nil, fmt.Errorf("failed to bring lo interface up in namespace %s: %w", name, err)
 	}
 
 	return netNs, nil

--- a/pkg/provision/engine.go
+++ b/pkg/provision/engine.go
@@ -189,9 +189,8 @@ func (e *Engine) provision(ctx context.Context, r *Reservation) error {
 
 		uniqueID := NetworkID(r.User, nr.Name)
 		exists, err := e.cache.NetworkExists(string(uniqueID))
-		if err == nil {
-			log.Error().Err(err).Msg("failed to check if network exists")
-			return err
+		if err != nil {
+			return errors.Wrap(err, "failed to check if network exists")
 		}
 		if exists {
 			return nil


### PR DESCRIPTION
This is to avoid creating multiple namespaces for the same
zdb deployment, which can result in address already in use error

Fixes #916