### PR TITLE
Fix/disk detection

### DIFF
--- a/cmds/storaged/main.go
+++ b/cmds/storaged/main.go
@@ -67,7 +67,7 @@ func main() {
 	})
 
 	go func() {
-		if err := http.ListenAndServe(":8080", http.DefaultServeMux); err != nil {
+		if err := http.ListenAndServe(":8081", http.DefaultServeMux); err != nil {
 			log.Error().Err(err).Msg("Error starting http server")
 		}
 	}()

--- a/cmds/storaged/main.go
+++ b/cmds/storaged/main.go
@@ -3,6 +3,7 @@ package main
 import (
 	"context"
 	"flag"
+	"fmt"
 	"net/http"
 
 	"github.com/rs/zerolog/log"
@@ -25,11 +26,13 @@ func main() {
 	var (
 		msgBrokerCon string
 		workerNr     uint
+		expvarPort   uint
 		ver          bool
 	)
 
 	flag.StringVar(&msgBrokerCon, "broker", redisSocket, "Connection string to the message broker")
 	flag.UintVar(&workerNr, "workers", 1, "Number of workers")
+	flag.UintVar(&expvarPort, "expvarPort", 28682, "Port to host expvar variables on")
 	flag.BoolVar(&ver, "v", false, "show version and exit")
 
 	flag.Parse()
@@ -67,7 +70,7 @@ func main() {
 	})
 
 	go func() {
-		if err := http.ListenAndServe(":8081", http.DefaultServeMux); err != nil {
+		if err := http.ListenAndServe(fmt.Sprintf(":%d", expvarPort), http.DefaultServeMux); err != nil {
 			log.Error().Err(err).Msg("Error starting http server")
 		}
 	}()

--- a/cmds/storaged/main.go
+++ b/cmds/storaged/main.go
@@ -3,6 +3,7 @@ package main
 import (
 	"context"
 	"flag"
+	"net/http"
 
 	"github.com/rs/zerolog/log"
 
@@ -64,6 +65,12 @@ func main() {
 	utils.OnDone(ctx, func(_ error) {
 		log.Info().Msg("shutting down")
 	})
+
+	go func() {
+		if err := http.ListenAndServe(":8080", http.DefaultServeMux); err != nil {
+			log.Error().Err(err).Msg("Error starting http server")
+		}
+	}()
 
 	if err := server.Run(ctx); err != nil && err != context.Canceled {
 		log.Fatal().Err(err).Msg("unexpected error")

--- a/go.sum
+++ b/go.sum
@@ -94,6 +94,7 @@ github.com/containernetworking/cni v0.7.2-0.20190807151350-8c6c47d1c7fc/go.mod h
 github.com/containernetworking/plugins v0.8.2/go.mod h1:TxALKWZpWL79BC3GOYKJzzXr7U8R23PdhwaLp6F3adc=
 github.com/containernetworking/plugins v0.8.4 h1:rOtM8umH7EGqtkFwP9RtmY/Q+PoZ7MRM2mAltEHoIHE=
 github.com/containernetworking/plugins v0.8.4/go.mod h1:UZ2539umj8djuRQmBxuazHeJbYrLV8BSBejkk+she6o=
+github.com/containernetworking/plugins v0.8.6 h1:npZTLiMa4CRn6m5P9+1Dz4O1j0UeFbm8VYN6dlsw568=
 github.com/coreos/go-iptables v0.4.2/go.mod h1:/mVI274lEDI2ns62jHCDnCyBF9Iwsmekav8Dbxlm1MU=
 github.com/coreos/go-iptables v0.4.5 h1:DpHb9vJrZQEFMcVLFKAAGMUVX0XoRC0ptCthinRYm38=
 github.com/coreos/go-iptables v0.4.5/go.mod h1:/mVI274lEDI2ns62jHCDnCyBF9Iwsmekav8Dbxlm1MU=

--- a/pkg/storage/filesystem/btrfs.go
+++ b/pkg/storage/filesystem/btrfs.go
@@ -494,6 +494,8 @@ func (p *btrfsPool) Shutdown() error {
 			log.Error().Err(err).Msgf("Error shutting down device %s", device.Path)
 			return err
 		}
+
+		device.ShutdownCount.Add(1)
 		log.Info().Msgf("Disk %s is shutdown", device.Path)
 	}
 	return nil

--- a/pkg/storage/filesystem/device.go
+++ b/pkg/storage/filesystem/device.go
@@ -7,6 +7,8 @@ import (
 	"strings"
 	"time"
 
+	"expvar"
+
 	"github.com/pkg/errors"
 	log "github.com/rs/zerolog/log"
 	"github.com/threefoldtech/zos/pkg"
@@ -55,7 +57,8 @@ type Device struct {
 	//devices are flattend in the device, cache, the children list is
 	//zeroed (since all devices are flat), then has partions is set to
 	//make sure the device is not altered.
-	HasPartions bool `json:"-"`
+	HasPartions   bool `json:"-"`
+	ShutdownCount *expvar.Int
 }
 
 // Used assumes that the device is used if it has custom label or fstype or children

--- a/pkg/storage/storage.go
+++ b/pkg/storage/storage.go
@@ -682,17 +682,12 @@ func (s *storageModule) Monitor(ctx context.Context) <-chan pkg.PoolsStats {
 
 func (s *storageModule) periodicallyCheckDiskShutdown() {
 	ticker := time.NewTicker(5 * time.Minute)
-	quit := make(chan struct{})
+
 	go func() {
 		for {
-			select {
-			case <-ticker.C:
-				log.Info().Msg("Checking pools for disks that should be shutdown...")
-				s.shutdownDisks()
-			case <-quit:
-				ticker.Stop()
-				return
-			}
+			<-ticker.C
+			log.Info().Msg("Checking pools for disks that should be shutdown...")
+			s.shutdownDisks()
 		}
 	}()
 }
@@ -706,7 +701,7 @@ func (s *storageModule) shutdownDisks() {
 			on, err := checkDiskPowerStatus(device.Path)
 			if err != nil {
 				log.Err(err).Msgf("error occurred while checking disk power status")
-				return
+				continue
 			}
 
 			_, mounted := pool.Mounted()
@@ -718,7 +713,7 @@ func (s *storageModule) shutdownDisks() {
 			err = pool.Shutdown()
 			if err != nil {
 				log.Err(err).Msgf("failed to shutdown device %s", device.Path)
-				return
+				continue
 			}
 		}
 	}

--- a/pkg/storage/storage.go
+++ b/pkg/storage/storage.go
@@ -685,7 +685,8 @@ func (s *storageModule) verifyShutdown() {
 						log.Debug().Msgf("checking device: %s", device.Path)
 						on, err := checkDiskPowerStatus(device.Path)
 						if err != nil {
-							if _, ok := err.(*exec.ExitError); ok {
+							if err, ok := err.(*exec.ExitError); ok {
+								log.Err(err).Msgf("skipping device")
 								// if cmd exits with exit error the device is shutdown
 								continue
 							}

--- a/pkg/storage/storage.go
+++ b/pkg/storage/storage.go
@@ -705,7 +705,7 @@ func (s *storageModule) shutdownDisks() {
 			log.Debug().Msgf("checking device: %s", device.Path)
 			on, err := checkDiskPowerStatus(device.Path)
 			if err != nil {
-				log.Err(err).Msgf("error occured while checking disk power status")
+				log.Err(err).Msgf("error occurred while checking disk power status")
 				return
 			}
 

--- a/pkg/storage/storage.go
+++ b/pkg/storage/storage.go
@@ -722,8 +722,7 @@ func (s *storageModule) shutdownDisks() {
 func checkDiskPowerStatus(path string) (bool, error) {
 	output, err := exec.Command("smartctl", "-i", "-n", "standby", path).Output()
 	if err != nil {
-		if err, ok := err.(*exec.ExitError); ok {
-			log.Err(err).Msgf("skipping device")
+		if _, ok := err.(*exec.ExitError); ok {
 			return false, nil
 		}
 		return false, err

--- a/pkg/storage/storage.go
+++ b/pkg/storage/storage.go
@@ -2,6 +2,7 @@ package storage
 
 import (
 	"context"
+	"expvar"
 	"fmt"
 	"os"
 	"os/exec"
@@ -281,6 +282,13 @@ func (s *storageModule) initialize(policy pkg.StoragePolicy) error {
 			return err
 		}
 		s.pools = append(s.pools, pool)
+	}
+
+	// add expvar variables
+	for _, pool := range s.pools {
+		for _, device := range pool.Devices() {
+			device.ShutdownCount = expvar.NewInt(device.Path)
+		}
 	}
 
 	if err := filesystem.Partprobe(ctx); err != nil {


### PR DESCRIPTION
We add the `-f` because some disks with an existing partition table that we know are free gave issues when trying to create the brfs filesystem.