### PR TITLE
Cache results and resend them when needed

### DIFF
--- a/pkg/provision/reservation.go
+++ b/pkg/provision/reservation.go
@@ -4,7 +4,6 @@ import (
 	"bytes"
 	"encoding/json"
 	"fmt"
-	"reflect"
 	"strconv"
 	"strings"
 	"time"
@@ -171,12 +170,22 @@ type Result struct {
 
 // IsNil checks if Result is the zero values
 func (r *Result) IsNil() bool {
-	return reflect.DeepEqual(r, &emptyResult)
+	// ideally this should be implemented like this
+	// emptyResult := Result{}
+	// return reflect.DeepEqual(r, &emptyResult)
+	//
+	// but unfortunately, the empty Result coming from the explorer already have some fields set
+	// (like the type)
+	// so instead we gonna check the Data and the Created filed
+
+	return (r.Created.Equal(epoch) || r.Created.Equal(nullTime)) && (len(r.Data) == 0 || bytes.Equal(r.Data, nullRaw))
 }
 
 var (
 	//emptyResult is the Result zero value
-	emptyResult = Result{}
+	epoch      = time.Unix(0, 0)
+	nullTime   = time.Time{}
+	nullRaw, _ = json.Marshal(nil)
 )
 
 // Bytes returns a slice of bytes container all the information

--- a/pkg/provision/reservation.go
+++ b/pkg/provision/reservation.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"encoding/json"
 	"fmt"
+	"reflect"
 	"strconv"
 	"strings"
 	"time"
@@ -167,6 +168,16 @@ type Result struct {
 	// and hex
 	Signature string `json:"signature"`
 }
+
+// IsNil checks if Result is the zero values
+func (r *Result) IsNil() bool {
+	return reflect.DeepEqual(r, &emptyResult)
+}
+
+var (
+	//emptyResult is the Result zero value
+	emptyResult = Result{}
+)
 
 // Bytes returns a slice of bytes container all the information
 // used to sign the Result object

--- a/pkg/provision/reservation_test.go
+++ b/pkg/provision/reservation_test.go
@@ -1,0 +1,26 @@
+package provision
+
+import (
+	"encoding/json"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestResultNil(t *testing.T) {
+	var result Result
+
+	require.True(t, result.IsNil())
+
+	result = Result{}
+	require.True(t, result.IsNil())
+
+	null, _ := json.Marshal(nil)
+	result = Result{
+		Data:    json.RawMessage(null),
+		Created: time.Unix(0, 0),
+	}
+
+	require.True(t, result.IsNil())
+}


### PR DESCRIPTION
We trying to improve how the node handle double send of reservations better by making sure that all reservations results are cached and send back if needed.

Related to #922