### PR TITLE
Include runc on containerd flist package

### DIFF
--- a/.github/workflows/bins-extra-development.yaml
+++ b/.github/workflows/bins-extra-development.yaml
@@ -43,7 +43,6 @@ jobs:
     - name: Merging packages
       id: packages
       run: |
-        cd bins
         mkdir /tmp/root
         sudo cp -av bins/releases/containerd/* /tmp/root/
         sudo cp -av bins/releases/runc/* /tmp/root/

--- a/.github/workflows/bins-extra-development.yaml
+++ b/.github/workflows/bins-extra-development.yaml
@@ -29,19 +29,19 @@ jobs:
         sudo ./bins-extra.sh --package basesystem
 
     - name: Build package (containerd)
-      id: package
+      id: package-1
       run: |
         cd bins
         sudo ./bins-extra.sh --package containerd
 
     - name: Build package (runc)
-      id: package
+      id: package-2
       run: |
         cd bins
         sudo ./bins-extra.sh --package runc
 
     - name: Merging packages
-      id: package
+      id: packages
       run: |
         cd bins
         mkdir /tmp/root

--- a/.github/workflows/bins-extra-development.yaml
+++ b/.github/workflows/bins-extra-development.yaml
@@ -28,11 +28,25 @@ jobs:
         cd bins
         sudo ./bins-extra.sh --package basesystem
 
-    - name: Build package
+    - name: Build package (containerd)
       id: package
       run: |
         cd bins
         sudo ./bins-extra.sh --package containerd
+
+    - name: Build package (runc)
+      id: package
+      run: |
+        cd bins
+        sudo ./bins-extra.sh --package runc
+
+    - name: Merging packages
+      id: package
+      run: |
+        cd bins
+        mkdir /tmp/root
+        sudo cp -av bins/releases/containerd/* /tmp/root/
+        sudo cp -av bins/releases/runc/* /tmp/root/
 
     - name: Publish flist (tf-autobuilder, ${{ steps.package.outputs.name }})
       if: success()
@@ -41,7 +55,7 @@ jobs:
         token: ${{ secrets.HUB_JWT }}
         action: publish
         user: tf-autobuilder
-        root: bins/releases/containerd
+        root: /tmp/root
         name: ${{ steps.package.outputs.name }}.flist
 
     - name: Crosslink flist (tf-zos-bins.dev)

--- a/.github/workflows/bins-extra-development.yaml
+++ b/.github/workflows/bins-extra-development.yaml
@@ -29,13 +29,13 @@ jobs:
         sudo ./bins-extra.sh --package basesystem
 
     - name: Build package (containerd)
-      id: package-1
+      id: package
       run: |
         cd bins
         sudo ./bins-extra.sh --package containerd
 
     - name: Build package (runc)
-      id: package-2
+      id: sub-package
       run: |
         cd bins
         sudo ./bins-extra.sh --package runc
@@ -43,9 +43,9 @@ jobs:
     - name: Merging packages
       id: packages
       run: |
-        mkdir /tmp/root
-        sudo cp -av bins/releases/containerd/* /tmp/root/
-        sudo cp -av bins/releases/runc/* /tmp/root/
+        mkdir bins/releases/rootfs
+        sudo cp -av bins/releases/containerd/* bins/releases/rootfs/
+        sudo cp -av bins/releases/runc/* bins/releases/rootfs/
 
     - name: Publish flist (tf-autobuilder, ${{ steps.package.outputs.name }})
       if: success()
@@ -54,7 +54,7 @@ jobs:
         token: ${{ secrets.HUB_JWT }}
         action: publish
         user: tf-autobuilder
-        root: /tmp/root
+        root: bins/releases/rootfs
         name: ${{ steps.package.outputs.name }}.flist
 
     - name: Crosslink flist (tf-zos-bins.dev)

--- a/.github/workflows/bins-extra-pre-release.yaml
+++ b/.github/workflows/bins-extra-pre-release.yaml
@@ -39,6 +39,19 @@ jobs:
         cd bins
         sudo ./bins-extra.sh --package containerd
 
+    - name: Build package (runc)
+      id: sub-package
+      run: |
+        cd bins
+        sudo ./bins-extra.sh --package runc
+
+    - name: Merging packages
+      id: packages
+      run: |
+        mkdir bins/releases/rootfs
+        sudo cp -av bins/releases/containerd/* bins/releases/rootfs/
+        sudo cp -av bins/releases/runc/* bins/releases/rootfs/
+
     - name: Publish flist (tf-autobuilder, ${{ steps.package.outputs.name }})
       if: success()
       uses: threefoldtech/publish-flist@master
@@ -46,7 +59,7 @@ jobs:
         token: ${{ secrets.HUB_JWT }}
         action: publish
         user: tf-autobuilder
-        root: bins/releases/containerd
+        root: bins/releases/rootfs
         name: ${{ steps.package.outputs.name }}.flist
 
     - name: Crosslink flist (tf-zos-bins.test)

--- a/.github/workflows/bins-extra-pre-release.yaml
+++ b/.github/workflows/bins-extra-pre-release.yaml
@@ -33,7 +33,7 @@ jobs:
         cd bins
         sudo ./bins-extra.sh --package basesystem
 
-    - name: Build package
+    - name: Build package (containerd)
       id: package
       run: |
         cd bins

--- a/.github/workflows/bins-extra-release.yaml
+++ b/.github/workflows/bins-extra-release.yaml
@@ -40,6 +40,19 @@ jobs:
         cd bins
         sudo ./bins-extra.sh --package containerd
 
+    - name: Build package (runc)
+      id: sub-package
+      run: |
+        cd bins
+        sudo ./bins-extra.sh --package runc
+
+    - name: Merging packages
+      id: packages
+      run: |
+        mkdir bins/releases/rootfs
+        sudo cp -av bins/releases/containerd/* bins/releases/rootfs/
+        sudo cp -av bins/releases/runc/* bins/releases/rootfs/
+
     - name: Publish flist (tf-autobuilder, ${{ steps.package.outputs.name }})
       if: success()
       uses: threefoldtech/publish-flist@master
@@ -47,7 +60,7 @@ jobs:
         token: ${{ secrets.HUB_JWT }}
         action: publish
         user: tf-autobuilder
-        root: bins/releases/containerd
+        root: bins/releases/rootfs
         name: ${{ steps.package.outputs.name }}.flist
 
     - name: crosslink flist (tf-zos-bins)

--- a/.github/workflows/bins-extra-release.yaml
+++ b/.github/workflows/bins-extra-release.yaml
@@ -34,7 +34,7 @@ jobs:
         cd bins
         sudo ./bins-extra.sh --package basesystem
 
-    - name: Build package
+    - name: Build package (containerd)
       id: package
       run: |
         cd bins

--- a/bins/packages/runc/runc.sh
+++ b/bins/packages/runc/runc.sh
@@ -1,0 +1,73 @@
+RUNC_VERSION="1.0.0-rc9"
+RUNC_CHECKSUM="e88bcb1a33e7ff0bfea495f7263826c2"
+RUNC_LINK="https://github.com/opencontainers/runc/archive/v${RUNC_VERSION}.tar.gz"
+
+dependencies_runc() {
+    apt-get install -y btrfs-tools libseccomp-dev build-essential pkg-config
+
+    if [ -z $GOPATH ]; then
+        if command -v go > /dev/null; then
+            export GOPATH=$(go env GOPATH)
+        else
+            curl -L https://dl.google.com/go/go1.13.1.linux-amd64.tar.gz > /tmp/go1.13.1.linux-amd64.tar.gz
+            tar -C /usr/local -xzf /tmp/go1.13.1.linux-amd64.tar.gz
+            mkdir -p /gopath
+
+            export PATH=$PATH:/usr/local/go/bin
+            export GOPATH=/gopath
+        fi
+    fi
+
+    RUNC_HOME="${GOPATH}/src/github.com/opencontainers"
+}
+
+download_runc() {
+    download_file ${RUNC_LINK} ${RUNC_CHECKSUM} runc-${RUNC_VERSION}.tar.gz
+}
+
+extract_runc() {
+    mkdir -p ${RUNC_HOME}
+    rm -rf ${RUNC_HOME}/runc
+
+    pushd ${RUNC_HOME}
+
+    echo "[+] extracting: runc-${RUNC_VERSION}"
+    tar -xf ${DISTDIR}/runc-${RUNC_VERSION}.tar.gz -C .
+    mv runc-${RUNC_VERSION} runc
+
+    popd
+}
+
+prepare_runc() {
+    echo "[+] prepare runc"
+    github_name "runc-${RUNC_VERSION}"
+}
+
+compile_runc() {
+    echo "[+] compiling runc"
+    make BUILDTAGS='seccomp'
+}
+
+install_runc() {
+    echo "[+] install runc"
+    mkdir -p "${ROOTDIR}/usr/bin"
+    cp -av runc "${ROOTDIR}/usr/bin/"
+}
+
+build_runc() {
+    pushd "${DISTDIR}"
+
+    dependencies_runc
+    download_runc
+    extract_runc
+
+    popd
+    pushd ${RUNC_HOME}/runc
+
+    prepare_runc
+    compile_runc
+    install_runc
+
+    popd
+}
+

--- a/bins/packages/runc/runc.sh
+++ b/bins/packages/runc/runc.sh
@@ -70,4 +70,3 @@ build_runc() {
 
     popd
 }
-

--- a/bins/packages/runc/runc.sh
+++ b/bins/packages/runc/runc.sh
@@ -50,6 +50,7 @@ compile_runc() {
 
 install_runc() {
     echo "[+] install runc"
+
     mkdir -p "${ROOTDIR}/usr/bin"
     cp -av runc "${ROOTDIR}/usr/bin/"
 }

--- a/bins/packages/runc/runc.sh
+++ b/bins/packages/runc/runc.sh
@@ -50,7 +50,6 @@ compile_runc() {
 
 install_runc() {
     echo "[+] install runc"
-
     mkdir -p "${ROOTDIR}/usr/bin"
     cp -av runc "${ROOTDIR}/usr/bin/"
 }

--- a/bins/packages/runc/runc.sh
+++ b/bins/packages/runc/runc.sh
@@ -70,3 +70,4 @@ build_runc() {
 
     popd
 }
+


### PR DESCRIPTION
Latest `initramfs` (autobuild branch) doesn't include `runc` anymore, since it's a runtime dependency linked to `containerd`. It was a mistake to keep it there and this is fixed now.

This lead to missing `runc` binary on new image and thus crash container deployment. This fix the `containerd.flist` with `runc` included.

This was tested on local VM on devnet and works out of box without local overlay :)