### PR TITLE
networkd: monitor default route on ndm npub4 interface

### DIFF
--- a/cmds/networkd/main.go
+++ b/cmds/networkd/main.go
@@ -104,7 +104,7 @@ func main() {
 		log.Fatal().Err(err).Msg("failed to create ndmz")
 	}
 
-	if err := ndmz.Create(); err != nil {
+	if err := ndmz.Create(ctx); err != nil {
 		log.Fatal().Err(err).Msg("failed to create ndmz")
 	}
 

--- a/pkg/network/dhcp/dhcp.go
+++ b/pkg/network/dhcp/dhcp.go
@@ -3,11 +3,8 @@ package dhcp
 import (
 	"fmt"
 	"os/exec"
-	"strings"
 
-	"github.com/pkg/errors"
 	"github.com/rs/zerolog/log"
-	"github.com/threefoldtech/zos/pkg/zinit"
 )
 
 // Probe is used to do some DHCP request on a interface
@@ -15,28 +12,9 @@ type Probe struct {
 	cmd *exec.Cmd
 }
 
-// BackgroundProbe is used to do some DHCP request on a interface controlled by zinit
-type BackgroundProbe struct {
-	z   *zinit.Client
-	inf string
-}
-
 // NewProbe returns a Probe
 func NewProbe() *Probe {
 	return &Probe{}
-}
-
-// NewBackgroundProbe return a new background Probe that can be controlled with zinit
-func NewBackgroundProbe(inf string) (*BackgroundProbe, error) {
-	z, err := zinit.New("")
-	if err != nil {
-		log.Error().Err(err).Msg("failed to connect to zinit")
-		return nil, err
-	}
-	return &BackgroundProbe{
-		z:   z,
-		inf: inf,
-	}, nil
 }
 
 // Start starts the DHCP client process
@@ -58,65 +36,6 @@ func (d *Probe) Start(inf string) error {
 	}
 
 	return nil
-}
-
-// Start runs the DHCP client process and registers it to zinit
-func (d *BackgroundProbe) Start() error {
-	serviceName := fmt.Sprintf("dhcp-%s", d.inf)
-
-	ns, err := exec.Command("ip", "netns", "identify").Output()
-	if err != nil {
-		return errors.Wrap(err, "failed to identify namespace")
-	}
-
-	exec := fmt.Sprintf("/sbin/udhcpc -v -f -i %s -t 20 -T 1 -s /usr/share/udhcp/simple.script", d.inf)
-
-	cleanedNs := strings.TrimSpace(string(ns))
-	if cleanedNs != "" {
-		exec = fmt.Sprintf("ip netns exec %s %s", cleanedNs, exec)
-	}
-
-	err = zinit.AddService(serviceName, zinit.InitService{
-		Exec:    exec,
-		Oneshot: false,
-		After:   []string{},
-	})
-
-	if err != nil {
-		log.Error().Err(err).Msg("fail to create dhcp-zos zinit service")
-		return err
-	}
-
-	if err := d.z.Monitor(serviceName); err != nil {
-		log.Error().Err(err).Msg("fail to start monitoring dhcp-zos zinit service")
-		return err
-	}
-
-	return nil
-}
-
-// IsRunning checks if a background process is running in zinit
-func (d *BackgroundProbe) IsRunning() (bool, error) {
-	serviceName := fmt.Sprintf("dhcp-%s", d.inf)
-
-	status, err := d.z.Status(serviceName)
-	if err == zinit.ErrUnknownService {
-		return false, nil
-	} else if err != nil {
-		return false, err
-	}
-
-	return !status.State.Exited(), nil
-}
-
-// Stop stops a zinit background process
-func (d *BackgroundProbe) Stop() error {
-	serviceName := fmt.Sprintf("dhcp-%s", d.inf)
-	err := d.z.Stop(serviceName)
-	if err != nil {
-		return errors.Wrap(err, "failed to stop background probe zinit service")
-	}
-	return d.z.Forget(serviceName)
 }
 
 // Stop kills the DHCP client process

--- a/pkg/network/ndmz/dhcp_monitor.go
+++ b/pkg/network/ndmz/dhcp_monitor.go
@@ -1,0 +1,158 @@
+package ndmz
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/containernetworking/plugins/pkg/ns"
+	"github.com/pkg/errors"
+	"github.com/rs/zerolog/log"
+	"github.com/threefoldtech/zos/pkg/network/ifaceutil"
+	"github.com/threefoldtech/zos/pkg/network/namespace"
+	"github.com/threefoldtech/zos/pkg/zinit"
+	"github.com/vishvananda/netlink"
+)
+
+// DHCPMon monitor a network interface status and force
+// renew of DHCP lease if needed
+type DHCPMon struct {
+	z         *zinit.Client
+	service   string
+	iface     string
+	namespace string
+}
+
+// NewDHCPMon create a new DHCPMon object managing interface iface
+// namespace is then network namespace name to use. it can be empty.
+func NewDHCPMon(iface, namespace string, z *zinit.Client) *DHCPMon {
+	return &DHCPMon{
+		z:         z,
+		service:   fmt.Sprintf("dhcp-%s", iface),
+		iface:     iface,
+		namespace: namespace,
+	}
+}
+
+// Start creates a zinit service for a DHCP client and start monitoring it
+// this method is blocking, start is in a goroutine if needed.
+// cancel the context to start it.
+func (d *DHCPMon) Start(ctx context.Context) error {
+
+	if err := d.startZinit(); err != nil {
+		return err
+	}
+	defer func() {
+		if err := d.stopZinit(); err != nil {
+			log.Error().Err(err).Msgf("error stopping zinit service %s", d.service)
+		}
+	}()
+
+	t := time.NewTicker(time.Minute)
+	defer t.Stop()
+
+	for {
+		select {
+		case <-ctx.Done():
+			return nil
+
+		case <-t.C:
+			log.Info().Msg("check if ndmz default route is still in place")
+			has, err := hasDefaultRoute(d.iface, d.namespace)
+			if err != nil {
+				log.Error().Str("iface", d.iface).Err(err).Msg("error checking default gateway")
+				continue
+			}
+
+			if !has {
+				log.Info().Msg("ndmz default route missing, waking up udhcpc")
+				if err := d.wakeUp(); err != nil {
+					log.Error().Err(err).Msg("error while sending signal to service ")
+				}
+			}
+		}
+	}
+}
+
+// wakeUp sends a signal to the udhcpc daemon to force a release of the DHCP lease
+func (d *DHCPMon) wakeUp() error {
+	err := d.z.Kill(d.service, zinit.SIGUSR1)
+	if err != nil {
+		log.Error().Err(err).Msg("error while sending signal to service ")
+	}
+	return err
+}
+
+// hasDefaultRoute checks if the network interface iface has a default route configured
+// if netNS is not empty, switch to the network namespace named netNS before checking the routes
+func hasDefaultRoute(iface, netNS string) (bool, error) {
+	var hasDefault bool
+	do := func(_ ns.NetNS) error {
+		link, err := netlink.LinkByName(iface)
+		if err != nil {
+			return err
+		}
+		hasDefault, _, err = ifaceutil.HasDefaultGW(link, netlink.FAMILY_V4)
+		return err
+	}
+
+	var oerr error
+	if netNS != "" {
+		n, err := namespace.GetByName(netNS)
+		if err != nil {
+			return false, err
+		}
+		oerr = n.Do(do)
+	} else {
+		oerr = do(nil)
+	}
+	return hasDefault, oerr
+}
+
+func (d *DHCPMon) startZinit() error {
+	status, err := d.z.Status(d.service)
+	if err != nil && err != zinit.ErrUnknownService {
+		log.Error().Err(err).Msgf("error checking zinit service %s status", d.service)
+		return err
+	}
+
+	if status.State.Exited() {
+		log.Info().Msgf("zinit service %s already exists but is stopped, starting it", d.service)
+		return d.z.Start(d.service)
+	}
+
+	log.Info().Msgf("create and start %s zinit service", d.service)
+	exec := fmt.Sprintf("/sbin/udhcpc -v -f -i %s -t 20 -T 1 -s /usr/share/udhcp/simple.script", d.iface)
+
+	if d.namespace != "" {
+		exec = fmt.Sprintf("ip netns exec %s %s", strings.TrimSpace(d.namespace), exec)
+	}
+
+	err = zinit.AddService(d.service, zinit.InitService{
+		Exec:    exec,
+		Oneshot: false,
+		After:   []string{},
+	})
+
+	if err != nil {
+		log.Error().Err(err).Msg("fail to create dhcp-zos zinit service")
+		return err
+	}
+
+	if err := d.z.Monitor(d.service); err != nil {
+		log.Error().Err(err).Msg("fail to start monitoring dhcp-zos zinit service")
+		return err
+	}
+
+	return err
+}
+
+// Stop stops a zinit background process
+func (d *DHCPMon) stopZinit() error {
+	err := d.z.StopWait(time.Second*10, d.service)
+	if err != nil {
+		return errors.Wrapf(err, "failed to stop zinit service %s", d.service)
+	}
+	return d.z.Forget(d.service)
+}

--- a/pkg/network/ndmz/ndmz.go
+++ b/pkg/network/ndmz/ndmz.go
@@ -2,6 +2,7 @@ package ndmz
 
 import (
 	"bytes"
+	"context"
 	"fmt"
 	"net"
 	"os"
@@ -45,7 +46,7 @@ const (
 // DMZ is an interface used to create an DMZ network namespace
 type DMZ interface {
 	// create the ndmz network namespace and all requires network interfaces
-	Create() error
+	Create(ctx context.Context) error
 	// delete the ndmz network namespace and clean up all network interfaces
 	Delete() error
 	// link a network resource from a user network to ndmz

--- a/pkg/network/ndmz/ndmz.go
+++ b/pkg/network/ndmz/ndmz.go
@@ -230,9 +230,12 @@ func configureYggdrasil(subnetIP net.IPNet) error {
 		if err != nil {
 			return err
 		}
-		return netlink.AddrAdd(link, &netlink.Addr{
+		if err := netlink.AddrAdd(link, &netlink.Addr{
 			IPNet: &subnetIP,
-		})
+		}); err != nil && !os.IsExist(err) {
+			return err
+		}
+		return nil
 	})
 	return err
 }

--- a/pkg/network/ndmz/ndmz.go
+++ b/pkg/network/ndmz/ndmz.go
@@ -97,15 +97,7 @@ func createPubIface6(name, master, nodeID string, netNS ns.NetNS) error {
 			Str("interface", name).
 			Msg("set mac on ipv6 ndmz public iface")
 
-		if err := ifaceutil.SetMAC(name, mac, nil); err != nil {
-			return err
-		}
-
-		link, err := netlink.LinkByName(name)
-		if err != nil {
-			return err
-		}
-		return netlink.LinkSetUp(link)
+		return ifaceutil.SetMAC(name, mac, nil)
 	})
 }
 


### PR DESCRIPTION
It seems udhcp is not the most reliable so we monitor the default route
of the npub4 interface manually and give a push to udhcp when needed to
force the renew of the DHCP lease

fixes #927
fixes https://github.com/threefoldtech/js-sdk/issues/1239
fixes https://github.com/threefoldtech/tfgateway/issues/27