### PR TITLE
Rename StatsAggregator field to Stats on Container

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -60,7 +60,7 @@ require (
 	github.com/stretchr/testify v1.6.1
 	github.com/syndtr/gocapability v0.0.0-20200815063812-42c35b437635 // indirect
 	github.com/termie/go-shutil v0.0.0-20140729215957-bcacb06fecae
-	github.com/threefoldtech/tfexplorer v0.4.1-0.20200924232024-7ce1840cdaa6
+	github.com/threefoldtech/tfexplorer v0.4.1-0.20200925140208-64f1857969f1
 	github.com/threefoldtech/zbus v0.1.3
 	github.com/urfave/cli v1.22.4
 	github.com/vishvananda/netlink v1.1.0

--- a/go.mod
+++ b/go.mod
@@ -60,7 +60,7 @@ require (
 	github.com/stretchr/testify v1.6.1
 	github.com/syndtr/gocapability v0.0.0-20200815063812-42c35b437635 // indirect
 	github.com/termie/go-shutil v0.0.0-20140729215957-bcacb06fecae
-	github.com/threefoldtech/tfexplorer v0.4.1-0.20200923122946-a429c33ade21
+	github.com/threefoldtech/tfexplorer v0.4.1-0.20200924232024-7ce1840cdaa6
 	github.com/threefoldtech/zbus v0.1.3
 	github.com/urfave/cli v1.22.4
 	github.com/vishvananda/netlink v1.1.0

--- a/go.sum
+++ b/go.sum
@@ -592,6 +592,8 @@ github.com/threefoldtech/tfexplorer v0.4.1-0.20200923122946-a429c33ade21 h1:p3Hp
 github.com/threefoldtech/tfexplorer v0.4.1-0.20200923122946-a429c33ade21/go.mod h1:wxnWTecsczkzkiJoZB19tt49l8CWkTNLD2VkKBK6mSc=
 github.com/threefoldtech/tfexplorer v0.4.1-0.20200924232024-7ce1840cdaa6 h1:RGOwrJjhM4QFVpejELSs4fe+OM5UNtbkvZNRpNeA3QQ=
 github.com/threefoldtech/tfexplorer v0.4.1-0.20200924232024-7ce1840cdaa6/go.mod h1:wxnWTecsczkzkiJoZB19tt49l8CWkTNLD2VkKBK6mSc=
+github.com/threefoldtech/tfexplorer v0.4.1-0.20200925140208-64f1857969f1 h1:PYrmO+AmHUBpHvjEAqNtRY4HCztwMeVVQK7pUPmwBcg=
+github.com/threefoldtech/tfexplorer v0.4.1-0.20200925140208-64f1857969f1/go.mod h1:0261YnFlaQNDv1hNzdJc/2DuYq9B9qe9D6QnZuZOCh0=
 github.com/threefoldtech/zbus v0.1.3 h1:18DnIzximRbATle5ZdZz0i84n/bCYB8k/gkhr2dXayc=
 github.com/threefoldtech/zbus v0.1.3/go.mod h1:ZtiRpcqzEBJetVQDsEbw0p48h/AF3O1kf0tvd30I0BU=
 github.com/threefoldtech/zos v0.2.4-rc2/go.mod h1:7A2oflcmSVsHFC4slOcydWgJyFBMFMH9wsaTRv+CnTA=

--- a/go.sum
+++ b/go.sum
@@ -590,6 +590,8 @@ github.com/threefoldtech/tfexplorer v0.3.2-0.20200918135528-58e333897454 h1:MUtG
 github.com/threefoldtech/tfexplorer v0.3.2-0.20200918135528-58e333897454/go.mod h1:fA2oR3D6Wre9tXSiWFiapeuUI5UA9aXP9fejr6hDEYM=
 github.com/threefoldtech/tfexplorer v0.4.1-0.20200923122946-a429c33ade21 h1:p3Hpq3bmBNKDaMCA7gn8ltMk84ZAU9OurMUF1K93Kqk=
 github.com/threefoldtech/tfexplorer v0.4.1-0.20200923122946-a429c33ade21/go.mod h1:wxnWTecsczkzkiJoZB19tt49l8CWkTNLD2VkKBK6mSc=
+github.com/threefoldtech/tfexplorer v0.4.1-0.20200924232024-7ce1840cdaa6 h1:RGOwrJjhM4QFVpejELSs4fe+OM5UNtbkvZNRpNeA3QQ=
+github.com/threefoldtech/tfexplorer v0.4.1-0.20200924232024-7ce1840cdaa6/go.mod h1:wxnWTecsczkzkiJoZB19tt49l8CWkTNLD2VkKBK6mSc=
 github.com/threefoldtech/zbus v0.1.3 h1:18DnIzximRbATle5ZdZz0i84n/bCYB8k/gkhr2dXayc=
 github.com/threefoldtech/zbus v0.1.3/go.mod h1:ZtiRpcqzEBJetVQDsEbw0p48h/AF3O1kf0tvd30I0BU=
 github.com/threefoldtech/zos v0.2.4-rc2/go.mod h1:7A2oflcmSVsHFC4slOcydWgJyFBMFMH9wsaTRv+CnTA=

--- a/pkg/container.go
+++ b/pkg/container.go
@@ -53,8 +53,8 @@ type Container struct {
 	Memory uint64
 	// Logs backends
 	Logs []logger.Logs
-	// StatsAggregator container metrics backend
-	StatsAggregator []stats.Aggregator
+	// Stats container metrics backend
+	Stats []stats.Stats
 }
 
 // ContainerModule defines rpc interface to containerd

--- a/pkg/container/container.go
+++ b/pkg/container/container.go
@@ -210,7 +210,7 @@ func (c *containerModule) Run(ns string, data pkg.Container) (id pkg.ContainerID
 	}
 
 	// set user defined endpoint stats
-	for _, l := range data.StatsAggregator {
+	for _, l := range data.Stats {
 		switch l.Type {
 		case stats.RedisType:
 			s, err := stats.NewRedis(l.Data.Endpoint)

--- a/pkg/container/stats/stats.go
+++ b/pkg/container/stats/stats.go
@@ -27,7 +27,7 @@ type Metrics struct {
 	PidsCurrent uint64 `json:"pids_current"`
 }
 
-// Aggregator defines a stats backend
+// Stats defines a stats backend
 type Stats struct {
 	Type string `bson:"type" json:"type"`
 	Data Redis  `bson:"data" json:"data"`

--- a/pkg/container/stats/stats.go
+++ b/pkg/container/stats/stats.go
@@ -28,7 +28,7 @@ type Metrics struct {
 }
 
 // Aggregator defines a stats backend
-type Aggregator struct {
+type Stats struct {
 	Type string `bson:"type" json:"type"`
 	Data Redis  `bson:"data" json:"data"`
 }

--- a/pkg/provision/primitives/container.go
+++ b/pkg/provision/primitives/container.go
@@ -80,8 +80,8 @@ type Container struct {
 	Capacity ContainerCapacity `json:"capacity"`
 	// Logs contains a list of endpoint where to send containerlogs
 	Logs []Logs `json:"logs,omitempty"`
-	// StatsAggregator container metrics backend
-	StatsAggregator []stats.Aggregator
+	// Stats container metrics backend
+	Stats []stats.Stats `json:"stats,omitempty"`
 }
 
 // ContainerResult is the information return to the BCDB
@@ -295,13 +295,13 @@ func (p *Provisioner) containerProvisionImpl(ctx context.Context, reservation *p
 			Network: pkg.NetworkInfo{
 				Namespace: join.Namespace,
 			},
-			Mounts:          mounts,
-			Entrypoint:      config.Entrypoint,
-			Interactive:     config.Interactive,
-			CPU:             config.Capacity.CPU,
-			Memory:          config.Capacity.Memory * mib,
-			Logs:            logs,
-			StatsAggregator: config.StatsAggregator,
+			Mounts:      mounts,
+			Entrypoint:  config.Entrypoint,
+			Interactive: config.Interactive,
+			CPU:         config.Capacity.CPU,
+			Memory:      config.Capacity.Memory * mib,
+			Logs:        logs,
+			Stats:       config.Stats,
 		},
 	)
 	if err != nil {

--- a/pkg/provision/primitives/converter.go
+++ b/pkg/provision/primitives/converter.go
@@ -39,15 +39,15 @@ func ContainerToProvisionType(w workloads.Workloader, reservationID string) (Con
 	}
 
 	container := Container{
-		FList:           c.Flist,
-		FlistStorage:    c.HubUrl,
-		Env:             c.Environment,
-		SecretEnv:       c.SecretEnvironment,
-		Entrypoint:      c.Entrypoint,
-		Interactive:     c.Interactive,
-		Mounts:          make([]Mount, len(c.Volumes)),
-		Logs:            make([]Logs, len(c.Logs)),
-		StatsAggregator: make([]stats.Aggregator, len(c.StatsAggregator)),
+		FList:        c.Flist,
+		FlistStorage: c.HubUrl,
+		Env:          c.Environment,
+		SecretEnv:    c.SecretEnvironment,
+		Entrypoint:   c.Entrypoint,
+		Interactive:  c.Interactive,
+		Mounts:       make([]Mount, len(c.Volumes)),
+		Logs:         make([]Logs, len(c.Logs)),
+		Stats:        make([]stats.Stats, len(c.Stats)),
 		Capacity: ContainerCapacity{
 			CPU:      uint(c.Capacity.Cpu),
 			Memory:   uint64(c.Capacity.Memory),
@@ -94,10 +94,10 @@ func ContainerToProvisionType(w workloads.Workloader, reservationID string) (Con
 		}
 	}
 
-	for i, s := range c.StatsAggregator {
+	for i, s := range c.Stats {
 		// Only support redis for now
 		if s.Type != stats.RedisType {
-			container.StatsAggregator[i] = stats.Aggregator{
+			container.Stats[i] = stats.Stats{
 				Type: "unknown",
 				Data: stats.Redis{
 					Endpoint: "",
@@ -105,7 +105,7 @@ func ContainerToProvisionType(w workloads.Workloader, reservationID string) (Con
 			}
 		}
 
-		container.StatsAggregator[i] = stats.Aggregator{
+		container.Stats[i] = stats.Stats{
 			Type: s.Type,
 			Data: stats.Redis{
 				Endpoint: s.Data.Endpoint,

--- a/pkg/provision/primitives/converter.go
+++ b/pkg/provision/primitives/converter.go
@@ -109,7 +109,7 @@ func ContainerToProvisionType(w workloads.Workloader, reservationID string) (Con
 		}
 
 		data := stats.Redis{}
-		err := json.Unmarshal(s.Data, data)
+		err := json.Unmarshal(s.Data, &data)
 		if err != nil {
 			container.Stats[i] = unknstats
 			continue

--- a/pkg/provision/primitives/converter.go
+++ b/pkg/provision/primitives/converter.go
@@ -94,21 +94,31 @@ func ContainerToProvisionType(w workloads.Workloader, reservationID string) (Con
 		}
 	}
 
+	unknstats := stats.Stats{
+		Type: "unknown",
+		Data: stats.Redis{
+			Endpoint: "",
+		},
+	}
+
 	for i, s := range c.Stats {
 		// Only support redis for now
 		if s.Type != stats.RedisType {
-			container.Stats[i] = stats.Stats{
-				Type: "unknown",
-				Data: stats.Redis{
-					Endpoint: "",
-				},
-			}
+			container.Stats[i] = unknstats
+			continue
+		}
+
+		data := stats.Redis{}
+		err := json.Unmarshal(s.Data, data)
+		if err != nil {
+			container.Stats[i] = unknstats
+			continue
 		}
 
 		container.Stats[i] = stats.Stats{
 			Type: s.Type,
 			Data: stats.Redis{
-				Endpoint: s.Data.Endpoint,
+				Endpoint: data.Endpoint,
 			},
 		}
 	}

--- a/pkg/provision/primitives/converter_test.go
+++ b/pkg/provision/primitives/converter_test.go
@@ -42,7 +42,7 @@ func TestTfgridReservationContainer1_ToProvisionType(t *testing.T) {
 		Interactive       bool
 		Volumes           []workloads.ContainerMount
 		NetworkConnection []workloads.NetworkConnection
-		StatsAggregator   []workloads.StatsAggregator
+		Stats             []workloads.Stats
 		Capacity          workloads.ContainerCapacity
 	}
 	tests := []struct {
@@ -63,7 +63,7 @@ func TestTfgridReservationContainer1_ToProvisionType(t *testing.T) {
 				Interactive:       false,
 				Volumes:           nil,
 				NetworkConnection: nil,
-				StatsAggregator:   nil,
+				Stats:             nil,
 				Capacity: workloads.ContainerCapacity{
 					Cpu:      2,
 					Memory:   1024,
@@ -72,16 +72,16 @@ func TestTfgridReservationContainer1_ToProvisionType(t *testing.T) {
 				},
 			},
 			want: Container{
-				FList:           "https://hub.grid.tf/tf-official-apps/ubuntu-bionic-build.flist",
-				FlistStorage:    "zdb://hub.grid.tf:9900",
-				Env:             map[string]string{"FOO": "BAR"},
-				SecretEnv:       nil,
-				Entrypoint:      "/sbin/my_init",
-				Interactive:     false,
-				Mounts:          []Mount{},
-				Network:         Network{},
-				Logs:            []Logs{},
-				StatsAggregator: []stats.Aggregator{},
+				FList:        "https://hub.grid.tf/tf-official-apps/ubuntu-bionic-build.flist",
+				FlistStorage: "zdb://hub.grid.tf:9900",
+				Env:          map[string]string{"FOO": "BAR"},
+				SecretEnv:    nil,
+				Entrypoint:   "/sbin/my_init",
+				Interactive:  false,
+				Mounts:       []Mount{},
+				Network:      Network{},
+				Logs:         []Logs{},
+				Stats:        []stats.Stats{},
 				Capacity: ContainerCapacity{
 					CPU:      2,
 					Memory:   1024,
@@ -145,8 +145,8 @@ func TestTfgridReservationContainer1_ToProvisionType(t *testing.T) {
 					NetworkID: "net1",
 					IPs:       []net.IP{net.ParseIP("10.0.0.1")},
 				},
-				Logs:            []Logs{},
-				StatsAggregator: []stats.Aggregator{},
+				Logs:  []Logs{},
+				Stats: []stats.Stats{},
 				Capacity: ContainerCapacity{
 					CPU:      2,
 					Memory:   1024,
@@ -172,7 +172,7 @@ func TestTfgridReservationContainer1_ToProvisionType(t *testing.T) {
 				Interactive:       tt.fields.Interactive,
 				Volumes:           tt.fields.Volumes,
 				NetworkConnection: tt.fields.NetworkConnection,
-				StatsAggregator:   tt.fields.StatsAggregator,
+				Stats:             tt.fields.Stats,
 				Capacity:          tt.fields.Capacity,
 			}
 			got, _, err := ContainerToProvisionType(&c, "reservation")
@@ -188,12 +188,12 @@ func TestTfgridReservationContainer1_ToProvisionType(t *testing.T) {
 
 func TestTfgridReservationVolume1_ToProvisionType(t *testing.T) {
 	type fields struct {
-		WorkloadID      int64
-		NodeID          string
-		ReservationID   int64
-		Size            int64
-		Type            workloads.VolumeTypeEnum
-		StatsAggregator []workloads.StatsAggregator
+		WorkloadID    int64
+		NodeID        string
+		ReservationID int64
+		Size          int64
+		Type          workloads.VolumeTypeEnum
+		Stats         []workloads.Stats
 	}
 	tests := []struct {
 		name    string
@@ -204,11 +204,11 @@ func TestTfgridReservationVolume1_ToProvisionType(t *testing.T) {
 		{
 			name: "HDD",
 			fields: fields{
-				WorkloadID:      1,
-				NodeID:          "node1",
-				Size:            10,
-				Type:            workloads.VolumeTypeHDD,
-				StatsAggregator: nil,
+				WorkloadID: 1,
+				NodeID:     "node1",
+				Size:       10,
+				Type:       workloads.VolumeTypeHDD,
+				Stats:      nil,
 			},
 			want: Volume{
 				Size: 10,
@@ -218,11 +218,11 @@ func TestTfgridReservationVolume1_ToProvisionType(t *testing.T) {
 		{
 			name: "SSD",
 			fields: fields{
-				WorkloadID:      1,
-				NodeID:          "node1",
-				Size:            10,
-				Type:            workloads.VolumeTypeSSD,
-				StatsAggregator: nil,
+				WorkloadID: 1,
+				NodeID:     "node1",
+				Size:       10,
+				Type:       workloads.VolumeTypeSSD,
+				Stats:      nil,
 			},
 			want: Volume{
 				Size: 10,


### PR DESCRIPTION
This update is related to https://github.com/threefoldtech/tfexplorer/pull/174

This update internal usage of `StatsAggregator` for container.
A dummy `StatsAggregator` struct still exists for the other types which needs it (but don't use it really).
A new `Stats` for containers is added next to that and is dedicated to `Container`

This prevent a misunderstanding (`StatsAggregator` field not using `StatsAggregator` type)

This update also points to a `tfexplorer` version already supporting the new schema.