### PR TITLE
rate limit the logs reservation poll logs

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -74,6 +74,7 @@ require (
 	golang.org/x/crypto v0.0.0-20200311171314-f7b00557c8c4
 	golang.org/x/net v0.0.0-20200301022130-244492dfa37a
 	golang.org/x/sys v0.0.0-20200302150141-5c8b2ff67527
+	golang.org/x/time v0.0.0-20200630173020-3af7569d3a1e
 	golang.zx2c4.com/wireguard/wgctrl v0.0.0-20191219145116-fa6499c8e75f
 	google.golang.org/appengine v1.6.5 // indirect
 	google.golang.org/grpc v1.29.1 // indirect

--- a/go.sum
+++ b/go.sum
@@ -773,6 +773,8 @@ golang.org/x/text v0.3.3-0.20191230102452-929e72ca90de h1:aYKJLPSrddB2N7/6OKyFqJ
 golang.org/x/text v0.3.3-0.20191230102452-929e72ca90de/go.mod h1:5Zoc/QRtKVWzQhOtBMvqHzDpF6irO9z98xDceosuGiQ=
 golang.org/x/text v0.3.3 h1:cokOdA+Jmi5PJGXLlLllQSgYigAEfHXJAERHVMaCc2k=
 golang.org/x/text v0.3.3/go.mod h1:5Zoc/QRtKVWzQhOtBMvqHzDpF6irO9z98xDceosuGiQ=
+golang.org/x/time v0.0.0-20200630173020-3af7569d3a1e h1:EHBhcS0mlXEAVwNyO2dLfjToGsyY4j24pTs2ScHnX7s=
+golang.org/x/time v0.0.0-20200630173020-3af7569d3a1e/go.mod h1:tRJNPiyCQ0inRvYxbN9jk5I+vvW/OXSQhTDSoE431IQ=
 golang.org/x/tools v0.0.0-20180221164845-07fd8470d635/go.mod h1:n7NCudcB/nEzxVGmLbDWY5pfWTLqBcC2KZ6jyYvM4mQ=
 golang.org/x/tools v0.0.0-20180828015842-6cd1fcedba52/go.mod h1:n7NCudcB/nEzxVGmLbDWY5pfWTLqBcC2KZ6jyYvM4mQ=
 golang.org/x/tools v0.0.0-20180917221912-90fa682c2a6e/go.mod h1:n7NCudcB/nEzxVGmLbDWY5pfWTLqBcC2KZ6jyYvM4mQ=

--- a/pkg/app/log.go
+++ b/pkg/app/log.go
@@ -67,3 +67,12 @@ func Initialize() {
 	})
 
 }
+
+// SampledLogger return a sampled logger that allow 1 log entry per hour
+// use this for logs used in loop when you do not want to overload the zint log ring buffer
+func SampledLogger() zerolog.Logger {
+	return log.Sample(&zerolog.BurstSampler{
+		Burst:  1,
+		Period: time.Hour,
+	})
+}

--- a/pkg/flist/cleanup.go
+++ b/pkg/flist/cleanup.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/pkg/errors"
 	"github.com/rs/zerolog/log"
+	"github.com/threefoldtech/zos/pkg/app"
 )
 
 // Cleaner interface, implementer of this interface
@@ -127,6 +128,8 @@ func (f *flistModule) cleanupAll() error {
 // Cleaner runs forever, checks the tracker files for filesystem processes
 // that requires cleanup
 func (f *flistModule) Cleaner(ctx context.Context, every time.Duration) {
+	log := app.SampledLogger()
+
 	for {
 		select {
 		case <-ctx.Done():

--- a/pkg/provision/primitives/cache/cache.go
+++ b/pkg/provision/primitives/cache/cache.go
@@ -73,7 +73,7 @@ func (s *Fs) removeAllButPersistent(rootPath string) error {
 		}
 		// if a file with size 0 is present we can assume its empty and remove it
 		if info.Size() == 0 {
-			log.Warn().Str("filename", info.Name()).Msg("cached reservation %d found, but file is empty, removing.")
+			log.Warn().Str("filename", info.Name()).Msg("cached reservation found, but file is empty, removing.")
 			return os.Remove(path)
 		}
 
@@ -171,7 +171,7 @@ func (s *Fs) GetExpired() ([]*provision.Reservation, error) {
 		// if the file is empty, remove it and return.
 		if info.Size() == 0 {
 			if info.Size() == 0 {
-				log.Warn().Str("filename", info.Name()).Msg("cached reservation %d found, but file is empty, removing.")
+				log.Warn().Str("filename", info.Name()).Msg("cached reservation found, but file is empty, removing.")
 				return nil, os.Remove(path.Join(s.root, info.Name()))
 			}
 		}


### PR DESCRIPTION
the goal is to avoid having provisiond logs spamming the circular buffer
of zinit and push away usefull logs.
We allow to pint these logs once every hour, just as an easy way to make
sure provisiond is not sutck.