### PR TITLE
Contd/decomission on crashes

### DIFF
--- a/cmds/contd/main.go
+++ b/cmds/contd/main.go
@@ -76,6 +76,9 @@ func main() {
 		log.Info().Msg("shutting down")
 	})
 
+	// start watching for events
+	go containerd.Watch(ctx)
+
 	if err := server.Run(ctx); err != nil && err != context.Canceled {
 		log.Fatal().Err(err).Msg("unexpected error")
 	}

--- a/cmds/contd/main.go
+++ b/cmds/contd/main.go
@@ -62,7 +62,12 @@ func main() {
 		log.Fatal().Msgf("fail to connect to message broker server: %v", err)
 	}
 
-	containerd := container.New(moduleRoot, containerdCon)
+	client, err := zbus.NewRedisClient(msgBrokerCon)
+	if err != nil {
+		log.Fatal().Msgf("fail to connect to message broker server: %v", err)
+	}
+
+	containerd := container.New(client, moduleRoot, containerdCon)
 
 	server.Register(zbus.ObjectID{Name: module, Version: "0.0.1"}, containerd)
 

--- a/cmds/provisiond/main.go
+++ b/cmds/provisiond/main.go
@@ -139,7 +139,7 @@ func main() {
 		ZbusCl:         zbusCl,
 	})
 
-	server.Register(zbus.ObjectID{Name: module, Version: "0.0.1"}, pkg.ProvisionMonitor(engine))
+	server.Register(zbus.ObjectID{Name: module, Version: "0.0.1"}, pkg.Provision(engine))
 
 	log.Info().
 		Str("broker", msgBrokerCon).

--- a/cmds/zui/prov.go
+++ b/cmds/zui/prov.go
@@ -34,7 +34,7 @@ func provisionRender(client zbus.Client, grid *ui.Grid, render *Flag) error {
 
 	ctx := context.Background()
 
-	monitor := stubs.NewProvisionMonitorStub(client)
+	monitor := stubs.NewProvisionStub(client)
 	counters, err := monitor.Counters(ctx)
 	if err != nil {
 		return errors.Wrap(err, "failed to start net monitor stream")

--- a/go.mod
+++ b/go.mod
@@ -53,6 +53,7 @@ require (
 	github.com/opencontainers/runc v0.1.1 // indirect
 	github.com/opencontainers/runtime-spec v1.0.1
 	github.com/opencontainers/selinux v1.5.2 // indirect
+	github.com/patrickmn/go-cache v2.1.0+incompatible
 	github.com/pkg/errors v0.9.1
 	github.com/robfig/cron/v3 v3.0.0
 	github.com/rs/zerolog v1.19.0

--- a/go.mod
+++ b/go.mod
@@ -9,6 +9,7 @@ require (
 	github.com/alexflint/go-filemutex v0.0.0-20171028004239-d358565f3c3f
 	github.com/asaskevich/govalidator v0.0.0-20200108200545-475eaeb16496 // indirect
 	github.com/blang/semver v3.5.1+incompatible
+	github.com/cenkalti/backoff v2.2.1+incompatible
 	github.com/cenkalti/backoff/v3 v3.2.2
 	github.com/containerd/cgroups v0.0.0-20200327175542-b44481373989
 	github.com/containerd/containerd v1.4.0-beta.1.0.20200615192441-ae2f3fdfd1a4
@@ -62,7 +63,7 @@ require (
 	github.com/stretchr/testify v1.6.1
 	github.com/syndtr/gocapability v0.0.0-20200815063812-42c35b437635 // indirect
 	github.com/termie/go-shutil v0.0.0-20140729215957-bcacb06fecae
-	github.com/threefoldtech/tfexplorer v0.4.1-0.20201008114938-260c3694ef48
+	github.com/threefoldtech/tfexplorer v0.4.1-0.20201014110255-653c7314b944
 	github.com/threefoldtech/zbus v0.1.3
 	github.com/urfave/cli v1.22.4
 	github.com/vishvananda/netlink v1.1.0

--- a/go.sum
+++ b/go.sum
@@ -57,6 +57,9 @@ github.com/beorn7/perks v1.0.1/go.mod h1:G2ZrVWU2WbWT9wwq4/hrbKbnv/1ERSJQ0ibhJ6r
 github.com/blang/semver v3.5.1+incompatible h1:cQNTCjp13qL8KC3Nbxr/y2Bqb63oX6wdnnjpJbkM4JQ=
 github.com/blang/semver v3.5.1+incompatible/go.mod h1:kRBLl5iJ+tD4TcOOxsy/0fnwebNt5EWlYSAyrTnjyyk=
 github.com/buger/jsonparser v0.0.0-20180808090653-f4dd9f5a6b44/go.mod h1:bbYlZJ7hK1yFx9hf58LP0zeX7UjIGs20ufpu3evjr+s=
+github.com/cenkalti/backoff v1.1.0 h1:QnvVp8ikKCDWOsFheytRCoYWYPO/ObCTBGxT19Hc+yE=
+github.com/cenkalti/backoff v2.2.1+incompatible h1:tNowT99t7UNflLxfYYSlKYsBpXdEet03Pg2g16Swow4=
+github.com/cenkalti/backoff v2.2.1+incompatible/go.mod h1:90ReRw6GdpyfrHakVjL/QHaoyV4aDUVVkXQJJJ3NXXM=
 github.com/cenkalti/backoff/v3 v3.0.0 h1:ske+9nBpD9qZsTBoF41nW5L+AIuFBKMeze18XQ3eG1c=
 github.com/cenkalti/backoff/v3 v3.0.0/go.mod h1:cIeZDE3IrqwwJl6VUwCN6trj1oXrTS4rc0ij+ULvLYs=
 github.com/cenkalti/backoff/v3 v3.2.2 h1:cfUAAO3yvKMYKPrvhDuHSwQnhZNk/RMHKdZqKTxfm6M=
@@ -123,6 +126,8 @@ github.com/deckarep/golang-set v1.7.1/go.mod h1:93vsz/8Wt4joVM7c2AVqh+YRMiUSc14y
 github.com/dgrijalva/jwt-go v3.2.0+incompatible h1:7qlOGliEKZXTDg6OTjfoBKDXWrumCAMpl/TFQ4/5kLM=
 github.com/dgrijalva/jwt-go v3.2.0+incompatible/go.mod h1:E3ru+11k8xSBh+hMPgOLZmtrrCbhqsmaPHjLKYnJCaQ=
 github.com/docker/distribution v2.7.1-0.20190205005809-0d3efadf0154+incompatible/go.mod h1:J2gT2udsDAN96Uj4KfcMRqY0/ypR+oyYUYmja8H+y+w=
+github.com/docker/docker v1.13.1/go.mod h1:eEKB0N0r5NX/I1kEveEz05bcu8tLC/8azJZsviup8Sk=
+github.com/docker/go-connections v0.4.0/go.mod h1:Gbd7IOopHjR8Iph03tsViu4nIes5XhDvyHbTtUxmeec=
 github.com/docker/go-events v0.0.0-20190806004212-e31b211e4f1c h1:+pKlWGMw7gf6bQ+oDZB4KHQFypsfjYlq/C4rfL7D3g8=
 github.com/docker/go-events v0.0.0-20190806004212-e31b211e4f1c/go.mod h1:Uw6UezgYA44ePAFQYUehOuCzmy5zmg/+nl2ZfMWGkpA=
 github.com/docker/go-units v0.3.3/go.mod h1:fgPhTUdO+D/Jk86RDLlptpiXQzgHJF7gydDDbaIK4Dk=
@@ -460,6 +465,8 @@ github.com/onsi/gomega v1.7.0 h1:XPnZz8VVBHjVsy1vzJmRwIcSwiUO+JFfrv/xGiigmME=
 github.com/onsi/gomega v1.7.0/go.mod h1:ex+gbHU/CVuBBDIJjb2X0qEXbFg53c61hWP/1CpauHY=
 github.com/opencontainers/go-digest v1.0.0-rc1 h1:WzifXhOVOEOuFYOJAW6aQqW0TooG2iki3E3Ii+WN7gQ=
 github.com/opencontainers/go-digest v1.0.0-rc1/go.mod h1:cMLVZDEM3+U2I4VmLI6N8jQYUd2OVphdqWwCJHrFt2s=
+github.com/opencontainers/go-digest v1.0.0 h1:apOUWs51W5PlhuyGyz9FCeeBIOUDA/6nW8Oi/yOhh5U=
+github.com/opencontainers/go-digest v1.0.0/go.mod h1:0JzlMkj0TRzQZfJkVvzbP0HBR3IKzErnv2BNG4W4MAM=
 github.com/opencontainers/image-spec v1.0.1 h1:JMemWkRwHx4Zj+fVxWoMCFm/8sYGGrUVojFA6h/TRcI=
 github.com/opencontainers/image-spec v1.0.1/go.mod h1:BtxoFyWECRxE4U/7sNtV5W15zMzWCbyJoFRP3s7yZA0=
 github.com/opencontainers/runc v0.1.1 h1:GlxAyO6x8rfZYN9Tt0Kti5a/cP41iuiO2yYT0IJGY8Y=
@@ -566,6 +573,8 @@ github.com/stellar/go v0.0.0-20200520124219-6cdb4e841dc7 h1:a98X4Lbv4mYreR7GVd4v
 github.com/stellar/go v0.0.0-20200520124219-6cdb4e841dc7/go.mod h1:Q4JDgZhGw7Ytu1924PzNkwr2GsLptrzAjwC/icuXnLU=
 github.com/stellar/go v0.0.0-20200917104244-8dc2a7354bf8 h1:hdrW8jhTrR6bagF4gzfItdiI/xeRv3FjptWco2Toz7I=
 github.com/stellar/go v0.0.0-20200917104244-8dc2a7354bf8/go.mod h1:PGVMUzNBHfCpregVTwNK1uNTQTgsw9yrZZN53csq5JA=
+github.com/stellar/go v0.0.0-20201005172357-947b63b1099f h1:AEqKJjkLINc2tLmzoefLah7XgwkCVolWFOFcLyMkKI4=
+github.com/stellar/go v0.0.0-20201005172357-947b63b1099f/go.mod h1:detHj8OVJH7sNNGahphTD9kMofOxMKAURZuRq9mHwGM=
 github.com/stellar/go-xdr v0.0.0-20180917104419-0bc96f33a18e h1:n/hfey8pO+RYMoGXyvyzuw5pdO8IFDoyAL/g5OiCesY=
 github.com/stellar/go-xdr v0.0.0-20180917104419-0bc96f33a18e/go.mod h1:gpOLVzy6TVYTQ3LvHSN9RJC700FkhFCpSE82u37aNRM=
 github.com/stellar/go-xdr v0.0.0-20200331223602-71a1e6d555f2 h1:K9H+A+eWe8ZlnpNha+pXbEK+jtIluQp/2dKxkK8k7OE=
@@ -609,6 +618,8 @@ github.com/threefoldtech/tfexplorer v0.4.1-0.20201006092040-c7f28e901ea5 h1:72io
 github.com/threefoldtech/tfexplorer v0.4.1-0.20201006092040-c7f28e901ea5/go.mod h1:0261YnFlaQNDv1hNzdJc/2DuYq9B9qe9D6QnZuZOCh0=
 github.com/threefoldtech/tfexplorer v0.4.1-0.20201008114938-260c3694ef48 h1:EADdhzDfiRYpddc9dSznO5nzg7hTyckUZn2NRoE0WT8=
 github.com/threefoldtech/tfexplorer v0.4.1-0.20201008114938-260c3694ef48/go.mod h1:0261YnFlaQNDv1hNzdJc/2DuYq9B9qe9D6QnZuZOCh0=
+github.com/threefoldtech/tfexplorer v0.4.1-0.20201014110255-653c7314b944 h1:jJG/lUhZVn70RWzi79nxrTQHWpd6Thb4lB+klQfVCiU=
+github.com/threefoldtech/tfexplorer v0.4.1-0.20201014110255-653c7314b944/go.mod h1:6thp8ja7vDbtGAn91mcYL2wUmDGBoUdxJKHceC3xIaE=
 github.com/threefoldtech/zbus v0.1.3 h1:18DnIzximRbATle5ZdZz0i84n/bCYB8k/gkhr2dXayc=
 github.com/threefoldtech/zbus v0.1.3/go.mod h1:ZtiRpcqzEBJetVQDsEbw0p48h/AF3O1kf0tvd30I0BU=
 github.com/threefoldtech/zos v0.2.4-rc2/go.mod h1:7A2oflcmSVsHFC4slOcydWgJyFBMFMH9wsaTRv+CnTA=

--- a/go.sum
+++ b/go.sum
@@ -472,6 +472,9 @@ github.com/opencontainers/selinux v1.5.2/go.mod h1:yTcKuYAh6R95iDpefGLQaPaRwJFwy
 github.com/opentracing/opentracing-go v1.0.2/go.mod h1:UkNAQd3GIcIGf0SeVgPpRdFStlNbqXla1AfSYxPUl2o=
 github.com/opentracing/opentracing-go v1.1.0/go.mod h1:UkNAQd3GIcIGf0SeVgPpRdFStlNbqXla1AfSYxPUl2o=
 github.com/openzipkin/zipkin-go v0.1.6/go.mod h1:QgAqvLzwWbR/WpD4A3cGpPtJrZXNIiJc5AZX7/PBEpw=
+github.com/patrickmn/go-cache v1.0.0 h1:3gD5McaYs9CxjyK5AXGcq8gdeCARtd/9gJDUvVeaZ0Y=
+github.com/patrickmn/go-cache v2.1.0+incompatible h1:HRMgzkcYKYpi3C8ajMPV8OFXaaRUnok+kx1WdO15EQc=
+github.com/patrickmn/go-cache v2.1.0+incompatible/go.mod h1:3Qf8kWWT7OJRJbdiICTKqZju1ZixQ/KpMGzzAfe6+WQ=
 github.com/pborman/uuid v1.2.0 h1:J7Q5mO4ysT1dv8hyrUGHb9+ooztCXu1D8MY8DZYsu3g=
 github.com/pborman/uuid v1.2.0/go.mod h1:X/NO0urCmaxf9VXbdlT7C2Yzkj2IKimNn4k+gtPdI/k=
 github.com/pelletier/go-toml v1.4.0/go.mod h1:PN7xzY2wHTK0K9p34ErDQMlFxa51Fk0OUruD3k1mMwo=

--- a/pkg/container/container.go
+++ b/pkg/container/container.go
@@ -302,7 +302,7 @@ func (c *Module) Inspect(ns string, id pkg.ContainerID) (result pkg.Container, e
 }
 
 // ListNS list the name of all the container namespaces
-func (c *containerModule) ListNS() ([]string, error) {
+func (c *Module) ListNS() ([]string, error) {
 	client, err := containerd.New(c.containerd)
 	if err != nil {
 		return nil, err
@@ -313,7 +313,7 @@ func (c *containerModule) ListNS() ([]string, error) {
 }
 
 // List all the existing container IDs from a certain namespace ns
-func (c *containerModule) List(ns string) ([]pkg.ContainerID, error) {
+func (c *Module) List(ns string) ([]pkg.ContainerID, error) {
 	client, err := containerd.New(c.containerd)
 	if err != nil {
 		return nil, err

--- a/pkg/container/container.go
+++ b/pkg/container/container.go
@@ -58,7 +58,7 @@ var (
 
 	// a marker value we use in failure cache to let the watcher
 	// no that we don't want to try restarting this container
-	permenant = struct{}{}
+	permanent = struct{}{}
 )
 
 var (
@@ -385,7 +385,7 @@ func (c *Module) Delete(ns string, id pkg.ContainerID) error {
 
 	// mark this container as perminant down. so the watcher
 	// does not try to restart it again
-	c.failures.Set(string(id), permenant, cache.DefaultExpiration)
+	c.failures.Set(string(id), permanent, cache.DefaultExpiration)
 
 	task, err := container.Task(ctx, nil)
 	if err == nil {

--- a/pkg/container/container.go
+++ b/pkg/container/container.go
@@ -25,6 +25,7 @@ import (
 	"github.com/containerd/containerd/runtime/restart"
 	"github.com/google/shlex"
 	"github.com/patrickmn/go-cache"
+	"github.com/threefoldtech/zbus"
 	"github.com/threefoldtech/zos/pkg"
 	"github.com/threefoldtech/zos/pkg/container/logger"
 	"github.com/threefoldtech/zos/pkg/container/stats"
@@ -65,12 +66,12 @@ var (
 type Module struct {
 	containerd string
 	root       string
-
-	failures *cache.Cache
+	client     zbus.Client
+	failures   *cache.Cache
 }
 
 // New return an new pkg.ContainerModule
-func New(root string, containerd string) *Module {
+func New(client zbus.Client, root string, containerd string) *Module {
 	if len(containerd) == 0 {
 		containerd = containerdSock
 	}
@@ -78,6 +79,7 @@ func New(root string, containerd string) *Module {
 	return &Module{
 		containerd: containerd,
 		root:       root,
+		client:     client,
 		// values are cached only for 1 minute. purge cache every 20 second
 		failures: cache.New(time.Minute, 20*time.Second),
 	}

--- a/pkg/container/watch.go
+++ b/pkg/container/watch.go
@@ -26,7 +26,7 @@ func (c *Module) handlerEventTaskExit(ns string, event *events.TaskExit) {
 		c.failures.Set(event.ContainerID, int(0), cache.DefaultExpiration)
 	}
 
-	if marker == permenant {
+	if marker == permanent {
 		// if the marker is permenant. it means that this container
 		// is being deleted. we don't need to take any more action here
 		// (don't try to restart or delete)

--- a/pkg/container/watch.go
+++ b/pkg/container/watch.go
@@ -8,7 +8,7 @@ import (
 	"github.com/containerd/typeurl"
 	"github.com/patrickmn/go-cache"
 	"github.com/rs/zerolog/log"
-	"github.com/threefoldtech/zos/pkg"
+	"github.com/threefoldtech/zos/pkg/stubs"
 )
 
 func (c *Module) handlerEventTaskExit(ns string, event *events.TaskExit) {
@@ -35,12 +35,13 @@ func (c *Module) handlerEventTaskExit(ns string, event *events.TaskExit) {
 	if count < failuresBeforeDestroy {
 		return
 	}
-	log.Debug().Msg("deleting container due to so many crashes")
-	if err := c.Delete(ns, pkg.ContainerID(event.ContainerID)); err != nil {
-		log.Error().Err(err).Msg("failed to delete container")
-	}
 
-	//TODO: report to provisiond
+	log.Debug().Msg("deleting container due to so many crashes")
+
+	stub := stubs.NewProvisionStub(c.client)
+	if err := stub.DecommissionCached(event.ContainerID, "deleting container due to so many crashes"); err != nil {
+		log.Error().Err(err).Msg("failed to decommission reservation")
+	}
 }
 
 func (c *Module) handleEvent(ns string, event interface{}) {

--- a/pkg/container/watch.go
+++ b/pkg/container/watch.go
@@ -1,0 +1,102 @@
+package container
+
+import (
+	"context"
+
+	"github.com/containerd/containerd"
+	"github.com/containerd/containerd/api/events"
+	"github.com/containerd/typeurl"
+	"github.com/patrickmn/go-cache"
+	"github.com/rs/zerolog/log"
+	"github.com/threefoldtech/zos/pkg"
+)
+
+func (c *Module) handlerEventTaskExit(ns string, event *events.TaskExit) {
+
+	log := log.With().
+		Str("namespace", ns).
+		Str("container", event.ContainerID).Logger()
+
+	log.Debug().Msg("task exited")
+
+	if _, ok := c.failures.Get(event.ContainerID); !ok {
+		c.failures.Set(event.ContainerID, int(0), cache.DefaultExpiration)
+	}
+
+	count, err := c.failures.IncrementInt(event.ContainerID, 1)
+	if err != nil {
+		// this should never happen because we make sure value
+		// is set
+		panic(err)
+	}
+
+	log.Debug().Int("count", count).Msg("recorded stops")
+
+	if count < failuresBeforeDestroy {
+		return
+	}
+	log.Debug().Msg("deleting container due to so many crashes")
+	if err := c.Delete(ns, pkg.ContainerID(event.ContainerID)); err != nil {
+		log.Error().Err(err).Msg("failed to delete container")
+	}
+
+	//TODO: report to provisiond
+}
+
+func (c *Module) handleEvent(ns string, event interface{}) {
+	switch event := event.(type) {
+	case *events.TaskExit:
+		c.handlerEventTaskExit(ns, event)
+	default:
+		log.Debug().Msgf("unhandled event: %+v", event)
+	}
+}
+
+// watch method will start a connection, and register for events
+// once an event is received, it will be handled. and exit on
+// first error or in case context was cancelled.
+// the caller must make sure this is called again in case of an
+// error
+func (c *Module) watch(ctx context.Context) error {
+	client, err := containerd.New(c.containerd)
+	if err != nil {
+		return err
+	}
+
+	defer client.Close()
+	log.Debug().Str("containerd", c.containerd).Msg("subscribe to events from containerd")
+
+	source, errors := client.Subscribe(ctx)
+	for {
+		select {
+		case <-ctx.Done():
+			return nil
+		case envelope := <-source:
+			event, err := typeurl.UnmarshalAny(envelope.Event)
+			if err != nil {
+				log.Error().Err(err).Msg("failed to unmarshal event envelope")
+				continue
+			}
+
+			c.handleEvent(envelope.Namespace, event)
+		case err := <-errors:
+			return err
+		}
+	}
+}
+
+// Watch start watching for events coming from containerd.
+// Blocks forever. caller need to run this in a go routine
+//
+// different events types are handled differently. Now, only
+// TaskExit event is handled.
+func (c *Module) Watch(ctx context.Context) {
+	for {
+		err := c.watch(ctx)
+		if err == nil {
+			break // end of context
+		}
+
+		log.Err(err).Msg("error while watching events from containerd")
+	}
+}

--- a/pkg/container/watch.go
+++ b/pkg/container/watch.go
@@ -43,7 +43,7 @@ func (c *Module) handlerEventTaskExit(ns string, event *events.TaskExit) {
 	}
 
 	if reason != nil {
-		log.Debug().Msg("deleting container due to so many crashes")
+		log.Debug().Err(reason).Msg("deleting container due to restart error")
 
 		stub := stubs.NewProvisionStub(c.client)
 		if err := stub.DecommissionCached(event.ContainerID, reason.Error()); err != nil {

--- a/pkg/container/watch.go
+++ b/pkg/container/watch.go
@@ -27,10 +27,10 @@ func (c *Module) handlerEventTaskExit(ns string, event *events.TaskExit) {
 	}
 
 	if marker == permanent {
-		// if the marker is permenant. it means that this container
+		// if the marker is permanent. it means that this container
 		// is being deleted. we don't need to take any more action here
 		// (don't try to restart or delete)
-		log.Debug().Msg("permenant delete marker is set")
+		log.Debug().Msg("permanent delete marker is set")
 		return
 	}
 

--- a/pkg/monitor.go
+++ b/pkg/monitor.go
@@ -4,7 +4,6 @@ package pkg
 //go:generate zbusc -module monitor -version 0.0.1 -name system -package stubs github.com/threefoldtech/zos/pkg+SystemMonitor stubs/system_monitor_stub.go
 //go:generate zbusc -module monitor -version 0.0.1 -name host -package stubs github.com/threefoldtech/zos/pkg+HostMonitor stubs/host_monitor_stub.go
 //go:generate zbusc -module identityd -version 0.0.1 -name monitor -package stubs github.com/threefoldtech/zos/pkg+VersionMonitor stubs/version_monitor_stub.go
-//go:generate zbusc -module provision -version 0.0.1 -name provision -package stubs github.com/threefoldtech/zos/pkg+ProvisionMonitor stubs/provision_monitor_stub.go
 
 import (
 	"context"
@@ -96,19 +95,4 @@ type HostMonitor interface {
 // VersionMonitor interface (provided by identityd)
 type VersionMonitor interface {
 	Version(ctx context.Context) <-chan semver.Version
-}
-
-// ProvisionCounters struct
-type ProvisionCounters struct {
-	Container int64 `json:"container"`
-	Volume    int64 `jons:"volume"`
-	Network   int64 `json:"network"`
-	ZDB       int64 `json:"zdb"`
-	VM        int64 `json:"vm"`
-	Debug     int64 `json:"debug"`
-}
-
-// ProvisionMonitor interface
-type ProvisionMonitor interface {
-	Counters(ctx context.Context) <-chan ProvisionCounters
 }

--- a/pkg/provision.go
+++ b/pkg/provision.go
@@ -1,0 +1,21 @@
+package pkg
+
+//go:generate zbusc -module provision -version 0.0.1 -name provision -package stubs github.com/threefoldtech/zos/pkg+Provision stubs/provision_stub.go
+
+import "context"
+
+// ProvisionCounters struct
+type ProvisionCounters struct {
+	Container int64 `json:"container"`
+	Volume    int64 `jons:"volume"`
+	Network   int64 `json:"network"`
+	ZDB       int64 `json:"zdb"`
+	VM        int64 `json:"vm"`
+	Debug     int64 `json:"debug"`
+}
+
+// Provision interface
+type Provision interface {
+	Counters(ctx context.Context) <-chan ProvisionCounters
+	DecommissionCached(id string, reason string) error
+}

--- a/pkg/provision/engine.go
+++ b/pkg/provision/engine.go
@@ -9,6 +9,7 @@ import (
 	"fmt"
 	"time"
 
+	"github.com/cenkalti/backoff/v3"
 	"github.com/jbenet/go-base58"
 	"github.com/threefoldtech/zbus"
 	"github.com/threefoldtech/zos/pkg"
@@ -336,11 +337,21 @@ func (e *Engine) DecommissionCached(id string, reason string) error {
 		return errors.Wrapf(err, "failed to build result object for reservation: %s", id)
 	}
 
-	if err := e.reply(ctx, result); err != nil {
+	if err := e.decommission(ctx, r); err != nil {
 		log.Error().Err(err).Msgf("failed to update reservation result with failure: %s", id)
 	}
 
-	return e.decommission(ctx, r)
+	bf := backoff.NewExponentialBackOff()
+	bf.MaxInterval = 10 * time.Second
+	bf.MaxElapsedTime = 1 * time.Minute
+
+	return backoff.Retry(func() error {
+		err := e.reply(ctx, result)
+		if err != nil {
+			log.Error().Err(err).Msgf("failed to update reservation result with failure: %s", id)
+		}
+		return err
+	}, bf)
 }
 
 func (e *Engine) buildResult(id string, typ ReservationType, err error, info interface{}) (*Result, error) {

--- a/pkg/stubs/provision_stub.go
+++ b/pkg/stubs/provision_stub.go
@@ -6,14 +6,14 @@ import (
 	pkg "github.com/threefoldtech/zos/pkg"
 )
 
-type ProvisionMonitorStub struct {
+type ProvisionStub struct {
 	client zbus.Client
 	module string
 	object zbus.ObjectID
 }
 
-func NewProvisionMonitorStub(client zbus.Client) *ProvisionMonitorStub {
-	return &ProvisionMonitorStub{
+func NewProvisionStub(client zbus.Client) *ProvisionStub {
+	return &ProvisionStub{
 		client: client,
 		module: "provision",
 		object: zbus.ObjectID{
@@ -23,7 +23,7 @@ func NewProvisionMonitorStub(client zbus.Client) *ProvisionMonitorStub {
 	}
 }
 
-func (s *ProvisionMonitorStub) Counters(ctx context.Context) (<-chan pkg.ProvisionCounters, error) {
+func (s *ProvisionStub) Counters(ctx context.Context) (<-chan pkg.ProvisionCounters, error) {
 	ch := make(chan pkg.ProvisionCounters)
 	recv, err := s.client.Stream(ctx, s.module, s.object, "Counters")
 	if err != nil {
@@ -40,4 +40,17 @@ func (s *ProvisionMonitorStub) Counters(ctx context.Context) (<-chan pkg.Provisi
 		}
 	}()
 	return ch, nil
+}
+
+func (s *ProvisionStub) DecommissionCached(arg0 string, arg1 string) (ret0 error) {
+	args := []interface{}{arg0, arg1}
+	result, err := s.client.Request(s.module, s.object, "DecommissionCached", args...)
+	if err != nil {
+		panic(err)
+	}
+	ret0 = new(zbus.RemoteError)
+	if err := result.Unmarshal(0, &ret0); err != nil {
+		panic(err)
+	}
+	return
 }


### PR DESCRIPTION
Fixes #957 

- `contd` watches for events from containerd 
- on task failure, contd keep tracks of how many failures happens in one minute. 
- if the number of failure above a certain threshold, a call to provisiond is made to delete this reservation
- provisoind updates the explorer with the failure reason, and decommission the reservation