### PR TITLE
do hash the shared secret generated to decrypt workloads sensitive information

### DIFF
--- a/pkg/crypto/crypto_test.go
+++ b/pkg/crypto/crypto_test.go
@@ -111,18 +111,21 @@ func TestECDHPyNACLCompatibility(t *testing.T) {
 	// import nacl.encoding
 	// from nacl.secret import SecretBox
 	// from nacl.bindings import crypto_scalarmult
+	// from hashlib import blake2b
 	// alice_private = nacl.public.PrivateKey.from_seed(b"11111111111111111111111111111111")
 	// bob_private = nacl.public.PrivateKey.from_seed(b"22222222222222222222222222222222")
 	// shared_secret = crypto_scalarmult(alice_private.encode(), bob_private.public_key.encode())
-	// box = SecretBox(shared_secret)
+	// h = blake2b(shared_secret,digest_size=32)
+	// key = h.digest()
+	// box = SecretBox(key)
 	// encrypted = box.encrypt(b'hello world')
 	// print(nacl.encoding.HexEncoder().encode(encrypted))
-	// b'74bb3109ad0a1947473ba6bccd3f44a8d735d6a99f8d046dff6e3853b664ad09148a2bf427a95d502c8222b62e4fc8603b2407'
+	// b'8a246cd20d2d29b8f45d7a32e469cd914707bf3abed5747bcd9b54383e56e9be97b940df5a6826400f36a829ce10c618979ee2'
 
 	alicePrivate := ed25519.NewKeyFromSeed([]byte("11111111111111111111111111111111"))
 	bobPrivate := ed25519.NewKeyFromSeed([]byte("22222222222222222222222222222222"))
 
-	encrypted, err := hex.DecodeString("74bb3109ad0a1947473ba6bccd3f44a8d735d6a99f8d046dff6e3853b664ad09148a2bf427a95d502c8222b62e4fc8603b2407")
+	encrypted, err := hex.DecodeString("8a246cd20d2d29b8f45d7a32e469cd914707bf3abed5747bcd9b54383e56e9be97b940df5a6826400f36a829ce10c618979ee2")
 	require.NoError(t, err)
 
 	decrypted, err := DecryptECDH(encrypted, bobPrivate, alicePrivate.Public().(ed25519.PublicKey))


### PR DESCRIPTION
Extract from
https://en.wikipedia.org/wiki/Elliptic-curve_Diffie%E2%80%93Hellman#Key_establishment_protocol:
> While the shared secret may be used directly as a key, it can be desirable to hash the secret to remove weak bits due to the Diffie–Hellman exchange.