### PR TITLE
provisiond: skip failed reservation when syncing cache

### DIFF
--- a/cmds/provisiond/main.go
+++ b/cmds/provisiond/main.go
@@ -111,7 +111,7 @@ func main() {
 		log.Fatal().Err(err).Msg("failed to instantiate BCDB client")
 	}
 
-	// keep track of resource unnits reserved and amount of workloads provisionned
+	// keep track of resource units reserved and amount of workloads provisionned
 	statser := &primitives.Counters{}
 
 	// to store reservation locally on the node

--- a/pkg/provision/primitives/cache/cache.go
+++ b/pkg/provision/primitives/cache/cache.go
@@ -76,40 +76,42 @@ func (s *Fs) updateReservationResults(rootPath string) error {
 	}
 
 	for _, reservation := range reservations {
-		if reservation.Result.IsNil() {
-			log.Info().Msgf("updating reservation result for %s", reservation.ID)
+		if !reservation.Result.IsNil() {
+			continue
+		}
 
-			result, err := client.Workloads.NodeWorkloadGet(reservation.ID)
-			if err != nil {
-				return errors.Wrapf(err, "error occured while requesting reservation result for %s", reservation.ID)
-			}
+		log.Info().Msgf("updating reservation result for %s", reservation.ID)
 
-			provisionResult := result.GetResult()
-			reservation.Result = provision.Result{
-				Type:      reservation.Type,
-				Created:   provisionResult.Epoch.Time,
-				State:     provision.ResultState(provisionResult.State),
-				Data:      provisionResult.DataJson,
-				Error:     provisionResult.Message,
-				ID:        provisionResult.WorkloadId,
-				Signature: provisionResult.Signature,
-			}
+		result, err := client.Workloads.NodeWorkloadGet(reservation.ID)
+		if err != nil {
+			return errors.Wrapf(err, "error occured while requesting reservation result for %s", reservation.ID)
+		}
 
-			// Open the reservation in cache file with write permission
-			f, err := os.OpenFile(filepath.Join(rootPath, reservation.ID), os.O_RDWR, 0644)
-			if err != nil {
-				return err
-			}
-			defer f.Close()
-			writer, err := versioned.NewWriter(f, reservationSchemaLastVersion)
-			if err != nil {
-				return err
-			}
+		provisionResult := result.GetResult()
+		reservation.Result = provision.Result{
+			Type:      reservation.Type,
+			Created:   provisionResult.Epoch.Time,
+			State:     provision.ResultState(provisionResult.State),
+			Data:      provisionResult.DataJson,
+			Error:     provisionResult.Message,
+			ID:        provisionResult.WorkloadId,
+			Signature: provisionResult.Signature,
+		}
 
-			// Write new content to the reservation in cache file
-			if err := json.NewEncoder(writer).Encode(reservation); err != nil {
-				return errors.Wrapf(err, "error while writing new reservation content for %s", reservation.ID)
-			}
+		// Open the reservation in cache file with write permission
+		f, err := os.OpenFile(filepath.Join(rootPath, reservation.ID), os.O_RDWR, 0644)
+		if err != nil {
+			return err
+		}
+		defer f.Close()
+		writer, err := versioned.NewWriter(f, reservationSchemaLastVersion)
+		if err != nil {
+			return err
+		}
+
+		// Write new content to the reservation in cache file
+		if err := json.NewEncoder(writer).Encode(reservation); err != nil {
+			return errors.Wrapf(err, "error while writing new reservation content for %s", reservation.ID)
 		}
 	}
 

--- a/pkg/provision/primitives/cache/cache.go
+++ b/pkg/provision/primitives/cache/cache.go
@@ -84,7 +84,7 @@ func (s *Fs) updateReservationResults(rootPath string) error {
 
 		result, err := client.Workloads.NodeWorkloadGet(reservation.ID)
 		if err != nil {
-			return errors.Wrapf(err, "error occured while requesting reservation result for %s", reservation.ID)
+			return errors.Wrapf(err, "error occurred while requesting reservation result for %s", reservation.ID)
 		}
 
 		provisionResult := result.GetResult()

--- a/pkg/provision/primitives/cache/cache.go
+++ b/pkg/provision/primitives/cache/cache.go
@@ -285,7 +285,7 @@ func (s *Fs) incrementCounters(statser provision.Statser) error {
 	}
 
 	for _, r := range reservations {
-		if r.Expired() {
+		if r.Expired() || r.Result.State != provision.StateOk {
 			continue
 		}
 		if r.Type == primitives.NetworkResourceReservation || r.Type == primitives.NetworkReservation {

--- a/pkg/storage/zdb.go
+++ b/pkg/storage/zdb.go
@@ -17,6 +17,10 @@ import (
 
 func (s *storageModule) Find(nsID string) (allocation pkg.Allocation, err error) {
 	for _, pool := range s.pools {
+		if _, mounted := pool.Mounted(); !mounted {
+			continue
+		}
+
 		volumes, err := pool.Volumes()
 		if err != nil {
 			return allocation, errors.Wrapf(err, "failed to list volume on pool %s", pool.Name())


### PR DESCRIPTION
when provisiond restarts, it does walk over all the reservation in the
cache to rebuild the state of the resource units statser.
We now properly skip the reservation that failed to provision