### PR TITLE
contd: do not wait forever on container delete

### DIFF
--- a/pkg/container/container.go
+++ b/pkg/container/container.go
@@ -135,6 +135,8 @@ func (c *Module) upgrade() error {
 
 // Run creates and starts a container
 func (c *Module) Run(ns string, data pkg.Container) (id pkg.ContainerID, err error) {
+	log.Info().Str("ns", ns).Msg("starting container")
+
 	// create a new client connected to the default socket path for containerd
 	client, err := containerd.New(c.containerd)
 	if err != nil {
@@ -326,6 +328,8 @@ func (c *Module) start(ns, id string) error {
 
 // Inspect returns the detail about a running container
 func (c *Module) Inspect(ns string, id pkg.ContainerID) (result pkg.Container, err error) {
+	log.Info().Str("id", string(id)).Str("ns", ns).Msg("inspect container")
+
 	client, err := containerd.New(c.containerd)
 	if err != nil {
 		return result, err
@@ -379,6 +383,8 @@ func (c *Module) Inspect(ns string, id pkg.ContainerID) (result pkg.Container, e
 
 // ListNS list the name of all the container namespaces
 func (c *Module) ListNS() ([]string, error) {
+	log.Info().Msg("list namespaces")
+
 	client, err := containerd.New(c.containerd)
 	if err != nil {
 		return nil, err
@@ -390,6 +396,8 @@ func (c *Module) ListNS() ([]string, error) {
 
 // List all the existing container IDs from a certain namespace ns
 func (c *Module) List(ns string) ([]pkg.ContainerID, error) {
+	log.Info().Str("ns", ns).Msg("list containers")
+
 	client, err := containerd.New(c.containerd)
 	if err != nil {
 		return nil, err
@@ -413,13 +421,18 @@ func (c *Module) List(ns string) ([]pkg.ContainerID, error) {
 
 // Delete stops and remove a container
 func (c *Module) Delete(ns string, id pkg.ContainerID) error {
+	log.Info().Str("id", string(id)).Str("ns", ns).Msg("delete container")
+
 	client, err := containerd.New(c.containerd)
 	if err != nil {
 		return err
 	}
 	defer client.Close()
+
+	// log.Debug().Msg("fetching namespace")
 	ctx := namespaces.WithNamespace(context.Background(), ns)
 
+	// log.Debug().Str("id", string(id)).Msg("fetching container")
 	container, err := client.LoadContainer(ctx, string(id))
 	if err != nil {
 		return err

--- a/pkg/provision/primitives/zdb.go
+++ b/pkg/provision/primitives/zdb.go
@@ -464,6 +464,7 @@ func (p *Provisioner) upgradeRunningZdb(ctx context.Context) error {
 	contmod := stubs.NewContainerModuleStub(p.zbus)
 
 	// Listing running zdb containers
+	log.Debug().Msg("fetching zdb containers list")
 	containers, err := contmod.List(zdbContainerNS)
 	if err != nil {
 		log.Error().Err(err).Msg("could not load containers list")
@@ -471,11 +472,14 @@ func (p *Provisioner) upgradeRunningZdb(ctx context.Context) error {
 	}
 
 	// fetching extected hash
+	log.Debug().Msg("fetching flist hash")
 	expected, err := flistmod.FlistHash(zdbFlistURL)
 	if err != nil {
 		log.Error().Err(err).Msg("could not load expected flist hash")
 		return err
 	}
+
+	log.Debug().Str("hash", expected).Msg("expecting hash")
 
 	// Checking if containers are running latest zdb version
 	for _, c := range containers {


### PR DESCRIPTION
Request of container delete waits forever if the process cannot be killed. The workflow tries to `SIGTERM` the running process then `SIGKILL` after some try, but it never stop trying `SIGKILL`.
    
 If process is in `D` or `Z` state, process won't be killed if stuck on kernel call (occured with `sync` on testnet). This make contd not responding because stuck on deleting.
    
This fix will make contd responding again and not being stuck forever but since an error is returned, provisiond will try to re-delete it later.

This PR add aswell more verbosity to `contd` to be less blind on what happen.
This PR is related to #1008 