### PR TITLE
contd: add -debug flag

### DIFF
--- a/cmds/contd/main.go
+++ b/cmds/contd/main.go
@@ -8,6 +8,7 @@ import (
 	"time"
 
 	"github.com/cenkalti/backoff/v3"
+	"github.com/rs/zerolog"
 	"github.com/rs/zerolog/log"
 
 	"github.com/threefoldtech/zbus"
@@ -27,6 +28,7 @@ func main() {
 		msgBrokerCon  string
 		containerdCon string
 		workerNr      uint
+		debug         bool
 		ver           bool
 	)
 
@@ -34,11 +36,18 @@ func main() {
 	flag.StringVar(&msgBrokerCon, "broker", "unix:///var/run/redis.sock", "connection string to the message broker")
 	flag.StringVar(&containerdCon, "containerd", "/run/containerd/containerd.sock", "connection string to containerd")
 	flag.UintVar(&workerNr, "workers", 1, "number of workers")
+	flag.BoolVar(&debug, "debug", false, "enable debug logging")
 	flag.BoolVar(&ver, "v", false, "show version and exit")
 
 	flag.Parse()
 	if ver {
 		version.ShowAndExit(false)
+	}
+
+	// Default level is info, unless debug flag is present
+	zerolog.SetGlobalLevel(zerolog.InfoLevel)
+	if debug {
+		zerolog.SetGlobalLevel(zerolog.DebugLevel)
 	}
 
 	// wait for shim-logs to be available before starting

--- a/pkg/container/container.go
+++ b/pkg/container/container.go
@@ -378,6 +378,7 @@ func (c *Module) Inspect(ns string, id pkg.ContainerID) (result pkg.Container, e
 		}
 	}
 
+	log.Debug().Str("id", string(id)).Str("ns", ns).Msg("container inspected")
 	return
 }
 
@@ -416,6 +417,7 @@ func (c *Module) List(ns string) ([]pkg.ContainerID, error) {
 		ids = append(ids, pkg.ContainerID(c.ID()))
 	}
 
+	log.Debug().Str("ns", ns).Msg("containers list generated")
 	return ids, nil
 }
 


### PR DESCRIPTION
Add `-debug` flag like some others binaries, to enable debug print and disable them by default.
This is useful and important to add debug message without flooding logs.

This is tested.