### PR TITLE
fix provisiond cleanup for reservation in state deleted

### DIFF
--- a/pkg/provision/cleanup.go
+++ b/pkg/provision/cleanup.go
@@ -110,7 +110,7 @@ func checkReservationToDelete(fs pkg.Filesystem, cl *client.Client) bool {
 
 	nextAction := reservation.GetNextAction()
 	if nextAction == workloads.NextActionDelete || nextAction == workloads.NextActionDeleted || nextAction == workloads.NextActionInvalid {
-		log.Info().Msgf("workload %d has next action to delete / deleted or invalid", fs.Name)
+		log.Info().Msgf("workload %s has next action to delete / deleted or invalid", fs.Name)
 		return true
 	}
 


### PR DESCRIPTION
Now checking reservations for state `deleted` and `invalid` as well. Also this client was returning an error because the `get` method was trying to unmarshal in an interface. Using `NodeWorkloadGet` now, it's the same result.