### PR TITLE
networkd: avoid infinite peers fetch retry

### DIFF
--- a/cmds/networkd/main.go
+++ b/cmds/networkd/main.go
@@ -187,14 +187,17 @@ func waitYggdrasilBin() {
 }
 
 func fetchPeerList() yggdrasil.PeerList {
-	// Try to fetch public peer for 1 minute, if we failed to do so, use the fallback hardcoded peer list
-
+	// Try to fetch public peer for 1 minute,
+	// if we failed to do so, use the fallback hardcoded peer list
 	var pl yggdrasil.PeerList
-	bo := backoff.NewConstantBackOff(time.Minute)
-	bo.Interval = 10 * time.Second
+
+	// Do not retry more than 4 times
+	bo := backoff.WithMaxRetries(backoff.NewConstantBackOff(time.Second), 4)
+
 	fetchPeerList := func() error {
 		p, err := yggdrasil.FetchPeerList()
 		if err != nil {
+			log.Debug().Err(err).Msg("failed to fetch yggdrasil peers")
 			return err
 		}
 		pl = p

--- a/cmds/networkd/main.go
+++ b/cmds/networkd/main.go
@@ -187,8 +187,8 @@ func waitYggdrasilBin() {
 }
 
 func fetchPeerList() yggdrasil.PeerList {
-	// Try to fetch public peer for 1 minute,
-	// if we failed to do so, use the fallback hardcoded peer list
+	// Try to fetch public peer
+	// If we failed to do so, use the fallback hardcoded peer list
 	var pl yggdrasil.PeerList
 
 	// Do not retry more than 4 times


### PR DESCRIPTION
Avoid infinite retry of fetching yggdrasil peers list.
When the webservice is down, node is stuck on fetching list and never reach fallback code.

Code tested