### PR TITLE
janitor vdisks

### DIFF
--- a/pkg/provision/cleanup.go
+++ b/pkg/provision/cleanup.go
@@ -315,14 +315,3 @@ func newZdbConnection(id string) (zdb.Client, error) {
 	cl := zdb.New(socket)
 	return cl, cl.Connect()
 }
-
-func listZdbNamespaces(containterID string) ([]string, error) {
-	zdbCl, err := newZdbConnection(containterID)
-	if err != nil {
-		return nil, errors.Wrap(err, "failed to connect to 0-db")
-	}
-
-	defer zdbCl.Close()
-
-	return zdbCl.Namespaces()
-}

--- a/pkg/provision/cleanup.go
+++ b/pkg/provision/cleanup.go
@@ -18,7 +18,7 @@ import (
 )
 
 var (
-	vdiskIdMatch = regexp.MustCompile(`^(\d+-\d+)`)
+	vdiskIDMatch = regexp.MustCompile(`^(\d+-\d+)`)
 )
 
 // Janitor structure
@@ -92,7 +92,7 @@ func (j *Janitor) cleanupVdisks(ctx context.Context) error {
 	}
 	for _, vdisk := range vdisks {
 		//fmt.Sscanf(str string, format string, a ...interface{})
-		gwid := vdiskIdMatch.FindString(vdisk.Name())
+		gwid := vdiskIDMatch.FindString(vdisk.Name())
 		clog := log.With().Str("vdisk", vdisk.Name()).Str("id", gwid).Logger()
 		if len(gwid) == 0 {
 			clog.Warn().Msg("vdisk has invalid id, skipping")

--- a/pkg/provision/engine.go
+++ b/pkg/provision/engine.go
@@ -157,7 +157,9 @@ func (e *Engine) Run(ctx context.Context) error {
 				continue
 			}
 			log.Info().Msg("start cleaning up resources")
-			if err := CleanupResources(ctx, e.zbusCl); err != nil {
+			var janitor Janitor
+			// TODO: decently initialize janitor
+			if err := janitor.CleanupResources(ctx); err != nil {
 				log.Error().Err(err).Msg("failed to cleanup resources")
 				continue
 			}

--- a/pkg/provision/explorer/source.go
+++ b/pkg/provision/explorer/source.go
@@ -33,6 +33,16 @@ func NewPoller(cl *client.Client, inputConv provision.ReservationConverterFunc, 
 	}
 }
 
+// Get gets a reservation by the global workload id
+func (r *Poller) Get(gwid string) (*provision.Reservation, error) {
+	workload, err := r.wl.NodeWorkloadGet(gwid)
+	if err != nil {
+		return nil, err
+	}
+
+	return r.inputConv(workload)
+}
+
 // Poll implements provision.ReservationPoller
 func (r *Poller) Poll(nodeID pkg.Identifier, from uint64) ([]*provision.Reservation, uint64, error) {
 

--- a/pkg/provision/interface.go
+++ b/pkg/provision/interface.go
@@ -15,6 +15,12 @@ type ReservationSource interface {
 	Reservations(ctx context.Context) <-chan *ReservationJob
 }
 
+// ReservationGetter interface. Some reservation sources
+// can implement the getter interface
+type ReservationGetter interface {
+	Get(gwid string) (*Reservation, error)
+}
+
 // ProvisionerFunc is the function called by the Engine to provision a workload
 type ProvisionerFunc func(ctx context.Context, reservation *Reservation) (interface{}, error)
 

--- a/pkg/provision/source.go
+++ b/pkg/provision/source.go
@@ -24,6 +24,7 @@ var (
 // ReservationPoller define the interface to implement
 // to poll the Explorer for new reservation
 type ReservationPoller interface {
+	ReservationGetter
 	// Poll ask the store to send us reservation for a specific node ID
 	// from is the used as a filter to which reservation to use as
 	// reservation.ID >= from. So a client to the Poll method should make

--- a/pkg/provision/source_test.go
+++ b/pkg/provision/source_test.go
@@ -20,6 +20,10 @@ func (s *TestPollSource) Poll(nodeID pkg.Identifier, from uint64) ([]*Reservatio
 	return returns.Get(0).([]*Reservation), uint64(returns.Get(1).(int)), returns.Error(2)
 }
 
+func (s *TestPollSource) Get(gwid string) (*Reservation, error) {
+	return nil, fmt.Errorf("unimplemented")
+}
+
 func TestHTTPReservationSource(t *testing.T) {
 	require := require.New(t)
 	var store TestPollSource
@@ -84,6 +88,10 @@ type TestTrackSource struct {
 	Max   uint64
 	ID    uint64
 	Calls []int64
+}
+
+func (s *TestTrackSource) Get(gwid string) (*Reservation, error) {
+	return nil, fmt.Errorf("unimplemented")
 }
 
 func (s *TestTrackSource) Poll(nodeID pkg.Identifier, from uint64) ([]*Reservation, uint64, error) {

--- a/pkg/storage.go
+++ b/pkg/storage.go
@@ -178,8 +178,8 @@ type VDisk struct {
 	Size int64
 }
 
-// ID returns the ID part of the disk path
-func (d *VDisk) ID() string {
+// Name returns the Name part of the disk path
+func (d *VDisk) Name() string {
 	return filepath.Base(d.Path)
 }
 

--- a/pkg/storage.go
+++ b/pkg/storage.go
@@ -3,6 +3,7 @@ package pkg
 import (
 	"context"
 	"fmt"
+	"path/filepath"
 )
 
 //go:generate mkdir -p stubs
@@ -177,6 +178,11 @@ type VDisk struct {
 	Size int64
 }
 
+// ID returns the ID part of the disk path
+func (d *VDisk) ID() string {
+	return filepath.Base(d.Path)
+}
+
 // VDiskModule interface
 type VDiskModule interface {
 	// AllocateDisk with given id and size, return path to virtual disk
@@ -187,6 +193,8 @@ type VDiskModule interface {
 	Exists(id string) bool
 	// Inspect return info about the disk
 	Inspect(id string) (VDisk, error)
+	// List lists all the available vdisks
+	List() ([]VDisk, error)
 }
 
 // StorageModule defines the api for storage

--- a/pkg/storage/disk.go
+++ b/pkg/storage/disk.go
@@ -2,6 +2,7 @@ package storage
 
 import (
 	"fmt"
+	"io/ioutil"
 	"os"
 	"path/filepath"
 	"syscall"
@@ -115,4 +116,25 @@ func (d *vdiskModule) Inspect(id string) (disk pkg.VDisk, err error) {
 
 	disk.Size = stat.Size()
 	return
+}
+
+func (d *vdiskModule) List() ([]pkg.VDisk, error) {
+	items, err := ioutil.ReadDir(d.path)
+	if err != nil {
+		return nil, errors.Wrap(err, "failed to list virtual disks")
+	}
+
+	disks := make([]pkg.VDisk, 0, len(items))
+	for _, item := range items {
+		if item.IsDir() {
+			continue
+		}
+
+		disks = append(disks, pkg.VDisk{
+			Path: filepath.Join(d.path, item.Name()),
+			Size: item.Size(),
+		})
+	}
+
+	return disks, nil
 }

--- a/pkg/stubs/vdisk_stub.go
+++ b/pkg/stubs/vdisk_stub.go
@@ -78,3 +78,19 @@ func (s *VDiskModuleStub) Inspect(arg0 string) (ret0 pkg.VDisk, ret1 error) {
 	}
 	return
 }
+
+func (s *VDiskModuleStub) List() (ret0 []pkg.VDisk, ret1 error) {
+	args := []interface{}{}
+	result, err := s.client.Request(s.module, s.object, "List", args...)
+	if err != nil {
+		panic(err)
+	}
+	if err := result.Unmarshal(0, &ret0); err != nil {
+		panic(err)
+	}
+	ret1 = new(zbus.RemoteError)
+	if err := result.Unmarshal(1, &ret1); err != nil {
+		panic(err)
+	}
+	return
+}


### PR DESCRIPTION
Fixes #1037

- The code has been refactor for readability and mainly abstraction. Janitor code should not be aware of the source of reservation. Hence should not be allowed to created an instance of the explorer client itself since that is hidden by the Source of the provision engine.
- Add clean up for vdisks