### PR TITLE
Vdisk allocation fix

### DIFF
--- a/pkg/provision/engine.go
+++ b/pkg/provision/engine.go
@@ -310,6 +310,18 @@ func (e *Engine) decommission(ctx context.Context, r *Reservation) error {
 		r.ID = r.Reference
 	}
 
+	if r.Result.State == StateError {
+		// this reservation already failed to deploy
+		// this code here shouldn't be executing because if
+		// the reservation has error-ed, it means is should
+		// not be in cache.
+		// BUT
+		// that was not always the case, so instead we
+		// will just return. here
+		log.Warn().Str("id", realID).Msg("skipping reservation because it is not provisioned")
+		return nil
+	}
+
 	err = fn(ctx, r)
 	if err != nil {
 		return errors.Wrap(err, "decommissioning of reservation failed")

--- a/pkg/provision/engine.go
+++ b/pkg/provision/engine.go
@@ -235,23 +235,29 @@ func (e *Engine) provision(ctx context.Context, r *Reservation) error {
 		return errors.Wrapf(err, "failed to build result object for reservation: %s", result.ID)
 	}
 
-	// we make sure we store the reservation in cache first before
-	// returning the reply back to the grid, this is to make sure
-	// if the reply failed for any reason, the node still doesn't
-	// try to redeploy that reservation.
-	r.ID = realID
-	r.Result = *result
-	if err := e.cache.Add(r); err != nil {
-		return errors.Wrapf(err, "failed to cache reservation %s locally", r.ID)
-	}
-
+	// send response to explorer
 	if err := e.reply(ctx, result); err != nil {
 		log.Error().Err(err).Msg("failed to send result to BCDB")
 	}
 
-	// we skip the counting.
+	// if we fail to decomission the reservation then must be marked
+	// as deleted so it's never tried again. we also skip caching
+	// the reservation object. this is similar to what decomission does
+	// since on a decomission we also clear up the cache.
 	if provisionError != nil {
+		// we need to mark the reservation as deleted as well
+		if err := e.feedback.Deleted(e.nodeID, realID); err != nil {
+			log.Error().Err(err).Msg("failed to mark failed reservation as deleted")
+		}
+
 		return provisionError
+	}
+
+	// we only cache successful reservations
+	r.ID = realID
+	r.Result = *result
+	if err := e.cache.Add(r); err != nil {
+		return errors.Wrapf(err, "failed to cache reservation %s locally", r.ID)
 	}
 
 	// If an update occurs on the network we don't increment the counter

--- a/pkg/storage.go
+++ b/pkg/storage.go
@@ -165,14 +165,6 @@ type VolumeAllocater interface {
 
 	// GetCacheFS return the special filesystem used by 0-OS to store internal state and flist cache
 	GetCacheFS() (Filesystem, error)
-
-	// GetVdiskFS return the filesystem used to store the vdisk file for the VM module
-	GetVdiskFS() (Filesystem, error)
-
-	// CanAllocate checks if the given subvolume name can use this given size
-	// it checks against physical disk space first if there is enough capacity
-	// to support this, and if okay, it checks against the subvolume quota limit if set
-	CanAllocate(name string, size uint64) (bool, error)
 }
 
 // VDisk info returned by a call to inspect

--- a/pkg/storage/disk.go
+++ b/pkg/storage/disk.go
@@ -19,44 +19,50 @@ const (
 )
 
 type vdiskModule struct {
-	v    pkg.VolumeAllocater
-	path string
+	module *Module
 }
 
 // NewVDiskModule creates a new disk allocator
-func NewVDiskModule(v pkg.VolumeAllocater) (pkg.VDiskModule, error) {
-	fs, err := v.Path(vdiskVolumeName)
-	if errors.Is(err, os.ErrNotExist) {
-		fs, err = v.CreateFilesystem(vdiskVolumeName, 0, pkg.SSDDevice)
-	}
+func NewVDiskModule(module *Module) (pkg.VDiskModule, error) {
+	return &vdiskModule{module: module}, nil
+}
 
+func (d *vdiskModule) findDisk(id string) (string, error) {
+	pools, err := d.module.VDiskPools()
 	if err != nil {
-		return nil, err
+		return "", errors.Wrapf(err, "failed to find disk with id '%s'", id)
 	}
 
-	return &vdiskModule{v: v, path: filepath.Clean(fs.Path)}, nil
+	for _, pool := range pools {
+		path, err := d.safePath(pool, id)
+		if err != nil {
+			return "", err
+		}
+
+		if _, err := os.Stat(path); err == nil {
+			// file exists
+			return path, nil
+		}
+	}
+
+	return "", os.ErrNotExist
 }
 
 // AllocateDisk with given size, return path to virtual disk (size in MB)
 func (d *vdiskModule) Allocate(id string, size int64) (string, error) {
-	path, err := d.safePath(id)
-	if err != nil {
-		return "", err
-	}
-
-	if _, err := os.Stat(path); err == nil {
-		// file exists
+	path, err := d.findDisk(id)
+	if err == nil {
 		return path, errors.Wrapf(os.ErrExist, "disk with id '%s' already exists", id)
 	}
 
-	supported, err := d.v.CanAllocate(vdiskVolumeName, uint64(size))
+	base, err := d.module.VDiskFindCandidate(uint64(size))
 	if err != nil {
-		return path, errors.Wrap(err, "failed to check capacity for this disk allocation")
+		return "", errors.Wrap(err, "failed to find a candidate to host vdisk")
 	}
 
-	if !supported {
-		// TODO: we need to find another disk on this node if possible
-		return path, fmt.Errorf("not enough space available for this disk size")
+	path, err = d.safePath(base, id)
+	if err != nil {
+		return "", err
 	}
 
 	file, err := os.Create(path)
@@ -69,13 +75,13 @@ func (d *vdiskModule) Allocate(id string, size int64) (string, error) {
 	return path, syscall.Fallocate(int(file.Fd()), 0, 0, size*mib)
 }
 
-func (d *vdiskModule) safePath(id string) (string, error) {
-	path := filepath.Join(d.path, id)
+func (d *vdiskModule) safePath(base, id string) (string, error) {
+	path := filepath.Join(base, id)
 	// this to avoid passing an `injection` id like '../name'
 	// and end up deleting a file on the system. so only delete
 	// allocated disks
 	location := filepath.Dir(path)
-	if filepath.Clean(location) != d.path {
+	if filepath.Clean(location) != base {
 		return "", fmt.Errorf("invalid disk id: '%s'", id)
 	}
 
@@ -84,8 +90,10 @@ func (d *vdiskModule) safePath(id string) (string, error) {
 
 // DeallocateVDisk removes a virtual disk
 func (d *vdiskModule) Deallocate(id string) error {
-	path, err := d.safePath(id)
-	if err != nil {
+	path, err := d.findDisk(id)
+	if os.IsNotExist(err) {
+		return nil
+	} else if err != nil {
 		return err
 	}
 
@@ -98,24 +106,16 @@ func (d *vdiskModule) Deallocate(id string) error {
 
 // DeallocateVDisk removes a virtual disk
 func (d *vdiskModule) Exists(id string) bool {
-	path, err := d.safePath(id)
-
-	if err != nil {
-		// invalid ID
-		return false
-	}
-
-	_, err = os.Stat(path)
+	_, err := d.findDisk(id)
 
 	return err == nil
 }
 
 // Inspect return info about the disk
 func (d *vdiskModule) Inspect(id string) (disk pkg.VDisk, err error) {
-	path, err := d.safePath(id)
+	path, err := d.findDisk(id)
 
 	if err != nil {
-		// invalid ID
 		return disk, err
 	}
 
@@ -130,21 +130,30 @@ func (d *vdiskModule) Inspect(id string) (disk pkg.VDisk, err error) {
 }
 
 func (d *vdiskModule) List() ([]pkg.VDisk, error) {
-	items, err := ioutil.ReadDir(d.path)
+	pools, err := d.module.VDiskPools()
 	if err != nil {
-		return nil, errors.Wrap(err, "failed to list virtual disks")
+		return nil, err
 	}
+	var disks []pkg.VDisk
+	for _, pool := range pools {
 
-	disks := make([]pkg.VDisk, 0, len(items))
-	for _, item := range items {
-		if item.IsDir() {
-			continue
+		items, err := ioutil.ReadDir(pool)
+		if err != nil {
+			return nil, errors.Wrap(err, "failed to list virtual disks")
 		}
 
-		disks = append(disks, pkg.VDisk{
-			Path: filepath.Join(d.path, item.Name()),
-			Size: item.Size(),
-		})
+		for _, item := range items {
+			if item.IsDir() {
+				continue
+			}
+
+			disks = append(disks, pkg.VDisk{
+				Path: filepath.Join(pool, item.Name()),
+				Size: item.Size(),
+			})
+		}
+
+		return disks, nil
 	}
 
 	return disks, nil

--- a/pkg/storage/disk.go
+++ b/pkg/storage/disk.go
@@ -57,7 +57,7 @@ func (d *vdiskModule) Allocate(id string, size int64) (string, error) {
 
 	base, err := d.module.VDiskFindCandidate(uint64(size))
 	if err != nil {
-		return "", errors.Wrap(err, "failed to find a candidate to host vdisk")
+		return "", errors.Wrapf(err, "failed to find a candidate to host vdisk of size '%d'", size)
 	}
 
 	path, err = d.safePath(base, id)

--- a/pkg/storage/storage_test.go
+++ b/pkg/storage/storage_test.go
@@ -164,7 +164,7 @@ func TestCreateSubvol(t *testing.T) {
 		ptype: pkg.HDDDevice,
 	}
 
-	mod := storageModule{
+	mod := Module{
 		pools: []filesystem.Pool{
 			pool1, pool2, pool3,
 		},
@@ -219,7 +219,7 @@ func TestCreateSubvolUnlimited(t *testing.T) {
 		ptype: pkg.HDDDevice,
 	}
 
-	mod := storageModule{
+	mod := Module{
 		pools: []filesystem.Pool{
 			pool1, pool2, pool3,
 		},
@@ -274,7 +274,7 @@ func TestCreateSubvolNoSpaceLeft(t *testing.T) {
 		ptype: pkg.HDDDevice,
 	}
 
-	mod := storageModule{
+	mod := Module{
 		pools: []filesystem.Pool{
 			pool1, pool2, pool3,
 		},
@@ -288,12 +288,12 @@ func TestCreateSubvolNoSpaceLeft(t *testing.T) {
 	require.EqualError(err, "Not enough space left in pools of this type ssd")
 }
 
-func TestCanAllocateUsageNoReservation(t *testing.T) {
+func TestVDiskFindCandidatesHasEnoughSpace(t *testing.T) {
 	require := require.New(t)
 
 	pool1 := &testPool{
 		name:     "pool-1",
-		reserved: 0,
+		reserved: 2000,
 		usage: filesystem.Usage{
 			Size: 10000,
 			Used: 100,
@@ -301,106 +301,155 @@ func TestCanAllocateUsageNoReservation(t *testing.T) {
 		ptype: pkg.SSDDevice,
 	}
 
-	mod := &storageModule{
+	pool2 := &testPool{
+		name:     "pool-2",
+		reserved: 1000,
+		usage: filesystem.Usage{
+			Size: 10000,
+			Used: 100,
+		},
+		ptype: pkg.SSDDevice,
+	}
+
+	pool3 := &testPool{
+		name:     "pool-3",
+		reserved: 0,
+		usage: filesystem.Usage{
+			Size: 100000,
+			Used: 0,
+		},
+		ptype: pkg.HDDDevice,
+	}
+
+	mod := Module{
 		pools: []filesystem.Pool{
-			pool1,
+			pool1, pool2, pool3,
 		},
 	}
 
-	pool1.On("Volumes").Return([]filesystem.Volume{
-		&testVolume{
-			name: "vdisk",
-		},
-	}, nil)
+	sub := &testVolume{
+		name: vdiskVolumeName,
+	}
 
-	can, err := mod.CanAllocate("vdisk", 100)
-	require.NoError(err)
-	require.True(can)
+	// pool3.On("AddVolume", "sub").Return(sub, nil)
+	// sub.On("Limit", uint64(0)).Return(nil)
 
-	can, err = mod.CanAllocate("vdisk", 1900)
-	require.NoError(err)
-	require.True(can)
+	pool1.On("Volumes").Return([]filesystem.Volume{sub}, nil)
+	pool2.On("Volumes").Return([]filesystem.Volume{}, nil)
+	pool3.On("Volumes").Return([]filesystem.Volume{}, nil)
 
-	can, err = mod.CanAllocate("vdisk", 10000)
+	_, err := mod.VDiskFindCandidate(500)
+
 	require.NoError(err)
-	require.False(can)
 }
 
-func TestCanAllocateReservationNoUsage(t *testing.T) {
+func TestVDiskFindCandidatesWrongType(t *testing.T) {
 	require := require.New(t)
 
 	pool1 := &testPool{
 		name:     "pool-1",
-		reserved: 5000,
+		reserved: 2000,
 		usage: filesystem.Usage{
 			Size: 10000,
+			Used: 100,
+		},
+		ptype: pkg.SSDDevice,
+	}
+
+	pool2 := &testPool{
+		name:     "pool-2",
+		reserved: 1000,
+		usage: filesystem.Usage{
+			Size: 10000,
+			Used: 100,
+		},
+		ptype: pkg.SSDDevice,
+	}
+
+	pool3 := &testPool{
+		name:     "pool-3",
+		reserved: 0,
+		usage: filesystem.Usage{
+			Size: 100000,
+			Used: 0,
+		},
+		ptype: pkg.HDDDevice,
+	}
+
+	mod := Module{
+		pools: []filesystem.Pool{
+			pool1, pool2, pool3,
+		},
+	}
+
+	sub := &testVolume{
+		name: vdiskVolumeName,
+	}
+
+	pool3.On("AddVolume", vdiskVolumeName).Return(sub, nil)
+
+	pool1.On("Volumes").Return([]filesystem.Volume{sub}, nil)
+	pool2.On("Volumes").Return([]filesystem.Volume{}, nil)
+	pool3.On("Volumes").Return([]filesystem.Volume{}, nil)
+
+	_, err := mod.VDiskFindCandidate(10000)
+	require.EqualError(err, "Not enough space left in pools of this type ssd")
+
+}
+
+func TestVDiskFindCandidatesNoSpace(t *testing.T) {
+	require := require.New(t)
+
+	pool1 := &testPool{
+		name:     "pool-1",
+		reserved: 2000,
+		usage: filesystem.Usage{
+			Size: 10000,
+			Used: 100,
+		},
+		ptype: pkg.SSDDevice,
+	}
+
+	pool2 := &testPool{
+		name:     "pool-2",
+		reserved: 1000,
+		usage: filesystem.Usage{
+			Size: 10000,
+			Used: 100,
+		},
+		ptype: pkg.SSDDevice,
+	}
+
+	pool3 := &testPool{
+		name:     "pool-3",
+		reserved: 0,
+		usage: filesystem.Usage{
+			Size: 100000,
 			Used: 0,
 		},
 		ptype: pkg.SSDDevice,
 	}
 
-	mod := &storageModule{
+	mod := Module{
 		pools: []filesystem.Pool{
-			pool1,
+			pool1, pool2, pool3,
 		},
 	}
 
-	pool1.On("Volumes").Return([]filesystem.Volume{
-		&testVolume{
-			name: "vdisk",
-		},
-	}, nil)
-
-	can, err := mod.CanAllocate("vdisk", 100)
-	require.NoError(err)
-	require.True(can)
-
-	can, err = mod.CanAllocate("vdisk", 5000)
-	require.NoError(err)
-	require.True(can)
-
-	can, err = mod.CanAllocate("vdisk", 6000)
-	require.NoError(err)
-	require.False(can)
-}
-
-func TestCanAllocateLimit(t *testing.T) {
-	require := require.New(t)
-
-	pool1 := &testPool{
-		name:     "pool-1",
-		reserved: 5000,
-		usage: filesystem.Usage{
-			Size: 10000,
-			Used: 0,
-		},
-		ptype: pkg.SSDDevice,
+	sub := &testVolume{
+		name: vdiskVolumeName,
 	}
 
-	mod := &storageModule{
-		pools: []filesystem.Pool{
-			pool1,
-		},
+	pool3.On("AddVolume", vdiskVolumeName).Return(sub, nil)
+
+	pool1.On("Volumes").Return([]filesystem.Volume{sub}, nil)
+	pool2.On("Volumes").Return([]filesystem.Volume{}, nil)
+	pool3.On("Volumes").Return([]filesystem.Volume{}, nil)
+
+	_, err := mod.VDiskFindCandidate(10000)
+	require.NoError(err)
+
+	if ok := pool3.AssertCalled(t, "AddVolume", vdiskVolumeName); !ok {
+		t.Fail()
 	}
-
-	pool1.On("Volumes").Return([]filesystem.Volume{
-		&testVolume{
-			name: "vdisk",
-			usage: filesystem.Usage{
-				Size: 2000,
-			},
-		},
-	}, nil)
-
-	can, err := mod.CanAllocate("vdisk", 100)
-	require.NoError(err)
-	require.True(can)
-
-	can, err = mod.CanAllocate("vdisk", 1500)
-	require.NoError(err)
-	require.True(can)
-
-	can, err = mod.CanAllocate("vdisk", 2100)
-	require.NoError(err)
-	require.False(can)
 }

--- a/pkg/storage/zdb.go
+++ b/pkg/storage/zdb.go
@@ -15,6 +15,7 @@ import (
 	"github.com/threefoldtech/zos/pkg/storage/zdbpool"
 )
 
+// Find finds a zdb namespace allocation
 func (s *Module) Find(nsID string) (allocation pkg.Allocation, err error) {
 	for _, pool := range s.pools {
 		if _, mounted := pool.Mounted(); !mounted {

--- a/pkg/storage/zdb.go
+++ b/pkg/storage/zdb.go
@@ -15,7 +15,7 @@ import (
 	"github.com/threefoldtech/zos/pkg/storage/zdbpool"
 )
 
-func (s *storageModule) Find(nsID string) (allocation pkg.Allocation, err error) {
+func (s *Module) Find(nsID string) (allocation pkg.Allocation, err error) {
 	for _, pool := range s.pools {
 		if _, mounted := pool.Mounted(); !mounted {
 			continue
@@ -54,7 +54,7 @@ func (s *storageModule) Find(nsID string) (allocation pkg.Allocation, err error)
 // Allocate is responsible to make sure the subvolume used by a 0-db as enough storage capacity
 // of specified size, type and mode
 // it returns the volume ID and its path or an error if it couldn't allocate enough storage
-func (s *storageModule) Allocate(nsID string, diskType pkg.DeviceType, size uint64, mode pkg.ZDBMode) (allocation pkg.Allocation, err error) {
+func (s *Module) Allocate(nsID string, diskType pkg.DeviceType, size uint64, mode pkg.ZDBMode) (allocation pkg.Allocation, err error) {
 	log := log.With().
 		Str("type", string(diskType)).
 		Uint64("size", size).
@@ -163,7 +163,7 @@ type zdbcandidate struct {
 	Free uint64
 }
 
-func (s *storageModule) checkForZDBCandidateVolumes(size uint64, poolType pkg.DeviceType, targetMode zdbpool.IndexMode) ([]zdbcandidate, error) {
+func (s *Module) checkForZDBCandidateVolumes(size uint64, poolType pkg.DeviceType, targetMode zdbpool.IndexMode) ([]zdbcandidate, error) {
 	var candidates []zdbcandidate
 	for _, pool := range s.pools {
 		// ignore pools that are not mounted for now

--- a/pkg/stubs/storage_stub.go
+++ b/pkg/stubs/storage_stub.go
@@ -2,6 +2,7 @@ package stubs
 
 import (
 	"context"
+
 	zbus "github.com/threefoldtech/zbus"
 	pkg "github.com/threefoldtech/zos/pkg"
 )
@@ -63,22 +64,6 @@ func (s *StorageModuleStub) BrokenPools() (ret0 []pkg.BrokenPool) {
 	return
 }
 
-func (s *StorageModuleStub) CanAllocate(arg0 string, arg1 uint64) (ret0 bool, ret1 error) {
-	args := []interface{}{arg0, arg1}
-	result, err := s.client.Request(s.module, s.object, "CanAllocate", args...)
-	if err != nil {
-		panic(err)
-	}
-	if err := result.Unmarshal(0, &ret0); err != nil {
-		panic(err)
-	}
-	ret1 = new(zbus.RemoteError)
-	if err := result.Unmarshal(1, &ret1); err != nil {
-		panic(err)
-	}
-	return
-}
-
 func (s *StorageModuleStub) CreateFilesystem(arg0 string, arg1 uint64, arg2 pkg.DeviceType) (ret0 pkg.Filesystem, ret1 error) {
 	args := []interface{}{arg0, arg1, arg2}
 	result, err := s.client.Request(s.module, s.object, "CreateFilesystem", args...)
@@ -114,22 +99,6 @@ func (s *StorageModuleStub) Find(arg0 string) (ret0 pkg.Allocation, ret1 error) 
 func (s *StorageModuleStub) GetCacheFS() (ret0 pkg.Filesystem, ret1 error) {
 	args := []interface{}{}
 	result, err := s.client.Request(s.module, s.object, "GetCacheFS", args...)
-	if err != nil {
-		panic(err)
-	}
-	if err := result.Unmarshal(0, &ret0); err != nil {
-		panic(err)
-	}
-	ret1 = new(zbus.RemoteError)
-	if err := result.Unmarshal(1, &ret1); err != nil {
-		panic(err)
-	}
-	return
-}
-
-func (s *StorageModuleStub) GetVdiskFS() (ret0 pkg.Filesystem, ret1 error) {
-	args := []interface{}{}
-	result, err := s.client.Request(s.module, s.object, "GetVdiskFS", args...)
 	if err != nil {
 		panic(err)
 	}


### PR DESCRIPTION
Fixes #1059

This fixes 2 issues:
- First one regarding reservation caching. A failed reservation should not be cached, otherwise it causes counters discrepancy (still testing this for now)
- The bigger changes are related to vdisk allocation the new code will utilize ALL disks if needed 