### PR TITLE
If no-keep-alive flag is set do not restart the machine

### DIFF
--- a/pkg/provision/primitives/kubernetes.go
+++ b/pkg/provision/primitives/kubernetes.go
@@ -201,6 +201,7 @@ func (p *Provisioner) kubernetesInstall(ctx context.Context, name string, cpu ui
 		InitrdImage: imagePath + "/k3os-initrd-amd64",
 		KernelArgs:  cmdline,
 		Disks:       disks,
+		NoKeepAlive: true, //machine will not restarted automatically when it exists
 	}
 
 	if err := vm.Run(installVM); err != nil {

--- a/pkg/vm.go
+++ b/pkg/vm.go
@@ -48,6 +48,11 @@ type VM struct {
 	// Disks are a list of disks that are going to
 	// be auto allocated on the provided storage path
 	Disks []VMDisk
+	// If this flag is set, the VM module will not auto start
+	// this machine hence, also no auto clean up when it exits
+	// it's up to the caller to check for the machine status
+	// and do clean up (module.Delete(vm)) when needed
+	NoKeepAlive bool
 }
 
 // Validate vm data

--- a/pkg/vm/manager.go
+++ b/pkg/vm/manager.go
@@ -274,6 +274,10 @@ func (m *Module) Run(vm pkg.VM) error {
 
 	logFile := jailed.Log(m.root)
 
+	if vm.NoKeepAlive {
+		m.failures.Set(jailed.ID, permanent, cache.NoExpiration)
+	}
+
 	if err = jailed.Start(ctx); err != nil {
 		return m.withLogs(logFile, err)
 	}
@@ -342,10 +346,11 @@ func (m *Module) Inspect(name string) (pkg.VMInfo, error) {
 // Delete deletes a machine by name (id)
 func (m *Module) Delete(name string) error {
 	defer m.cleanFs(name)
+	defer m.failures.Delete(name)
 
 	// before we do anything we set failures to permanent to prevent monitoring from trying
 	// to revive this machine
-	m.failures.Set(name, permanent, cache.DefaultExpiration)
+	m.failures.Set(name, permanent, cache.NoExpiration)
 
 	pid, err := find(name)
 	if err != nil {

--- a/pkg/vm/monitor.go
+++ b/pkg/vm/monitor.go
@@ -19,6 +19,9 @@ const (
 )
 
 var (
+	// if the failures marker is set to permanent it means
+	// the monitoring will not try to restart this machine
+	// when it detects that it is down.
 	permanent = struct{}{}
 )
 
@@ -90,7 +93,7 @@ func (m *Module) monitorID(ctx context.Context, running map[string]int, id strin
 
 	if marker == permanent {
 		// if the marker is permanent. it means that this vm
-		// is being deleted. we don't need to take any more action here
+		// is being deleted or not monitored. we don't need to take any more action here
 		// (don't try to restart or delete)
 		log.Debug().Msg("permanent delete marker is set")
 		return nil
@@ -115,7 +118,6 @@ func (m *Module) monitorID(ctx context.Context, running map[string]int, id strin
 		if reason == nil {
 			reason = m.waitAndAdjOom(ctx, id)
 		}
-
 	} else {
 		reason = fmt.Errorf("deleting vm due to so many crashes")
 	}


### PR DESCRIPTION
This is needed by the provision process for the installation
to work since the machine shutsdown when it's done with the
installations