### PR TITLE
Vm pub ip

### DIFF
--- a/cmds/networkd/main.go
+++ b/cmds/networkd/main.go
@@ -122,11 +122,6 @@ func main() {
 		log.Fatal().Err(err).Msgf("fail to configure yggdrasil subnet gateway IP")
 	}
 
-	// make sure ndmz has a way out
-	if err := ndmzNs.EnsureRoutable(); err != nil {
-		log.Fatal().Err(err).Msg("failed to ensure ndmz routability")
-	}
-
 	// send another detail of network interfaces now that ndmz is created
 	ndmzIfaces, err := getNdmzInterfaces()
 	if err != nil {

--- a/cmds/networkd/main.go
+++ b/cmds/networkd/main.go
@@ -99,16 +99,16 @@ func main() {
 		}
 	}
 
-	ndmz, err := buildNDMZ(nodeID.Identity())
+	ndmzNs, err := buildNDMZ(nodeID.Identity())
 	if err != nil {
 		log.Fatal().Err(err).Msg("failed to create ndmz")
 	}
 
-	if err := ndmz.Create(ctx); err != nil {
+	if err := ndmzNs.Create(ctx); err != nil {
 		log.Fatal().Err(err).Msg("failed to create ndmz")
 	}
 
-	ygg, err := startYggdrasil(ctx, identity.PrivateKey(), ndmz)
+	ygg, err := startYggdrasil(ctx, identity.PrivateKey(), ndmzNs)
 	if err != nil {
 		log.Fatal().Err(err).Msgf("fail to start yggdrasil")
 	}
@@ -118,9 +118,13 @@ func main() {
 		log.Fatal().Err(err).Msgf("fail read yggdrasil subnet")
 	}
 
-	if err := ndmz.SetIP6PublicIface(gw); err != nil {
+	if err := ndmzNs.SetIP6PublicIface(gw); err != nil {
 		log.Fatal().Err(err).Msgf("fail to configure yggdrasil subnet gateway IP")
+	}
 
+	// make sure ndmz has a way out
+	if err := ndmzNs.EnsureRoutable(); err != nil {
+		log.Fatal().Err(err).Msg("failed to ensure ndmz routability")
 	}
 
 	// send another detail of network interfaces now that ndmz is created
@@ -143,7 +147,7 @@ func main() {
 		log.Fatal().Err(err).Msgf("fail to create module root")
 	}
 
-	networker, err := network.NewNetworker(identity, directory, root, ndmz, ygg)
+	networker, err := network.NewNetworker(identity, directory, root, ndmzNs, ygg)
 	if err != nil {
 		log.Fatal().Err(err).Msg("error creating network manager")
 	}

--- a/cmds/networkd/pubiface.go
+++ b/cmds/networkd/pubiface.go
@@ -10,6 +10,7 @@ import (
 	"github.com/threefoldtech/zos/pkg"
 	"github.com/threefoldtech/zos/pkg/network"
 	"github.com/threefoldtech/zos/pkg/network/namespace"
+	"github.com/threefoldtech/zos/pkg/network/ndmz"
 	"github.com/threefoldtech/zos/pkg/network/types"
 )
 
@@ -75,7 +76,7 @@ func watchPubIface(ctx context.Context, nodeID pkg.Identifier, dir client.Direct
 	return ch
 }
 
-func configurePubIface(iface *types.PubIface, nodeID pkg.Identifier) error {
+func configurePubIface(dmz ndmz.DMZ, iface *types.PubIface, nodeID pkg.Identifier) error {
 	cleanup := func() error {
 		pubNs, err := namespace.GetByName(types.PublicNamespace)
 		if err != nil {
@@ -89,7 +90,7 @@ func configurePubIface(iface *types.PubIface, nodeID pkg.Identifier) error {
 		return nil
 	}
 
-	if err := network.CreatePublicNS(iface, nodeID); err != nil {
+	if err := network.CreatePublicNS(dmz, iface, nodeID); err != nil {
 		_ = cleanup()
 		return errors.Wrap(err, "failed to configure public namespace")
 	}

--- a/go.mod
+++ b/go.mod
@@ -49,5 +49,3 @@ require (
 )
 
 replace github.com/docker/distribution v2.7.1+incompatible => github.com/docker/distribution v2.7.1-0.20190205005809-0d3efadf0154+incompatible
-
-replace github.com/threefoldtech/zbus => ../zbus

--- a/go.mod
+++ b/go.mod
@@ -33,7 +33,7 @@ require (
 	github.com/stretchr/testify v1.6.1
 	github.com/termie/go-shutil v0.0.0-20140729215957-bcacb06fecae
 	github.com/threefoldtech/0-fs v1.3.1-0.20201111155454-6f328c14703a
-	github.com/threefoldtech/tfexplorer v0.4.1-0.20201014110255-653c7314b944
+	github.com/threefoldtech/tfexplorer v0.4.1-0.20201120111415-6fefe983b035
 	github.com/threefoldtech/zbus v0.1.4
 	github.com/urfave/cli v1.22.4
 	github.com/vishvananda/netlink v1.1.0
@@ -49,7 +49,5 @@ require (
 )
 
 replace github.com/docker/distribution v2.7.1+incompatible => github.com/docker/distribution v2.7.1-0.20190205005809-0d3efadf0154+incompatible
-
-replace github.com/threefoldtech/tfexplorer v0.4.1-0.20201014110255-653c7314b944 => ../tfexplorer
 
 replace github.com/threefoldtech/zbus => ../zbus

--- a/go.mod
+++ b/go.mod
@@ -49,3 +49,7 @@ require (
 )
 
 replace github.com/docker/distribution v2.7.1+incompatible => github.com/docker/distribution v2.7.1-0.20190205005809-0d3efadf0154+incompatible
+
+replace github.com/threefoldtech/tfexplorer v0.4.1-0.20201014110255-653c7314b944 => ../tfexplorer
+
+replace github.com/threefoldtech/zbus => ../zbus

--- a/go.sum
+++ b/go.sum
@@ -606,6 +606,8 @@ github.com/threefoldtech/tfexplorer v0.3.2-0.20200918135528-58e333897454 h1:MUtG
 github.com/threefoldtech/tfexplorer v0.3.2-0.20200918135528-58e333897454/go.mod h1:fA2oR3D6Wre9tXSiWFiapeuUI5UA9aXP9fejr6hDEYM=
 github.com/threefoldtech/tfexplorer v0.4.1-0.20201014110255-653c7314b944 h1:jJG/lUhZVn70RWzi79nxrTQHWpd6Thb4lB+klQfVCiU=
 github.com/threefoldtech/tfexplorer v0.4.1-0.20201014110255-653c7314b944/go.mod h1:6thp8ja7vDbtGAn91mcYL2wUmDGBoUdxJKHceC3xIaE=
+github.com/threefoldtech/tfexplorer v0.4.1-0.20201120111415-6fefe983b035 h1:/WRli4BS1VT1Q8nJAsHlVGwtosQ+Cktx6JJnZTAF4cU=
+github.com/threefoldtech/tfexplorer v0.4.1-0.20201120111415-6fefe983b035/go.mod h1:6thp8ja7vDbtGAn91mcYL2wUmDGBoUdxJKHceC3xIaE=
 github.com/threefoldtech/zbus v0.1.3 h1:18DnIzximRbATle5ZdZz0i84n/bCYB8k/gkhr2dXayc=
 github.com/threefoldtech/zbus v0.1.3/go.mod h1:ZtiRpcqzEBJetVQDsEbw0p48h/AF3O1kf0tvd30I0BU=
 github.com/threefoldtech/zbus v0.1.4 h1:c8lF4H9HMDJGknhcEK2p+zJWWM09fByGe3uL9m/iKgM=

--- a/pkg/network.go
+++ b/pkg/network.go
@@ -72,9 +72,16 @@ type Networker interface {
 	// GetSubnet of the network with the given ID on the local node
 	GetSubnet(networkID NetID) (net.IPNet, error)
 
-	// GetDefaultGwIP returns the IP(v4) of the default gateway inside the network
-	// resource identified by the network ID on the local node
-	GetDefaultGwIP(networkID NetID) (net.IP, error)
+	// GetNet returns the full network range of the network
+	GetNet(networkID NetID) (net.IPNet, error)
+
+	// GetDefaultGwIP returns the IPs of the default gateways inside the network
+	// resource identified by the network ID on the local node, for IPv4 and IPv6
+	// repsectively
+	GetDefaultGwIP(networkID NetID) (net.IP, net.IP, error)
+
+	// GetIPv6From4 generates an IPv6 address from a given IPv4 address in a NR
+	GetIPv6From4(networkID NetID, ip net.IP) (net.IPNet, error)
 
 	// Addrs return the IP addresses of interface
 	// if the interface is in a network namespace netns needs to be not empty

--- a/pkg/network.go
+++ b/pkg/network.go
@@ -69,6 +69,20 @@ type Networker interface {
 	// of the networkID
 	RemoveTap(networkID NetID) error
 
+	// PublicIPv4Support enabled on this node for reservations
+	PublicIPv4Support() bool
+
+	// SetupPubTap sets up a tap device in the host namespace for the networkID. It is hooked
+	// to the public bridge. The name of the tap interface is returned
+	SetupPubTap(networkID NetID) (string, error)
+
+	// PubTapExists checks if the tap device for the public network exists already
+	PubTapExists(networkID NetID) (bool, error)
+
+	// RemovePubTap removes the public tap device from the host namespace
+	// of the networkID
+	RemovePubTap(networkID NetID) error
+
 	// GetSubnet of the network with the given ID on the local node
 	GetSubnet(networkID NetID) (net.IPNet, error)
 

--- a/pkg/network.go
+++ b/pkg/network.go
@@ -91,7 +91,7 @@ type Networker interface {
 
 	// GetDefaultGwIP returns the IPs of the default gateways inside the network
 	// resource identified by the network ID on the local node, for IPv4 and IPv6
-	// repsectively
+	// respectively
 	GetDefaultGwIP(networkID NetID) (net.IP, net.IP, error)
 
 	// GetIPv6From4 generates an IPv6 address from a given IPv4 address in a NR

--- a/pkg/network/ifaceutil/interface.go
+++ b/pkg/network/ifaceutil/interface.go
@@ -12,6 +12,7 @@ import (
 	"time"
 
 	"github.com/containernetworking/plugins/pkg/ns"
+	"github.com/pkg/errors"
 
 	"github.com/rs/zerolog/log"
 
@@ -154,6 +155,21 @@ func MakeVethPair(name, peer string, mtu int) (netlink.Link, error) {
 	}
 
 	return veth2, nil
+}
+
+// VethByName loads one end of a veth pair given its name
+func VethByName(name string) (netlink.Link, error) {
+	link, err := netlink.LinkByName(name)
+	if err != nil {
+		return nil, errors.Wrapf(err, "veth %s not found", name)
+	}
+
+	if link.Type() != "veth" {
+		return nil, fmt.Errorf("device '%s' is not a veth pair", name)
+	}
+
+	return link.(*netlink.Veth), nil
+
 }
 
 // Exists test check if the named interface exists

--- a/pkg/network/ndmz/dualstack.go
+++ b/pkg/network/ndmz/dualstack.go
@@ -257,6 +257,12 @@ func (d *DualStack) SupportsPubIPv4() bool {
 	return d.hasPubBridge
 }
 
+// EnsureRoutable implements DMZ interface
+func (d *DualStack) EnsureRoutable() error {
+	// dualstack nodes have a dedicated physical interface so this is a no op
+	return nil
+}
+
 // waitIP4 waits to receives some IPv4 from DHCP
 // it returns the pid of the dhcp process or an error
 func waitIP4() error {

--- a/pkg/network/ndmz/dualstack.go
+++ b/pkg/network/ndmz/dualstack.go
@@ -94,6 +94,8 @@ func (d *DualStack) Create(ctx context.Context) error {
 		d.hasPubBridge = true
 	}
 
+	log.Info().Bool("public bridge", d.hasPubBridge).Msg("set up public bridge")
+
 	netNS, err := namespace.GetByName(NetNSNDMZ)
 	if err != nil {
 		// since we create the NDMZ here this should be a freshly booted node,
@@ -110,6 +112,7 @@ func (d *DualStack) Create(ctx context.Context) error {
 		return errors.Wrapf(err, "ndmz: createRoutingBride error")
 	}
 
+	log.Info().Msgf("set ndmz ipv6 master to %s", master)
 	d.ipv6Master = master
 
 	if err := createPubIface6(DMZPub6, master, d.nodeID, netNS); err != nil {

--- a/pkg/network/ndmz/dualstack.go
+++ b/pkg/network/ndmz/dualstack.go
@@ -88,6 +88,10 @@ func (d *DualStack) Create(ctx context.Context) error {
 		// this is the master now
 		master = publicBridge
 		d.hasPubBridge = true
+	} else if ifaceutil.Exists(publicBridge, nil) {
+		// existing bridge is the master
+		master = publicBridge
+		d.hasPubBridge = true
 	}
 
 	netNS, err := namespace.GetByName(NetNSNDMZ)

--- a/pkg/network/ndmz/dualstack.go
+++ b/pkg/network/ndmz/dualstack.go
@@ -8,6 +8,7 @@ import (
 	"time"
 
 	"github.com/cenkalti/backoff/v3"
+	"github.com/threefoldtech/zos/pkg/network/bridge"
 	"github.com/threefoldtech/zos/pkg/network/dhcp"
 	"github.com/threefoldtech/zos/pkg/network/ifaceutil"
 	"github.com/threefoldtech/zos/pkg/zinit"
@@ -25,10 +26,15 @@ import (
 	"github.com/threefoldtech/zos/pkg/network/namespace"
 )
 
+const (
+	publicBridge = "br-pub"
+)
+
 // DualStack implement DMZ interface using dual stack ipv4/ipv6
 type DualStack struct {
-	nodeID     string
-	ipv6Master string
+	nodeID       string
+	ipv6Master   string
+	hasPubBridge bool
 }
 
 // NewDualStack creates a new DMZ DualStack
@@ -40,8 +46,45 @@ func NewDualStack(nodeID string) *DualStack {
 
 //Create create the NDMZ network namespace and configure its default routes and addresses
 func (d *DualStack) Create(ctx context.Context) error {
+	master, err := FindIPv6Master()
+	if err != nil {
+		return errors.Wrap(err, "could not find public master iface for ndmz")
+	}
+	if master == "" {
+		return errors.New("invalid physical interface to use as master for ndmz npub6")
+	}
+
+	// There are 2 options for the master:
+	// - use the physical interface directly
+	// - create a bridge and plug the physical interface into that one
+	// The second option is used by default, and the first one is now legacy.
+	// However to not break existing containers, we keep the old one if networkd
+	// is restarted but the node is not. In this case, ndmz will already be present.
+	// TODO: properly check if we can switch from a phys iface to a bridge in
+	// between, probably by enumerating every device in every namespace and verifying
+	// none has the phys iface as master.
+	if !namespace.Exists(NetNSNDMZ) {
+		// create bridge, this needs to happen on the host ns
+		masterBr, err := bridge.New(publicBridge)
+		if err != nil {
+			return errors.Wrap(err, "could not create public bridge")
+		}
+		physLink, err := netlink.LinkByName(master)
+		if err != nil {
+			return errors.Wrap(err, "could not load public physical iface")
+		}
+		if err = bridge.AttachNic(physLink, masterBr); err != nil {
+			return errors.Wrap(err, "could not attach public physical iface to bridge")
+		}
+		// this is the master now
+		master = publicBridge
+		d.hasPubBridge = true
+	}
+
 	netNS, err := namespace.GetByName(NetNSNDMZ)
 	if err != nil {
+		// since we create the NDMZ here this should be a freshly booted node,
+		// so create the bridge in between for public networking
 		netNS, err = namespace.Create(NetNSNDMZ)
 		if err != nil {
 			return err
@@ -54,14 +97,6 @@ func (d *DualStack) Create(ctx context.Context) error {
 		return errors.Wrapf(err, "ndmz: createRoutingBride error")
 	}
 
-	master, err := FindIPv6Master()
-	if err != nil {
-		return err
-	}
-
-	if master == "" {
-		return errors.Wrap(err, "cannot find a valid physical interface to use as master for ndmz npub6")
-	}
 	d.ipv6Master = master
 
 	if err := createPubIface6(DMZPub6, master, d.nodeID, netNS); err != nil {
@@ -199,6 +234,11 @@ func (d *DualStack) SetIP6PublicIface(subnet net.IPNet) error {
 // IP6PublicIface implements DMZ interface
 func (d *DualStack) IP6PublicIface() string {
 	return d.ipv6Master
+}
+
+// SupportsPubIPv4 implements DMZ interface
+func (d *DualStack) SupportsPubIPv4() bool {
+	return d.hasPubBridge
 }
 
 // waitIP4 waits to receives some IPv4 from DHCP

--- a/pkg/network/ndmz/hidden.go
+++ b/pkg/network/ndmz/hidden.go
@@ -178,3 +178,8 @@ func (d *Hidden) SetIP6PublicIface(subnet net.IPNet) error {
 func (d *Hidden) IP6PublicIface() string {
 	return types.DefaultBridge
 }
+
+// SupportsPubIPv4 implements DMZ interface
+func (d *Hidden) SupportsPubIPv4() bool {
+	return false
+}

--- a/pkg/network/ndmz/hidden.go
+++ b/pkg/network/ndmz/hidden.go
@@ -5,6 +5,7 @@ import (
 	"net"
 	"os"
 
+	"github.com/threefoldtech/zos/pkg/network/bridge"
 	"github.com/threefoldtech/zos/pkg/network/ifaceutil"
 	"github.com/threefoldtech/zos/pkg/network/types"
 	"github.com/threefoldtech/zos/pkg/zinit"
@@ -24,7 +25,9 @@ import (
 
 // Hidden implement DMZ interface using ipv4 only
 type Hidden struct {
-	nodeID string
+	nodeID       string
+	hasPubBridge bool
+	master       string
 }
 
 // NewHidden creates a new DMZ Hidden
@@ -36,6 +39,49 @@ func NewHidden(nodeID string) *Hidden {
 
 //Create create the NDMZ network namespace and configure its default routes and addresses
 func (d *Hidden) Create(ctx context.Context) error {
+	// shameless code duplication from `dualstack.go`. Since we want to streamline
+	// operation of the different modes, we might be able to unify both ndmz
+	// imlementations in the cleanup
+	d.master = types.DefaultBridge
+	if !namespace.Exists(NetNSNDMZ) {
+		var masterBr *netlink.Bridge
+		var err error
+		if !ifaceutil.Exists(publicBridge, nil) {
+			// create bridge, this needs to happen on the host ns
+			masterBr, err = bridge.New(publicBridge)
+			if err != nil {
+				return errors.Wrap(err, "could not create public bridge")
+			}
+		} else {
+			masterBr, err = bridge.Get(publicBridge)
+			if err != nil {
+				return errors.Wrap(err, "could not load public bridge")
+			}
+		}
+		var veth netlink.Link
+		if !ifaceutil.Exists(toZosVeth, nil) {
+			veth, err = ifaceutil.MakeVethPair(toZosVeth, publicBridge, 1500)
+			if err != nil {
+				return errors.Wrap(err, "failed to create veth pair")
+			}
+		} else {
+			veth, err = ifaceutil.VethByName(toZosVeth)
+			if err != nil {
+				return errors.Wrap(err, "failed to load existing veth link to master bridge")
+			}
+		}
+		if err = bridge.AttachNic(veth, masterBr); err != nil {
+			return errors.Wrap(err, "failed to add veth to ndmz master bridge")
+		}
+
+		// this is the master now
+		d.master = publicBridge
+		d.hasPubBridge = true
+	} else if ifaceutil.Exists(publicBridge, nil) {
+		// existing bridge is the master
+		d.master = publicBridge
+		d.hasPubBridge = true
+	}
 	netNS, err := namespace.GetByName(NetNSNDMZ)
 	if err != nil {
 		netNS, err = namespace.Create(NetNSNDMZ)
@@ -49,7 +95,7 @@ func (d *Hidden) Create(ctx context.Context) error {
 		return errors.Wrapf(err, "ndmz: createRoutingBride error")
 	}
 
-	if err := createPubIface6(DMZPub6, types.DefaultBridge, d.nodeID, netNS); err != nil {
+	if err := createPubIface6(DMZPub6, d.master, d.nodeID, netNS); err != nil {
 		return errors.Wrapf(err, "ndmz: could not node create pub iface 6")
 	}
 
@@ -176,7 +222,7 @@ func (d *Hidden) SetIP6PublicIface(subnet net.IPNet) error {
 
 // IP6PublicIface implements DMZ interface
 func (d *Hidden) IP6PublicIface() string {
-	return types.DefaultBridge
+	return d.master
 }
 
 // SupportsPubIPv4 implements DMZ interface

--- a/pkg/network/ndmz/hidden.go
+++ b/pkg/network/ndmz/hidden.go
@@ -5,7 +5,6 @@ import (
 	"net"
 	"os"
 
-	"github.com/threefoldtech/zos/pkg/network/bridge"
 	"github.com/threefoldtech/zos/pkg/network/ifaceutil"
 	"github.com/threefoldtech/zos/pkg/network/types"
 	"github.com/threefoldtech/zos/pkg/zinit"
@@ -22,8 +21,6 @@ import (
 	"github.com/pkg/errors"
 	"github.com/threefoldtech/zos/pkg/network/namespace"
 )
-
-const yggVeth = "ndmztozos"
 
 // Hidden implement DMZ interface using ipv4 only
 type Hidden struct {
@@ -185,35 +182,4 @@ func (d *Hidden) IP6PublicIface() string {
 // SupportsPubIPv4 implements DMZ interface
 func (d *Hidden) SupportsPubIPv4() bool {
 	return false
-}
-
-// EnsureRoutable implements DMZ interface
-func (d *Hidden) EnsureRoutable() error {
-	// since we are a hidden node, we need to plug the ndmz bridge into the zos
-	// bridge, as the zos bridge has the (only) physical interface
-	var veth netlink.Link
-	var err error
-	if !ifaceutil.Exists(yggVeth, nil) {
-		veth, err = ifaceutil.MakeVethPair(yggVeth, types.DefaultBridge, 1500)
-		if err != nil {
-			return errors.Wrap(err, "failed to create veth pair")
-		}
-	} else {
-		veth, err = ifaceutil.VethByName(yggVeth)
-		if err != nil {
-			return errors.Wrap(err, "failed to load existing yggdrasil veth link")
-		}
-	}
-
-	// now plug the other end of the veth pair in the ndmz master bridge
-	ndmzBr, err := bridge.Get(BridgeNDMZ)
-	if err != nil {
-		return errors.Wrap(err, "failed to load ndmz bridge")
-	}
-
-	if err := bridge.AttachNic(veth, ndmzBr); err != nil {
-		return errors.Wrap(err, "failed to add veth to ndmz master bridge")
-	}
-
-	return nil
 }

--- a/pkg/network/ndmz/ndmz.go
+++ b/pkg/network/ndmz/ndmz.go
@@ -55,6 +55,9 @@ type DMZ interface {
 	IP6PublicIface() string
 	//configure an address on the public IPv6 interface
 	SetIP6PublicIface(net.IPNet) error
+	// SupportsPubIPv4 indicates if the node supports public ipv4 addresses for
+	// workloads
+	SupportsPubIPv4() bool
 }
 
 // FindIPv6Master finds which interface to use as master for NDMZ npub6 interface

--- a/pkg/network/ndmz/ndmz.go
+++ b/pkg/network/ndmz/ndmz.go
@@ -58,6 +58,8 @@ type DMZ interface {
 	// SupportsPubIPv4 indicates if the node supports public ipv4 addresses for
 	// workloads
 	SupportsPubIPv4() bool
+	// EnsureRoutable makes sure the DMZ has a way to reach the public internet
+	EnsureRoutable() error
 }
 
 // FindIPv6Master finds which interface to use as master for NDMZ npub6 interface

--- a/pkg/network/ndmz/ndmz.go
+++ b/pkg/network/ndmz/ndmz.go
@@ -58,8 +58,6 @@ type DMZ interface {
 	// SupportsPubIPv4 indicates if the node supports public ipv4 addresses for
 	// workloads
 	SupportsPubIPv4() bool
-	// EnsureRoutable makes sure the DMZ has a way to reach the public internet
-	EnsureRoutable() error
 }
 
 // FindIPv6Master finds which interface to use as master for NDMZ npub6 interface

--- a/pkg/network/ndmz/ndmz.go
+++ b/pkg/network/ndmz/ndmz.go
@@ -53,7 +53,7 @@ type DMZ interface {
 	AttachNR(networkID string, nr *nr.NetResource, ipamLeaseDir string) error
 	// Return the interface used by ndmz to router public ipv6 traffic
 	IP6PublicIface() string
-	//configure an address on the public IPv6 interface
+	// configure an address on the public IPv6 interface
 	SetIP6PublicIface(net.IPNet) error
 	// SupportsPubIPv4 indicates if the node supports public ipv4 addresses for
 	// workloads
@@ -62,7 +62,6 @@ type DMZ interface {
 
 // FindIPv6Master finds which interface to use as master for NDMZ npub6 interface
 func FindIPv6Master() (master string, err error) {
-
 	if namespace.Exists(types.PublicNamespace) {
 		pubNS, err := namespace.GetByName(types.PublicNamespace)
 		if err != nil {

--- a/pkg/network/networker.go
+++ b/pkg/network/networker.go
@@ -522,7 +522,8 @@ func (n networker) GetDefaultGwIP(networkID pkg.NetID) (net.IP, net.IP, error) {
 	// also a subnet in a NR is assumed to be a /24
 	ip[len(ip)-1] = 1
 
-	return ip, net.ParseIP("fe80::1"), nil
+	// ipv6 is derived from the ipv4
+	return ip, nr.Convert4to6(string(networkID), ip), nil
 }
 
 // GetIPv6From4 generates an IPv6 address from a given IPv4 address in a NR

--- a/pkg/network/nr/container.go
+++ b/pkg/network/nr/container.go
@@ -94,7 +94,7 @@ func (nr *NetResource) Join(cfg ContainerConfig) (join pkg.Member, err error) {
 		// then we create derive one to allow IPv6 traffic to go out
 		// if the user ask for a public IPv6, then the all config comes from SLAAC so we don't have to do anything ourself
 		if !cfg.IPv4Only && !cfg.PublicIP6 {
-			ipv6 := convert4to6(nr.ID(), cfg.IPs[0])
+			ipv6 := Convert4to6(nr.ID(), cfg.IPs[0])
 			slog.Info().
 				Str("ip", ipv6.String()).
 				Msgf("set ip to container")

--- a/pkg/network/nr/net_resource.go
+++ b/pkg/network/nr/net_resource.go
@@ -494,8 +494,19 @@ func Convert4to6(netID string, ip net.IP) net.IP {
 	h := md5.New()
 	md5NetID := h.Sum([]byte(netID))
 
+	// pick the last 2 bytes, handle ipv4 in both ipv6 form (leading 0 bytes)
+	// and ipv4 form
+	var lastbyte, secondtolastbyte byte
+	if len(ip) == net.IPv6len {
+		lastbyte = ip[15]
+		secondtolastbyte = ip[14]
+	} else if len(ip) == net.IPv4len {
+		lastbyte = ip[3]
+		secondtolastbyte = ip[2]
+	}
+
 	ipv6 := fmt.Sprintf("fd%x:%x%x:%x%x", md5NetID[0], md5NetID[1], md5NetID[2], md5NetID[3], md5NetID[4])
-	ipv6 = fmt.Sprintf("%s:%x::%x", ipv6, ip[14], ip[15])
+	ipv6 = fmt.Sprintf("%s:%x::%x", ipv6, secondtolastbyte, lastbyte)
 
 	return net.ParseIP(ipv6)
 }

--- a/pkg/network/nr/net_resource.go
+++ b/pkg/network/nr/net_resource.go
@@ -353,7 +353,7 @@ func (nr *NetResource) attachToNRBridge() error {
 			return err
 		}
 
-		ipv6 := convert4to6(nr.ID(), ipnet.IP)
+		ipv6 := Convert4to6(nr.ID(), ipnet.IP)
 		addr = &netlink.Addr{IPNet: &net.IPNet{
 			IP:   ipv6,
 			Mask: net.CIDRMask(64, 128),
@@ -489,7 +489,7 @@ func (nr *NetResource) applyFirewall() error {
 	return nil
 }
 
-func convert4to6(netID string, ip net.IP) net.IP {
+func Convert4to6(netID string, ip net.IP) net.IP {
 	h := md5.New()
 	md5NetID := h.Sum([]byte(netID))
 

--- a/pkg/network/nr/net_resource.go
+++ b/pkg/network/nr/net_resource.go
@@ -489,6 +489,7 @@ func (nr *NetResource) applyFirewall() error {
 	return nil
 }
 
+// Convert4to6 converts a (private) ipv4 to the corresponding ipv6
 func Convert4to6(netID string, ip net.IP) net.IP {
 	h := md5.New()
 	md5NetID := h.Sum([]byte(netID))

--- a/pkg/network/nr/net_resource_test.go
+++ b/pkg/network/nr/net_resource_test.go
@@ -183,7 +183,7 @@ func Test_convert4to6(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			require.NotNil(t, tt.want)
-			got := convert4to6(tt.args.netID, tt.args.ip)
+			got := Convert4to6(tt.args.netID, tt.args.ip)
 			require.NotNil(t, got)
 			assert.EqualValues(t, tt.want, got)
 		})

--- a/pkg/network/public_test.go
+++ b/pkg/network/public_test.go
@@ -27,6 +27,6 @@ func TestCreatePublicNS(t *testing.T) {
 		require.NoError(t, err)
 	}()
 
-	err := CreatePublicNS(iface, pkg.StrIdentifier(""))
+	err := CreatePublicNS(nil, iface, pkg.StrIdentifier(""))
 	require.NoError(t, err)
 }

--- a/pkg/provision/primitives/converter.go
+++ b/pkg/provision/primitives/converter.go
@@ -194,6 +194,7 @@ func K8SToProvisionType(w workloads.Workloader) (Kubernetes, string, error) {
 		ClusterSecret: k.ClusterSecret,
 		MasterIPs:     k.MasterIps,
 		SSHKeys:       k.SshKeys,
+		PublicIP:      k.PublicIP,
 	}
 
 	return k8s, k.NodeId, nil

--- a/pkg/provision/primitives/converter.go
+++ b/pkg/provision/primitives/converter.go
@@ -200,6 +200,20 @@ func K8SToProvisionType(w workloads.Workloader) (Kubernetes, string, error) {
 	return k8s, k.NodeId, nil
 }
 
+// PublicIPToProvisionType converts type to internal provision type
+func PublicIPToProvisionType(w workloads.Workloader) (PublicIP, string, error) {
+	p, ok := w.(*workloads.PublicIP)
+	if !ok {
+		return PublicIP{}, "", fmt.Errorf("failed to convert kubernetes workload, wrong format")
+	}
+
+	publicIP := PublicIP{
+		IP: p.IPaddress.IPNet,
+	}
+
+	return publicIP, p.NodeId, nil
+}
+
 // NetworkResourceToProvisionType converts type to internal provision type
 func NetworkResourceToProvisionType(w workloads.Workloader) (pkg.NetResource, error) {
 	n, ok := w.(*workloads.NetworkResource)
@@ -294,6 +308,11 @@ func WorkloadToProvisionType(w workloads.Workloader) (*provision.Reservation, er
 		if err != nil {
 			return nil, err
 		}
+	case workloads.WorkloadTypePublicIP:
+		data, reservation.NodeID, err = PublicIPToProvisionType(w)
+		if err != nil {
+			return nil, err
+		}
 	default:
 		return nil, fmt.Errorf("%w (%s) (%T)", ErrUnsupportedWorkload, w.GetWorkloadType().String(), w)
 	}
@@ -321,6 +340,8 @@ func ResultToSchemaType(r provision.Result) (*workloads.Result, error) {
 		rType = workloads.WorkloadTypeNetwork
 	case KubernetesReservation:
 		rType = workloads.WorkloadTypeKubernetes
+	case PublicIPReservation:
+		rType = workloads.WorkloadTypePublicIP
 	default:
 		return nil, fmt.Errorf("unknown reservation type: %s", r.Type)
 	}

--- a/pkg/provision/primitives/kubernetes.go
+++ b/pkg/provision/primitives/kubernetes.go
@@ -154,7 +154,6 @@ func (p *Provisioner) kubernetesProvisionImpl(ctx context.Context, reservation *
 
 	defer func() {
 		if err != nil {
-			_ = vm.Delete(reservation.ID)
 			_ = network.RemoveTap(netID)
 		}
 	}()

--- a/pkg/provision/primitives/kubernetes.go
+++ b/pkg/provision/primitives/kubernetes.go
@@ -244,6 +244,9 @@ func (p *Provisioner) kubernetesInstall(ctx context.Context, name string, cpu ui
 		case <-time.After(time.Second * 3):
 			// retry after 3 secs
 		case <-deadline.Done():
+			//TODO: if node failed to start in 5 min we need to do
+			// clean up here to make sure we don't leave any trash
+			// behind.
 			return errors.New("failed to install vm in 5 minutes")
 		}
 	}

--- a/pkg/provision/primitives/kubernetes.go
+++ b/pkg/provision/primitives/kubernetes.go
@@ -244,9 +244,13 @@ func (p *Provisioner) kubernetesInstall(ctx context.Context, name string, cpu ui
 		case <-time.After(time.Second * 3):
 			// retry after 3 secs
 		case <-deadline.Done():
-			//TODO: if node failed to start in 5 min we need to do
-			// clean up here to make sure we don't leave any trash
-			// behind.
+			// If install takes longer than 5 minutes, we consider it a failure.
+			// In that case, we attempt a delete first. This will kill the vm process
+			// if it is still going. The actual resources (disk, taps, ...) should
+			// be handled by the caller.
+			if err := vm.Delete(name); err != nil {
+				log.Warn().Err(err).Msg("could not delete vm who's install deadline expired")
+			}
 			return errors.New("failed to install vm in 5 minutes")
 		}
 	}

--- a/pkg/provision/primitives/kubernetes.go
+++ b/pkg/provision/primitives/kubernetes.go
@@ -165,6 +165,12 @@ func (p *Provisioner) kubernetesProvisionImpl(ctx context.Context, reservation *
 		if err != nil {
 			return result, errors.Wrap(err, "could not set up tap device for public network")
 		}
+
+		defer func() {
+			if err != nil {
+				_ = network.RemovePubTap(netID)
+			}
+		}()
 	}
 
 	var netInfo pkg.VMNetworkInfo
@@ -354,7 +360,7 @@ func (p *Provisioner) buildNetworkInfo(ctx context.Context, userID string, iface
 			IP6GatewayIP:   gw6,
 			Public:         false,
 		}},
-		Nameservers: []net.IP{net.ParseIP("8.8.8.8"), net.ParseIP("8.8.4.4")},
+		Nameservers: []net.IP{net.ParseIP("8.8.8.8"), net.ParseIP("1.1.1.1"), net.ParseIP("2001:4860:4860::8888")},
 	}
 
 	if cfg.PublicIP != 0 {
@@ -391,7 +397,8 @@ func (p *Provisioner) getPubIPConfig(rid schema.ID) (net.IPNet, net.IP, error) {
 		return net.IPNet{}, nil, errors.Wrap(err, "could not create explorer client")
 	}
 
-	workloadDefinition, err := explorerClient.Workloads.Get(rid)
+	// explorerClient.Workloads.Get(...) is currently broken
+	workloadDefinition, err := explorerClient.Workloads.NodeWorkloadGet(fmt.Sprintf("%d-1", rid))
 	if err != nil {
 		return net.IPNet{}, nil, errors.Wrap(err, "could not load public ip reservation")
 	}

--- a/pkg/provision/primitives/kubernetes.go
+++ b/pkg/provision/primitives/kubernetes.go
@@ -173,7 +173,7 @@ func (p *Provisioner) kubernetesProvisionImpl(ctx context.Context, reservation *
 	}
 
 	var netInfo pkg.VMNetworkInfo
-	netInfo, err = p.buildNetworkInfo(ctx, reservation.User, iface, pubIface, config)
+	netInfo, err = p.buildNetworkInfo(ctx, reservation.Version, reservation.User, iface, pubIface, config)
 	if err != nil {
 		return result, errors.Wrap(err, "could not generate network info")
 	}
@@ -327,7 +327,7 @@ func (p *Provisioner) kubernetesDecomission(ctx context.Context, reservation *pr
 	return nil
 }
 
-func (p *Provisioner) buildNetworkInfo(ctx context.Context, userID string, iface string, pubIface string, cfg Kubernetes) (pkg.VMNetworkInfo, error) {
+func (p *Provisioner) buildNetworkInfo(ctx context.Context, rversion int, userID string, iface string, pubIface string, cfg Kubernetes) (pkg.VMNetworkInfo, error) {
 	network := stubs.NewNetworkerStub(p.zbus)
 
 	netID := provision.NetworkID(userID, string(cfg.NetworkID))
@@ -372,6 +372,11 @@ func (p *Provisioner) buildNetworkInfo(ctx context.Context, userID string, iface
 			Public:         false,
 		}},
 		Nameservers: []net.IP{net.ParseIP("8.8.8.8"), net.ParseIP("1.1.1.1"), net.ParseIP("2001:4860:4860::8888")},
+	}
+
+	// from this reservation version on we deploy new VM's with the custom boot script for IP
+	if rversion >= 2 {
+		networkInfo.NewStyle = true
 	}
 
 	if cfg.PublicIP != 0 {

--- a/pkg/provision/primitives/kubernetes.go
+++ b/pkg/provision/primitives/kubernetes.go
@@ -185,6 +185,11 @@ func (p *Provisioner) kubernetesProvisionImpl(ctx context.Context, reservation *
 	}
 
 	err = p.kubernetesRun(ctx, reservation.ID, cpu, memory, diskPath, imagePath, netInfo, config)
+	if err != nil {
+		// attempt to delete the vm, should the process still be lingering
+		vm.Delete(reservation.ID)
+	}
+
 	return result, err
 }
 

--- a/pkg/provision/primitives/kubernetes.go
+++ b/pkg/provision/primitives/kubernetes.go
@@ -52,7 +52,8 @@ type Kubernetes struct {
 	PlainClusterSecret string `json:"-"`
 }
 
-const k3osFlistURL = "https://hub.grid.tf/tf-official-apps/k3os.flist"
+// const k3osFlistURL = "https://hub.grid.tf/tf-official-apps/k3os.flist"
+const k3osFlistURL = "https://hub.grid.tf/lee/k3os.flist"
 
 func (p *Provisioner) kubernetesProvision(ctx context.Context, reservation *provision.Reservation) (interface{}, error) {
 	return p.kubernetesProvisionImpl(ctx, reservation)

--- a/pkg/provision/primitives/order.go
+++ b/pkg/provision/primitives/order.go
@@ -17,6 +17,8 @@ const (
 	DebugReservation provision.ReservationType = "debug"
 	// KubernetesReservation type
 	KubernetesReservation provision.ReservationType = "kubernetes"
+	// PublicIPReservation type
+	PublicIPReservation provision.ReservationType = "public_ip"
 )
 
 // ProvisionOrder is used to sort the workload type
@@ -29,4 +31,5 @@ var ProvisionOrder = map[provision.ReservationType]int{
 	VolumeReservation:          4,
 	ContainerReservation:       5,
 	KubernetesReservation:      6,
+	PublicIPReservation:        7,
 }

--- a/pkg/provision/primitives/provisioner.go
+++ b/pkg/provision/primitives/provisioner.go
@@ -31,6 +31,7 @@ func NewProvisioner(cache provision.ReservationCache, zbus zbus.Client) *Provisi
 		ZDBReservation:             p.zdbProvision,
 		DebugReservation:           p.debugProvision,
 		KubernetesReservation:      p.kubernetesProvision,
+		PublicIPReservation:        p.publicIPProvision,
 	}
 	p.Decommissioners = map[provision.ReservationType]provision.DecomissionerFunc{
 		ContainerReservation:       p.containerDecommission,
@@ -40,6 +41,7 @@ func NewProvisioner(cache provision.ReservationCache, zbus zbus.Client) *Provisi
 		ZDBReservation:             p.zdbDecommission,
 		DebugReservation:           p.debugDecommission,
 		KubernetesReservation:      p.kubernetesDecomission,
+		PublicIPReservation:        p.publicIPDecomission,
 	}
 
 	return p

--- a/pkg/provision/primitives/public_ip.go
+++ b/pkg/provision/primitives/public_ip.go
@@ -1,0 +1,25 @@
+package primitives
+
+import (
+	"context"
+
+	"github.com/threefoldtech/zos/pkg/provision"
+)
+
+// PublicIPResult result returned by publicIP reservation
+type PublicIPResult struct {
+	ID string `json:"id"`
+	IP string `json:"ip"`
+}
+
+func (p *Provisioner) publicIPProvision(ctx context.Context, reservation *provision.Reservation) (interface{}, error) {
+	return p.publicIPProvisionImpl(ctx, reservation)
+}
+
+func (p *Provisioner) publicIPProvisionImpl(ctx context.Context, reservation *provision.Reservation) (result PublicIPResult, err error) {
+	return PublicIPResult{}, nil
+}
+
+func (p *Provisioner) publicIPDecomission(ctx context.Context, reservation *provision.Reservation) error {
+	return nil
+}

--- a/pkg/provision/primitives/public_ip.go
+++ b/pkg/provision/primitives/public_ip.go
@@ -2,9 +2,17 @@ package primitives
 
 import (
 	"context"
+	"net"
 
 	"github.com/threefoldtech/zos/pkg/provision"
 )
+
+// PublicIP structure
+type PublicIP struct {
+	// IP of the VM. The IP must be part of the subnet available in the network
+	// resource defined by the networkID on this node
+	IP net.IPNet `json:"ip"`
+}
 
 // PublicIPResult result returned by publicIP reservation
 type PublicIPResult struct {

--- a/pkg/stubs/network_stub.go
+++ b/pkg/stubs/network_stub.go
@@ -88,9 +88,44 @@ func (s *NetworkerStub) DeleteNR(arg0 pkg.NetResource) (ret0 error) {
 	return
 }
 
-func (s *NetworkerStub) GetDefaultGwIP(arg0 pkg.NetID) (ret0 []uint8, ret1 error) {
+func (s *NetworkerStub) GetDefaultGwIP(arg0 pkg.NetID) (ret0 []uint8, ret1 []uint8, ret2 error) {
 	args := []interface{}{arg0}
 	result, err := s.client.Request(s.module, s.object, "GetDefaultGwIP", args...)
+	if err != nil {
+		panic(err)
+	}
+	if err := result.Unmarshal(0, &ret0); err != nil {
+		panic(err)
+	}
+	if err := result.Unmarshal(1, &ret1); err != nil {
+		panic(err)
+	}
+	ret2 = new(zbus.RemoteError)
+	if err := result.Unmarshal(2, &ret2); err != nil {
+		panic(err)
+	}
+	return
+}
+
+func (s *NetworkerStub) GetIPv6From4(arg0 pkg.NetID, arg1 []uint8) (ret0 net.IPNet, ret1 error) {
+	args := []interface{}{arg0, arg1}
+	result, err := s.client.Request(s.module, s.object, "GetIPv6From4", args...)
+	if err != nil {
+		panic(err)
+	}
+	if err := result.Unmarshal(0, &ret0); err != nil {
+		panic(err)
+	}
+	ret1 = new(zbus.RemoteError)
+	if err := result.Unmarshal(1, &ret1); err != nil {
+		panic(err)
+	}
+	return
+}
+
+func (s *NetworkerStub) GetNet(arg0 pkg.NetID) (ret0 net.IPNet, ret1 error) {
+	args := []interface{}{arg0}
+	result, err := s.client.Request(s.module, s.object, "GetNet", args...)
 	if err != nil {
 		panic(err)
 	}

--- a/pkg/stubs/network_stub.go
+++ b/pkg/stubs/network_stub.go
@@ -184,6 +184,22 @@ func (s *NetworkerStub) Leave(arg0 pkg.NetID, arg1 string) (ret0 error) {
 	return
 }
 
+func (s *NetworkerStub) PubTapExists(arg0 pkg.NetID) (ret0 bool, ret1 error) {
+	args := []interface{}{arg0}
+	result, err := s.client.Request(s.module, s.object, "PubTapExists", args...)
+	if err != nil {
+		panic(err)
+	}
+	if err := result.Unmarshal(0, &ret0); err != nil {
+		panic(err)
+	}
+	ret1 = new(zbus.RemoteError)
+	if err := result.Unmarshal(1, &ret1); err != nil {
+		panic(err)
+	}
+	return
+}
+
 func (s *NetworkerStub) PublicAddresses(ctx context.Context) (<-chan pkg.NetlinkAddresses, error) {
 	ch := make(chan pkg.NetlinkAddresses)
 	recv, err := s.client.Stream(ctx, s.module, s.object, "PublicAddresses")
@@ -203,9 +219,34 @@ func (s *NetworkerStub) PublicAddresses(ctx context.Context) (<-chan pkg.Netlink
 	return ch, nil
 }
 
+func (s *NetworkerStub) PublicIPv4Support() (ret0 bool) {
+	args := []interface{}{}
+	result, err := s.client.Request(s.module, s.object, "PublicIPv4Support", args...)
+	if err != nil {
+		panic(err)
+	}
+	if err := result.Unmarshal(0, &ret0); err != nil {
+		panic(err)
+	}
+	return
+}
+
 func (s *NetworkerStub) Ready() (ret0 error) {
 	args := []interface{}{}
 	result, err := s.client.Request(s.module, s.object, "Ready", args...)
+	if err != nil {
+		panic(err)
+	}
+	ret0 = new(zbus.RemoteError)
+	if err := result.Unmarshal(0, &ret0); err != nil {
+		panic(err)
+	}
+	return
+}
+
+func (s *NetworkerStub) RemovePubTap(arg0 pkg.NetID) (ret0 error) {
+	args := []interface{}{arg0}
+	result, err := s.client.Request(s.module, s.object, "RemovePubTap", args...)
 	if err != nil {
 		panic(err)
 	}
@@ -224,6 +265,22 @@ func (s *NetworkerStub) RemoveTap(arg0 pkg.NetID) (ret0 error) {
 	}
 	ret0 = new(zbus.RemoteError)
 	if err := result.Unmarshal(0, &ret0); err != nil {
+		panic(err)
+	}
+	return
+}
+
+func (s *NetworkerStub) SetupPubTap(arg0 pkg.NetID) (ret0 string, ret1 error) {
+	args := []interface{}{arg0}
+	result, err := s.client.Request(s.module, s.object, "SetupPubTap", args...)
+	if err != nil {
+		panic(err)
+	}
+	if err := result.Unmarshal(0, &ret0); err != nil {
+		panic(err)
+	}
+	ret1 = new(zbus.RemoteError)
+	if err := result.Unmarshal(1, &ret1); err != nil {
 		panic(err)
 	}
 	return

--- a/pkg/stubs/storage_stub.go
+++ b/pkg/stubs/storage_stub.go
@@ -2,7 +2,6 @@ package stubs
 
 import (
 	"context"
-
 	zbus "github.com/threefoldtech/zbus"
 	pkg "github.com/threefoldtech/zos/pkg"
 )

--- a/pkg/vm.go
+++ b/pkg/vm.go
@@ -35,6 +35,11 @@ type VMNetworkInfo struct {
 	Ifaces []VMIface
 	// Nameservers dns servers
 	Nameservers []net.IP
+	// NewStyle version of the network. This specifically differentiates between
+	// the old way of statically setting the IP via the `IP` kernel parameter,
+	// or using a boot script. The new way allows multiple interfaces and more
+	// configuration
+	NewStyle bool
 }
 
 // VMDisk specifies vm disk params

--- a/pkg/vm.go
+++ b/pkg/vm.go
@@ -7,16 +7,32 @@ import (
 
 //go:generate zbusc -module vmd -version 0.0.1 -name manager -package stubs github.com/threefoldtech/zos/pkg+VMModule stubs/vmd_stub.go
 
-// VMNetworkInfo structure
-type VMNetworkInfo struct {
+// VMIface structure
+type VMIface struct {
 	// Tap device name
 	Tap string
 	// Mac address of the device
 	MAC string
-	// Address of the device in the form of cidr
-	AddressCIDR net.IPNet
-	// Gateway gateway address
-	GatewayIP net.IP
+	// Address of the device in the form of cidr for ipv4
+	IP4AddressCIDR net.IPNet
+	// Gateway address for ipv4
+	IP4GatewayIP net.IP
+	// Full subnet for the IP4 resource. This allows configuration of networking for
+	// non local subnets (i.e. NR on other nodes).
+	// Does not need to be set for public ifaces
+	IP4Net net.IPNet
+	// Address of the device in the form of cidr for ipv6
+	IP6AddressCIDR net.IPNet
+	// Gateway address for ipv6
+	IP6GatewayIP net.IP
+	// Private or public network
+	Public bool
+}
+
+// VMNetworkInfo structure
+type VMNetworkInfo struct {
+	// Interfaces for the vm network
+	Ifaces []VMIface
 	// Nameservers dns servers
 	Nameservers []net.IP
 }

--- a/pkg/vm/manager.go
+++ b/pkg/vm/manager.go
@@ -198,7 +198,7 @@ func (m *Module) makeNetCmdLine(idx int, ifcfg pkg.VMIface) string {
 
 	privPub := "priv"
 	if ifcfg.Public {
-		privPub = "pub"
+		privPub = "public"
 	}
 
 	return fmt.Sprintf("net_eth%d=%s,%s,%s", idx, strings.Join(ip4Elems, ","), strings.Join(ip6Elems, ","), privPub)

--- a/pkg/vm/manager.go
+++ b/pkg/vm/manager.go
@@ -151,9 +151,6 @@ func (m *Module) makeNetwork(vm *pkg.VM) ([]Interface, string, error) {
 	if len(vm.Network.Nameservers) > 1 {
 		dns1 = vm.Network.Nameservers[1].String()
 	}
-	if len(vm.Network.Nameservers) > 2 {
-		dns1 = vm.Network.Nameservers[2].String()
-	}
 
 	oldCmdline := fmt.Sprintf("ip=%s::%s:%s:::off:%s:%s:",
 		netIP.IP.String(),
@@ -195,9 +192,9 @@ func (m *Module) makeNetCmdLine(idx int, ifcfg pkg.VMIface) string {
 		ip6Elems = append(ip6Elems, "slaac")
 	}
 
-	privPub := "private"
+	privPub := "priv"
 	if ifcfg.Public {
-		privPub = "public"
+		privPub = "pub"
 	}
 
 	return fmt.Sprintf("net_eth%d=%s,%s,%s", idx, strings.Join(ip4Elems, ","), strings.Join(ip6Elems, ","), privPub)

--- a/pkg/vm/manager.go
+++ b/pkg/vm/manager.go
@@ -127,12 +127,7 @@ func (m *Module) makeNetwork(vm *pkg.VM) ([]Interface, string, error) {
 	// for FC vms there are 2 different methods. The original one used a built-in
 	// NFS module to allow setting a static ipv4 from the command line. The newer
 	// method uses a custom script inside the image to set proper IP. The config
-	// is also passed through the command line. To have easy backward compatibility,
-	// we just set the args for both here, as unused params don't crash the guest.
-
-	// netIP is only used for the old style network, which only had 1 iface, so we
-	// just take it from the first iface config (which should be the only one)
-	netIP := vm.Network.Ifaces[0].IP4AddressCIDR
+	// is also passed through the command line.
 
 	nics := make([]Interface, 0, len(vm.Network.Ifaces))
 	for i, ifcfg := range vm.Network.Ifaces {
@@ -143,34 +138,43 @@ func (m *Module) makeNetwork(vm *pkg.VM) ([]Interface, string, error) {
 		})
 	}
 
-	dns0 := ""
-	dns1 := ""
-	if len(vm.Network.Nameservers) > 0 {
-		dns0 = vm.Network.Nameservers[0].String()
-	}
-	if len(vm.Network.Nameservers) > 1 {
-		dns1 = vm.Network.Nameservers[1].String()
+	if !vm.Network.NewStyle {
+		// netIP is only used for the old style network, which only had 1 iface, so we
+		// just take it from the first iface config (which should be the only one)
+		netIP := vm.Network.Ifaces[0].IP4AddressCIDR
+
+		dns0 := ""
+		dns1 := ""
+		if len(vm.Network.Nameservers) > 0 {
+			dns0 = vm.Network.Nameservers[0].String()
+		}
+		if len(vm.Network.Nameservers) > 1 {
+			dns1 = vm.Network.Nameservers[1].String()
+		}
+
+		cmdline := fmt.Sprintf("ip=%s::%s:%s:::off:%s:%s:",
+			netIP.IP.String(),
+			vm.Network.Ifaces[0].IP4GatewayIP.String(), // again the old style network has a single iface so use the gw directly
+			net.IP(netIP.Mask).String(),
+			dns0,
+			dns1,
+		)
+
+		// only return the first nic should multiple be present (shouldnt be possible)
+		return nics[:1], cmdline, nil
 	}
 
-	oldCmdline := fmt.Sprintf("ip=%s::%s:%s:::off:%s:%s:",
-		netIP.IP.String(),
-		vm.Network.Ifaces[0].IP4GatewayIP.String(), // again the old style network has a single iface so use the gw directly
-		net.IP(netIP.Mask).String(),
-		dns0,
-		dns1,
-	)
-
-	newCmdLineSections := make([]string, 0, len(vm.Network.Ifaces)+1)
+	cmdLineSections := make([]string, 0, len(vm.Network.Ifaces)+1)
 	for i, ifcfg := range vm.Network.Ifaces {
-		newCmdLineSections = append(newCmdLineSections, m.makeNetCmdLine(i, ifcfg))
+		cmdLineSections = append(cmdLineSections, m.makeNetCmdLine(i, ifcfg))
 	}
 	dnsSection := make([]string, 0, len(vm.Network.Nameservers))
 	for _, ns := range vm.Network.Nameservers {
 		dnsSection = append(dnsSection, ns.String())
 	}
-	newCmdLineSections = append(newCmdLineSections, fmt.Sprintf("net_dns=%s", strings.Join(dnsSection, ",")))
+	cmdLineSections = append(cmdLineSections, fmt.Sprintf("net_dns=%s", strings.Join(dnsSection, ",")))
 
-	cmdline := strings.Join(append([]string{oldCmdline}, newCmdLineSections...), " ")
+	cmdline := strings.Join(cmdLineSections, " ")
 
 	return nics, cmdline, nil
 }

--- a/pkg/vm/manager.go
+++ b/pkg/vm/manager.go
@@ -117,13 +117,30 @@ func (m *Module) cleanFs(id string) error {
 	return os.RemoveAll(m.machineRoot(id))
 }
 
-func (m *Module) makeNetwork(vm *pkg.VM) (iface Interface, cmdline string, err error) {
-	netIP := vm.Network.AddressCIDR
+func (m *Module) makeNetwork(vm *pkg.VM) ([]Interface, string, error) {
+	// assume there is always at least 1 iface present
 
-	nic := Interface{
-		ID:  "eth0",
-		Tap: vm.Network.Tap,
-		Mac: vm.Network.MAC,
+	// we do 2 things here:
+	// - create the correct fc structure
+	// - create the cmd line params
+	//
+	// for FC vms there are 2 different methods. The original one used a built-in
+	// NFS module to allow setting a static ipv4 from the command line. The newer
+	// method uses a custom script inside the image to set proper IP. The config
+	// is also passed through the command line. To have easy backward compatibility,
+	// we just set the args for both here, as unused params don't crash the guest.
+
+	// netIP is only used for the old style network, which only had 1 iface, so we
+	// just take it from the first iface config (which should be the only one)
+	netIP := vm.Network.Ifaces[0].IP4AddressCIDR
+
+	nics := make([]Interface, 0, len(vm.Network.Ifaces))
+	for i, ifcfg := range vm.Network.Ifaces {
+		nics = append(nics, Interface{
+			ID:  fmt.Sprintf("eth%d", i),
+			Tap: ifcfg.Tap,
+			Mac: ifcfg.MAC,
+		})
 	}
 
 	dns0 := ""
@@ -134,16 +151,56 @@ func (m *Module) makeNetwork(vm *pkg.VM) (iface Interface, cmdline string, err e
 	if len(vm.Network.Nameservers) > 1 {
 		dns1 = vm.Network.Nameservers[1].String()
 	}
+	if len(vm.Network.Nameservers) > 2 {
+		dns1 = vm.Network.Nameservers[2].String()
+	}
 
-	cmdline = fmt.Sprintf("ip=%s::%s:%s:::off:%s:%s:",
+	oldCmdline := fmt.Sprintf("ip=%s::%s:%s:::off:%s:%s:",
 		netIP.IP.String(),
-		vm.Network.GatewayIP.String(),
+		vm.Network.Ifaces[0].IP4GatewayIP.String(), // again the old style network has a single iface so use the gw directly
 		net.IP(netIP.Mask).String(),
 		dns0,
 		dns1,
 	)
 
-	return nic, cmdline, nil
+	newCmdLineSections := make([]string, 0, len(vm.Network.Ifaces)+1)
+	for i, ifcfg := range vm.Network.Ifaces {
+		newCmdLineSections = append(newCmdLineSections, m.makeNetCmdLine(i, ifcfg))
+	}
+	dnsSection := make([]string, 0, len(vm.Network.Nameservers))
+	for _, ns := range vm.Network.Nameservers {
+		dnsSection = append(dnsSection, ns.String())
+	}
+	newCmdLineSections = append(newCmdLineSections, fmt.Sprintf("net_dns=%s", strings.Join(dnsSection, ",")))
+
+	cmdline := strings.Join(append([]string{oldCmdline}, newCmdLineSections...), " ")
+
+	return nics, cmdline, nil
+}
+
+func (m *Module) makeNetCmdLine(idx int, ifcfg pkg.VMIface) string {
+	// net_%ifacename=%ip4_cidr,$ip4_gw[,$ip4_route],$ipv6_cidr,$ipv6_gw,public|priv
+	ip4Elems := make([]string, 0, 3)
+	ip4Elems = append(ip4Elems, ifcfg.IP4AddressCIDR.String())
+	ip4Elems = append(ip4Elems, ifcfg.IP4GatewayIP.String())
+	if len(ifcfg.IP4Net.IP) > 0 {
+		ip4Elems = append(ip4Elems, ifcfg.IP4Net.String())
+	}
+
+	ip6Elems := make([]string, 0, 3)
+	if ifcfg.IP6AddressCIDR.IP.To16() != nil {
+		ip6Elems = append(ip6Elems, ifcfg.IP6AddressCIDR.String())
+		ip6Elems = append(ip6Elems, ifcfg.IP6GatewayIP.String())
+	} else {
+		ip6Elems = append(ip6Elems, "slaac")
+	}
+
+	privPub := "private"
+	if ifcfg.Public {
+		privPub = "public"
+	}
+
+	return fmt.Sprintf("net_eth%d=%s,%s,%s", idx, strings.Join(ip4Elems, ","), strings.Join(ip6Elems, ","), privPub)
 }
 
 func (m *Module) tail(path string) (string, error) {
@@ -228,7 +285,7 @@ func (m *Module) Run(vm pkg.VM) error {
 		kargs.WriteString(defaultKernelArgs)
 	}
 
-	nic, args, err := m.makeNetwork(&vm)
+	nics, args, err := m.makeNetwork(&vm)
 	if err != nil {
 		return err
 	}
@@ -251,10 +308,8 @@ func (m *Module) Run(vm pkg.VM) error {
 			Mem:       vm.Memory,
 			HTEnabled: false,
 		},
-		Interfaces: []Interface{
-			nic,
-		},
-		Drives: devices,
+		Interfaces: nics,
+		Drives:     devices,
 	}
 
 	defer func() {


### PR DESCRIPTION
Before merging this, a new explorer version should be deployed on devnet, where the reservation version is incremeted to 2.

Nodes will need to be rebooted to get the new network setup which allows public IP's. I'd prefer this does not happen immediatly, since that will not be the case in the field, and we should test the code to see if the backward compatibility works as expected. To also be able to test the new stuff, it might be best to reboot half of devnet (the "upper part in 10.6.0.{11-14}, since one of those has been manually patched to have the new stuff.

Yggdrasil IP in containers and vms is not yet present in this PR though support for it *should* have been prepared.

Fixes #1069 
Close #1057 
Close #1046