### PR TITLE
Make sure we handle both delete and deleted status

### DIFF
--- a/pkg/provision/primitives/converter.go
+++ b/pkg/provision/primitives/converter.go
@@ -262,7 +262,7 @@ func WireguardToProvisionType(p workloads.WireguardPeer) (pkg.Peer, error) {
 
 // WorkloadToProvisionType converts from the explorer type to the internal provision.Reservation
 func WorkloadToProvisionType(w workloads.Workloader) (*provision.Reservation, error) {
-
+	nextAction := w.GetNextAction()
 	reservation := &provision.Reservation{
 		ID:        fmt.Sprintf("%d-%d", w.GetID(), w.WorkloadID()),
 		User:      fmt.Sprintf("%d", w.GetCustomerTid()),
@@ -270,7 +270,7 @@ func WorkloadToProvisionType(w workloads.Workloader) (*provision.Reservation, er
 		Created:   w.GetEpoch().Time,
 		Duration:  math.MaxInt64, //ensure we never decomission based on expiration time. Since the capacity pool introduction this is not needed anymore
 		Signature: []byte(w.GetCustomerSignature()),
-		ToDelete:  w.GetNextAction() == workloads.NextActionDelete,
+		ToDelete:  nextAction == workloads.NextActionDelete || nextAction == workloads.NextActionDeleted,
 		Reference: w.GetReference(),
 		Result:    resultFromSchemaType(w.GetResult()),
 		Version:   w.GetVersion(),


### PR DESCRIPTION
Fixes #1037

This fix will correct handle both delete` and `deleted` next-actions so the node still do clean up correctly. The clean up still only run midnight though it means if the node got in dirty situation, it won't be freed until midnight.

But there is another fix (not released yet) that will make this situation less likely to happen