### PR TITLE
Close #1098: Expire public ip reservations

### DIFF
--- a/pkg/network.go
+++ b/pkg/network.go
@@ -72,16 +72,20 @@ type Networker interface {
 	// PublicIPv4Support enabled on this node for reservations
 	PublicIPv4Support() bool
 
-	// SetupPubTap sets up a tap device in the host namespace for the networkID. It is hooked
-	// to the public bridge. The name of the tap interface is returned
-	SetupPubTap(networkID NetID) (string, error)
+	// SetupPubTap sets up a tap device in the host namespace for the public ip
+	// reservation id. It is hooked to the public bridge. The name of the tap
+	// interface is returned
+	SetupPubTap(PubIPReservationID string) (string, error)
 
 	// PubTapExists checks if the tap device for the public network exists already
-	PubTapExists(networkID NetID) (bool, error)
+	PubTapExists(PubIPReservationID string) (bool, error)
 
 	// RemovePubTap removes the public tap device from the host namespace
-	// of the networkID
-	RemovePubTap(networkID NetID) error
+	RemovePubTap(PubIPReservationID string) error
+
+	// DisconnectPubTap disconnects the public tap from the network. The interface
+	// itself is not removed and will need to be cleaned up later
+	DisconnectPubTap(PubIPReservationID string) error
 
 	// GetSubnet of the network with the given ID on the local node
 	GetSubnet(networkID NetID) (net.IPNet, error)

--- a/pkg/provision/primitives/kubernetes.go
+++ b/pkg/provision/primitives/kubernetes.go
@@ -164,14 +164,14 @@ func (p *Provisioner) kubernetesProvisionImpl(ctx context.Context, reservation *
 
 	var pubIface string
 	if config.PublicIP != 0 {
-		pubIface, err = network.SetupPubTap(netID)
+		pubIface, err = network.SetupPubTap(pubIPResID(config.PublicIP))
 		if err != nil {
 			return result, errors.Wrap(err, "could not set up tap device for public network")
 		}
 
 		defer func() {
 			if err != nil {
-				_ = network.RemovePubTap(netID)
+				_ = network.RemovePubTap(pubIPResID(config.PublicIP))
 			}
 		}()
 	}
@@ -320,7 +320,7 @@ func (p *Provisioner) kubernetesDecomission(ctx context.Context, reservation *pr
 	}
 
 	if cfg.PublicIP != 0 {
-		if err := network.RemovePubTap(netID); err != nil {
+		if err := network.RemovePubTap(pubIPResID(cfg.PublicIP)); err != nil {
 			return errors.Wrap(err, "could not clean up public tap device")
 		}
 	}
@@ -512,4 +512,9 @@ func vmSize(size uint8) (cpu uint8, memory uint64, storage uint64, err error) {
 	}
 
 	return 0, 0, 0, fmt.Errorf("unsupported vm size %d, only size 1 and 2 are supported", size)
+}
+
+func pubIPResID(reservationID schema.ID) string {
+	// TODO: should this change in the actual reservation?
+	return fmt.Sprintf("%d-1", reservationID)
 }

--- a/pkg/provision/primitives/public_ip.go
+++ b/pkg/provision/primitives/public_ip.go
@@ -5,6 +5,7 @@ import (
 	"net"
 
 	"github.com/threefoldtech/zos/pkg/provision"
+	"github.com/threefoldtech/zos/pkg/stubs"
 )
 
 // PublicIP structure
@@ -29,5 +30,7 @@ func (p *Provisioner) publicIPProvisionImpl(ctx context.Context, reservation *pr
 }
 
 func (p *Provisioner) publicIPDecomission(ctx context.Context, reservation *provision.Reservation) error {
-	return nil
+	// Disconnect the public interface from the network if one exists
+	network := stubs.NewNetworkerStub(p.zbus)
+	return network.DisconnectPubTap(reservation.ID)
 }

--- a/pkg/stubs/network_stub.go
+++ b/pkg/stubs/network_stub.go
@@ -88,6 +88,19 @@ func (s *NetworkerStub) DeleteNR(arg0 pkg.NetResource) (ret0 error) {
 	return
 }
 
+func (s *NetworkerStub) DisconnectPubTap(arg0 string) (ret0 error) {
+	args := []interface{}{arg0}
+	result, err := s.client.Request(s.module, s.object, "DisconnectPubTap", args...)
+	if err != nil {
+		panic(err)
+	}
+	ret0 = new(zbus.RemoteError)
+	if err := result.Unmarshal(0, &ret0); err != nil {
+		panic(err)
+	}
+	return
+}
+
 func (s *NetworkerStub) GetDefaultGwIP(arg0 pkg.NetID) (ret0 []uint8, ret1 []uint8, ret2 error) {
 	args := []interface{}{arg0}
 	result, err := s.client.Request(s.module, s.object, "GetDefaultGwIP", args...)
@@ -184,7 +197,7 @@ func (s *NetworkerStub) Leave(arg0 pkg.NetID, arg1 string) (ret0 error) {
 	return
 }
 
-func (s *NetworkerStub) PubTapExists(arg0 pkg.NetID) (ret0 bool, ret1 error) {
+func (s *NetworkerStub) PubTapExists(arg0 string) (ret0 bool, ret1 error) {
 	args := []interface{}{arg0}
 	result, err := s.client.Request(s.module, s.object, "PubTapExists", args...)
 	if err != nil {
@@ -244,7 +257,7 @@ func (s *NetworkerStub) Ready() (ret0 error) {
 	return
 }
 
-func (s *NetworkerStub) RemovePubTap(arg0 pkg.NetID) (ret0 error) {
+func (s *NetworkerStub) RemovePubTap(arg0 string) (ret0 error) {
 	args := []interface{}{arg0}
 	result, err := s.client.Request(s.module, s.object, "RemovePubTap", args...)
 	if err != nil {
@@ -270,7 +283,7 @@ func (s *NetworkerStub) RemoveTap(arg0 pkg.NetID) (ret0 error) {
 	return
 }
 
-func (s *NetworkerStub) SetupPubTap(arg0 pkg.NetID) (ret0 string, ret1 error) {
+func (s *NetworkerStub) SetupPubTap(arg0 string) (ret0 string, ret1 error) {
 	args := []interface{}{arg0}
 	result, err := s.client.Request(s.module, s.object, "SetupPubTap", args...)
 	if err != nil {


### PR DESCRIPTION
This change also reworkds the way public interfaces are named, meaning
it is not backward compatible with the existing way of using public
interfaces and a reboot is required on nodes which have such an iface.
This is fine since the feature hasn't landed on mainnet yet.

Signed-off-by: Lee Smet <lee.smet@hotmail.com>