### PR TITLE
persist the no-keep-alive flag

### DIFF
--- a/pkg/vm/machine.go
+++ b/pkg/vm/machine.go
@@ -54,6 +54,9 @@ type Machine struct {
 	Drives     []Drive     `json:"drives"`
 	Interfaces []Interface `json:"network-interfaces"`
 	Config     Config      `json:"machine-config"`
+	// NoKeepAlive is not used by firecracker, but instead a marker
+	// for the vm  mananger to not restart the machine when it stops
+	NoKeepAlive bool `json:"no-keep-alive"`
 }
 
 // Jailed represents a jailed machine.

--- a/pkg/vm/manager.go
+++ b/pkg/vm/manager.go
@@ -309,8 +309,9 @@ func (m *Module) Run(vm pkg.VM) error {
 			Mem:       vm.Memory,
 			HTEnabled: false,
 		},
-		Interfaces: nics,
-		Drives:     devices,
+		Interfaces:  nics,
+		Drives:      devices,
+		NoKeepAlive: vm.NoKeepAlive,
 	}
 
 	defer func() {

--- a/pkg/vm/monitor.go
+++ b/pkg/vm/monitor.go
@@ -116,6 +116,14 @@ func (m *Module) monitorID(ctx context.Context, running map[string]int, id strin
 			return err
 		}
 
+		if jailed.NoKeepAlive {
+			// if the permenant marker was not set, and we reach here it's possible that
+			// the vmd was restarted, hence the in-memory copy of this flag was gone. Hence
+			// we need to set it correctly, and just return
+			m.failures.Set(id, permanent, cache.NoExpiration)
+			return nil
+		}
+
 		reason = jailed.Start(ctx)
 		if reason == nil {
 			reason = m.waitAndAdjOom(ctx, id)

--- a/pkg/vm/monitor.go
+++ b/pkg/vm/monitor.go
@@ -117,7 +117,7 @@ func (m *Module) monitorID(ctx context.Context, running map[string]int, id strin
 		}
 
 		if jailed.NoKeepAlive {
-			// if the permenant marker was not set, and we reach here it's possible that
+			// if the permanent marker was not set, and we reach here it's possible that
 			// the vmd was restarted, hence the in-memory copy of this flag was gone. Hence
 			// we need to set it correctly, and just return
 			m.failures.Set(id, permanent, cache.NoExpiration)


### PR DESCRIPTION
This is to avoid the flag being lost on vmd reboots (duo to updates)

Fixes #1088 