### PR TITLE
Fix #1142: Make sure veth lower half is set up

### DIFF
--- a/pkg/network/ifaceutil/interface.go
+++ b/pkg/network/ifaceutil/interface.go
@@ -166,6 +166,11 @@ func MakeVethPair(name, master string, mtu int) (netlink.Link, error) {
 		return nil, err
 	}
 
+	// make sure the lowerhalf is up, this automatically sets the upperhalf UP
+	if err = netlink.LinkSetUp(peerLink); err != nil {
+		return nil, errors.Wrap(err, "could not set veth peer up")
+	}
+
 	// Re-fetch the link to get its creation-time parameters, e.g. index and mac
 	veth2, err := netlink.LinkByName(name)
 	if err != nil {


### PR DESCRIPTION
When creating the veth pair, the lowerhalf is always plugged into the
given bridge. After doing this, we now make sure this iface is set up.
As a result, its peer will also be up. Failure to do so results in the
veth pair being unable to transfer traffic.

Signed-off-by: Lee Smet <lee.smet@hotmail.com>