### PR TITLE
Process unknown types to clean up explorer

### DIFF
--- a/pkg/provision/explorer/source.go
+++ b/pkg/provision/explorer/source.go
@@ -53,7 +53,7 @@ func (r *Poller) Poll(nodeID pkg.Identifier, from uint64) ([]*provision.Reservat
 
 	result := make([]*provision.Reservation, 0, len(list))
 	for _, wl := range list {
-		r, err := r.inputConv(wl)
+		converted, err := r.inputConv(wl)
 		if err != nil {
 			if errors.Is(err, primitives.ErrUnsupportedWorkload) {
 				log.Warn().Err(err).Msgf("received unsupported workload, skipping")
@@ -62,7 +62,7 @@ func (r *Poller) Poll(nodeID pkg.Identifier, from uint64) ([]*provision.Reservat
 			return nil, 0, err
 		}
 
-		result = append(result, r)
+		result = append(result, converted)
 	}
 
 	if r.provisionOrder != nil {

--- a/pkg/provision/explorer/source_test.go
+++ b/pkg/provision/explorer/source_test.go
@@ -84,5 +84,6 @@ func TestSkipUnsupportedType(t *testing.T) {
 
 	result, _, err := p.Poll(pkg.StrIdentifier(""), 0)
 	assert.NoError(t, err)
-	assert.Equal(t, 1, len(result))
+	assert.Equal(t, 2, len(result))
+	assert.Len(t, result[1].Data, 0)
 }

--- a/pkg/provision/primitives/converter.go
+++ b/pkg/provision/primitives/converter.go
@@ -8,6 +8,7 @@ import (
 	"strings"
 
 	"github.com/pkg/errors"
+	"github.com/rs/zerolog/log"
 	"github.com/threefoldtech/tfexplorer/models/generated/workloads"
 	"github.com/threefoldtech/tfexplorer/schema"
 	"github.com/threefoldtech/zos/pkg"
@@ -314,7 +315,8 @@ func WorkloadToProvisionType(w workloads.Workloader) (*provision.Reservation, er
 			return nil, err
 		}
 	default:
-		return nil, fmt.Errorf("%w (%s) (%T)", ErrUnsupportedWorkload, w.GetWorkloadType().String(), w)
+		log.Error().Str("type", w.GetWorkloadType().String()).Msg("unsupported reservation type")
+		return reservation, nil
 	}
 
 	reservation.Data, err = json.Marshal(data)


### PR DESCRIPTION
If there was a reservation of the wrong type, it will stay in the node queue forever and it will get sent to the node each time the node asks for new reservations. Instead we process the reservation and sent result with the proper error message instead of skipping it.