### PR TITLE
flist: cast time to int64, type mismatch on arm build

### DIFF
--- a/pkg/flist/cleanup.go
+++ b/pkg/flist/cleanup.go
@@ -178,7 +178,8 @@ func (f *flistModule) cleanCache(now time.Time, age time.Duration) error {
 		}
 
 		if sys, ok := sys.(*syscall.Stat_t); ok {
-			atime := time.Unix(sys.Atim.Sec, sys.Atim.Nsec)
+			// int64 cast required for arm32 targets
+			atime := time.Unix(int64(sys.Atim.Sec), int64(sys.Atim.Nsec))
 
 			if now.Sub(atime) > age {
 				if err := os.Remove(path); err != nil {


### PR DESCRIPTION
Fixes ARM build:
```
  cannot use sys.Atim.Sec (type int32) as type int64 in argument to time.Unix
  cannot use sys.Atim.Nsec (type int32) as type int64 in argument to time.Unix
```