### PR TITLE
Set the correct container cpu limit

### DIFF
--- a/pkg/container/opts.go
+++ b/pkg/container/opts.go
@@ -107,7 +107,7 @@ func WithCPUCount(cru uint) oci.SpecOpts {
 			return fmt.Errorf("asked %d CRU while only %d are available", cru, totalCPU)
 		}
 
-		quota, period := cruToLimit(cru, totalCPU)
+		quota, period := cruToLimit(cru)
 
 		if s.Linux.Resources == nil {
 			s.Linux.Resources = &specs.LinuxResources{}
@@ -123,8 +123,9 @@ func WithCPUCount(cru uint) oci.SpecOpts {
 	}
 }
 
-func cruToLimit(cru uint, totalCPU int) (quota int64, period uint64) {
-	quota = 100000
-	period = uint64(quota) * uint64(cru)
+func cruToLimit(cru uint) (quota int64, period uint64) {
+	period = 100000
+	quota = int64(period * uint64(cru))
+
 	return quota, period
 }

--- a/pkg/container/opts.go
+++ b/pkg/container/opts.go
@@ -3,7 +3,6 @@ package container
 import (
 	"context"
 	"fmt"
-	"math"
 
 	"path"
 
@@ -125,14 +124,7 @@ func WithCPUCount(cru uint) oci.SpecOpts {
 }
 
 func cruToLimit(cru uint, totalCPU int) (quota int64, period uint64) {
-	var (
-		required = float64(cru)
-		total    = float64(totalCPU)
-		p        float64
-	)
-	quota = int64(1000000) // 1 sec
-	p = required / total
-	p *= float64(quota)
-	p = math.Ceil(p)
-	return quota, uint64(p)
+	quota = 100000
+	period = uint64(quota) * uint64(cru)
+	return quota, period
 }

--- a/pkg/container/opts.go
+++ b/pkg/container/opts.go
@@ -14,6 +14,9 @@ import (
 	"github.com/containerd/containerd/oci"
 )
 
+// Defines the container cpu period
+const period = 100000
+
 // withNetworkNamespace set the named network namespace to use for the container
 func withNetworkNamespace(name string) oci.SpecOpts {
 	return oci.WithLinuxNamespace(
@@ -123,9 +126,8 @@ func WithCPUCount(cru uint) oci.SpecOpts {
 	}
 }
 
-func cruToLimit(cru uint) (quota int64, period uint64) {
-	period = 100000
-	quota = int64(period * uint64(cru))
+func cruToLimit(cru uint) (int64, uint64) {
+	quota := int64(period * uint64(cru))
 
 	return quota, period
 }

--- a/pkg/container/opts_test.go
+++ b/pkg/container/opts_test.go
@@ -14,45 +14,41 @@ func Test_cruToLimit(t *testing.T) {
 		wantPeriod uint64
 	}{
 		{
-			name: "1-1",
+			name: "1",
 			args: args{
-				cru:      1,
-				totalCPU: 1,
+				cru: 1,
 			},
 			wantPeriod: 100000,
 			wantQuota:  100000,
 		},
 		{
-			name: "1-4",
+			name: "2",
 			args: args{
-				cru:      1,
-				totalCPU: 4,
+				cru: 2,
 			},
 			wantPeriod: 100000,
-			wantQuota:  100000,
+			wantQuota:  200000,
 		},
 		{
-			name: "1-6",
+			name: "3",
 			args: args{
-				cru:      1,
-				totalCPU: 6,
+				cru: 3,
 			},
 			wantPeriod: 100000,
-			wantQuota:  100000,
+			wantQuota:  300000,
 		},
 		{
-			name: "2-4",
+			name: "10",
 			args: args{
-				cru:      2,
-				totalCPU: 4,
+				cru: 10,
 			},
-			wantPeriod: 200000,
-			wantQuota:  100000,
+			wantPeriod: 100000,
+			wantQuota:  1000000,
 		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			gotQuota, gotPeriod := cruToLimit(tt.args.cru, tt.args.totalCPU)
+			gotQuota, gotPeriod := cruToLimit(tt.args.cru)
 			if gotQuota != tt.wantQuota {
 				t.Errorf("cruToLimit() gotQuota = %v, want %v", gotQuota, tt.wantQuota)
 			}

--- a/pkg/container/opts_test.go
+++ b/pkg/container/opts_test.go
@@ -4,8 +4,7 @@ import "testing"
 
 func Test_cruToLimit(t *testing.T) {
 	type args struct {
-		cru      uint
-		totalCPU int
+		cru uint
 	}
 	tests := []struct {
 		name       string

--- a/pkg/container/opts_test.go
+++ b/pkg/container/opts_test.go
@@ -19,8 +19,8 @@ func Test_cruToLimit(t *testing.T) {
 				cru:      1,
 				totalCPU: 1,
 			},
-			wantPeriod: 1000000,
-			wantQuota:  1000000,
+			wantPeriod: 100000,
+			wantQuota:  100000,
 		},
 		{
 			name: "1-4",
@@ -28,8 +28,8 @@ func Test_cruToLimit(t *testing.T) {
 				cru:      1,
 				totalCPU: 4,
 			},
-			wantPeriod: 250000,
-			wantQuota:  1000000,
+			wantPeriod: 100000,
+			wantQuota:  100000,
 		},
 		{
 			name: "1-6",
@@ -37,8 +37,8 @@ func Test_cruToLimit(t *testing.T) {
 				cru:      1,
 				totalCPU: 6,
 			},
-			wantPeriod: 166667,
-			wantQuota:  1000000,
+			wantPeriod: 100000,
+			wantQuota:  100000,
 		},
 		{
 			name: "2-4",
@@ -46,8 +46,8 @@ func Test_cruToLimit(t *testing.T) {
 				cru:      2,
 				totalCPU: 4,
 			},
-			wantPeriod: 500000,
-			wantQuota:  1000000,
+			wantPeriod: 200000,
+			wantQuota:  100000,
 		},
 	}
 	for _, tt := range tests {


### PR DESCRIPTION
This PR fixes the issue where containers were using all the cpu they could find on the host. 

It has the following implications:

- load will be divided over all the cpus on the host, but cannot exceed the total reserved cpu for that container.
- monitoring a container cpu will be harder because the load is divided over all cpus