### PR TITLE
zdb: update flist url to latest version in release mode

### DIFF
--- a/pkg/provision/primitives/zdb.go
+++ b/pkg/provision/primitives/zdb.go
@@ -26,7 +26,7 @@ import (
 const (
 	// https://hub.grid.tf/api/flist/tf-autobuilder/threefoldtech-0-db-development.flist/light
 	// To get the latest symlink pointer
-	zdbFlistURL    = "https://hub.grid.tf/tf-autobuilder/threefoldtech-0-db-development-b5155357d5.flist"
+	zdbFlistURL    = "https://hub.grid.tf/tf-autobuilder/threefoldtech-0-db-release-development-c81c68391d.flist"
 	zdbContainerNS = "zdb"
 	zdbPort        = 9900
 )


### PR DESCRIPTION
Update zdb flist, contains lot of fixes and features, including `fd` leaks.
Switch to development to `release` mode, which will improve performance a lot, we don't really monitor logs anyway.