### PR TITLE
Build CH from release

### DIFF
--- a/bins/packages/cloudhypervisor/cloudhypervisor.sh
+++ b/bins/packages/cloudhypervisor/cloudhypervisor.sh
@@ -1,35 +1,18 @@
 CLOUDHYPERVISOR_VERSION="0.14.1"
-CLOUDHYPERVISOR_CHECKSUM="4c3bfa150e16c97a92ea96ab7d2eed78"
-CLOUDHYPERVISOR_LINK="https://github.com/cloud-hypervisor/cloud-hypervisor/archive/v${CLOUDHYPERVISOR_VERSION}.tar.gz"
+CLOUDHYPERVISOR_CHECKSUM="4510d198f6defcfe1df14ac82de0cb82"
+CLOUDHYPERVISOR_LINK="https://github.com/cloud-hypervisor/cloud-hypervisor/releases/download/v${CLOUDHYPERVISOR_VERSION}/cloud-hypervisor-static"
 CLOUDHYPERVISOR_RUST_TOOLCHAIN="1.50.0"
 
-dependencies_cloudhypervisor() {
-    apt-get install -y curl build-essential
-
-    curl https://sh.rustup.rs -sSf | sh -s -- -y --default-toolchain "${CLOUDHYPERVISOR_RUST_TOOLCHAIN}"
-    . $HOME/.cargo/env
-
-    rustup target add x86_64-unknown-linux-musl
-}
 
 download_cloudhypervisor() {
     echo "down"
-    download_file ${CLOUDHYPERVISOR_LINK} ${CLOUDHYPERVISOR_CHECKSUM} cloud-hypervisor-${CLOUDHYPERVISOR_VERSION}.tar.gz
+    download_file ${CLOUDHYPERVISOR_LINK} ${CLOUDHYPERVISOR_CHECKSUM} cloud-hypervisor-${CLOUDHYPERVISOR_VERSION}
 }
 
-extract_cloudhypervisor() {
-    echo "[+] extracting cloud-hypervisor"
-    tar -xf ${DISTDIR}/cloud-hypervisor-${CLOUDHYPERVISOR_VERSION}.tar.gz -C ${WORKDIR}
-}
 
 prepare_cloudhypervisor() {
     echo "[+] prepare cloud-hypervisor"
     github_name "cloud-hypervisor-${CLOUDHYPERVISOR_VERSION}"
-}
-
-compile_cloudhypervisor() {
-    echo "[+] compile cloud-hypervisor"
-    cargo build --release --target=x86_64-unknown-linux-musl --all
 }
 
 install_cloudhypervisor() {
@@ -37,25 +20,15 @@ install_cloudhypervisor() {
 
     mkdir -p "${ROOTDIR}/usr/bin"
 
-
-    RELEASEDIR="target/x86_64-unknown-linux-musl/release"
-    cp "${RELEASEDIR}/cloud-hypervisor" ${ROOTDIR}/usr/bin/
-
+    cp ${DISTDIR}/cloud-hypervisor-${CLOUDHYPERVISOR_VERSION} ${ROOTDIR}/usr/bin/cloud-hypervisor
     chmod +x ${ROOTDIR}/usr/bin/*
 }
 
 build_cloudhypervisor() {
     pushd "${DISTDIR}"
 
-    dependencies_cloudhypervisor
     download_cloudhypervisor
-    extract_cloudhypervisor
-
-    popd
-    pushd ${WORKDIR}/cloud-hypervisor-${CLOUDHYPERVISOR_VERSION}
-
     prepare_cloudhypervisor
-    compile_cloudhypervisor
     install_cloudhypervisor
 
     popd


### PR DESCRIPTION
We avoid building CH ourself because when we do
this it uses the release of zos itself (not CH)
which makes debugging impossible