### PR TITLE
Add -cpu host-phys-bits to allow ch images on qemu

### DIFF
--- a/qemu/vm.sh
+++ b/qemu/vm.sh
@@ -73,7 +73,7 @@ fi
 echo "boot $image"
 
 qemu-system-x86_64 -kernel $image \
-    -m 3072 -enable-kvm -cpu host -smp $smp \
+    -m 3072 -enable-kvm -cpu host,host-phys-bits -smp $smp \
     -uuid $uuid \
     -netdev bridge,id=zos0,br=${bridge} -device virtio-net-pci,netdev=zos0,mac="${basemac}1" \
     -drive file=fat:rw:$basepath/overlay,format=raw \


### PR DESCRIPTION
Description:
VMs when the node was run using qemu was failing due to kernel panic. Updated using the fix in https://github.com/cloud-hypervisor/cloud-hypervisor/issues/456#issuecomment-659091773 .

Related issues:

https://github.com/threefoldtech/zos/issues/1247