### PR TITLE
Make the node more memory conservative 

### DIFF
--- a/pkg/provision/engine.go
+++ b/pkg/provision/engine.go
@@ -27,7 +27,6 @@ const gib = 1024 * 1024 * 1024
 
 const (
 	minimunZosMemory = 2 * gib
-	maximumZosMemory = 4 * gib
 )
 
 // Engine is the core of this package
@@ -94,13 +93,9 @@ func New(opts EngineOps) (*Engine, error) {
 
 	// we round the total memory size to the nearest 1G
 	totalMemory := math.Ceil(float64(memStats.Total)/gib) * gib
-	reservedMemory := totalMemory * 0.20
-	reservedMemory = math.Max(
-		math.Min(
-			reservedMemory,
-			maximumZosMemory,
-		),
-		minimunZosMemory,
+	reservedMemory := math.Max(
+		totalMemory*0.1,  //10% of total memory
+		minimunZosMemory, // min of 2G
 	)
 
 	reservedMemory = math.Ceil(reservedMemory/gib) * gib

--- a/pkg/provision/primitives/counters.go
+++ b/pkg/provision/primitives/counters.go
@@ -187,7 +187,7 @@ type resourceUnits struct {
 
 // CheckMemoryRequirements checks memory requirements for a reservation and compares it to whats in the counters
 // and what is the total memory on this node
-func (c *Counters) CheckMemoryRequirements(r *provision.Reservation, totalMemAvailable uint64) error {
+func (c *Counters) CheckMemoryRequirements(r *provision.Reservation, usableMemoryBytes uint64) error {
 	var requestedUnits resourceUnits
 	var err error
 
@@ -206,8 +206,8 @@ func (c *Counters) CheckMemoryRequirements(r *provision.Reservation, totalMemAva
 	}
 
 	if requestedUnits.MRU != 0 {
-		// If current MRU + requested MRU exceeds total, return an error
-		if c.MRU.Current()+requestedUnits.MRU > totalMemAvailable {
+		// requested MRU exceeds usable, return an error
+		if requestedUnits.MRU > usableMemoryBytes {
 			return errors.New("not enough free resources to support this memory size")
 		}
 	}


### PR DESCRIPTION
What we do here:
- The "Reserved" system memory is a 20% of node memory, no more than 4G
- We check if the node can deploy a workload against the real free
  memory, not against the computed memory of total - deployed workloads
- reported capacity is max(actual used, deployed worklaods)