### PR TITLE
Hash public tap names before sending to network module

### DIFF
--- a/pkg/network.go
+++ b/pkg/network.go
@@ -87,13 +87,13 @@ type Networker interface {
 	// SetupPubTap sets up a tap device in the host namespace for the public ip
 	// reservation id. It is hooked to the public bridge. The name of the tap
 	// interface is returned
-	SetupPubTap(PubIPReservationID string) (string, error)
+	SetupPubTap(name string) (string, error)
 
 	// PubTapExists checks if the tap device for the public network exists already
-	PubTapExists(PubIPReservationID string) (bool, error)
+	PubTapExists(name string) (bool, error)
 
 	// RemovePubTap removes the public tap device from the host namespace
-	RemovePubTap(PubIPReservationID string) error
+	RemovePubTap(name string) error
 
 	// SetupPubIPFilter sets up filter for this public ip
 	SetupPubIPFilter(filterName string, iface string, ip string, ipv6 string, mac string) error
@@ -105,7 +105,7 @@ type Networker interface {
 	PubIPFilterExists(filterName string) bool
 	// DisconnectPubTap disconnects the public tap from the network. The interface
 	// itself is not removed and will need to be cleaned up later
-	DisconnectPubTap(PubIPReservationID string) error
+	DisconnectPubTap(name string) error
 
 	// GetSubnet of the network with the given ID on the local node
 	GetSubnet(networkID NetID) (net.IPNet, error)

--- a/pkg/network/networker.go
+++ b/pkg/network/networker.go
@@ -302,19 +302,19 @@ func (n *networker) PublicIPv4Support() bool {
 // SetupPubTap sets up a tap device in the host namespace for the public ip
 // reservation id. It is hooked to the public bridge. The name of the tap
 // interface is returned
-func (n *networker) SetupPubTap(pubIPReservationID string) (string, error) {
-	log.Info().Str("pubip-res-id", string(pubIPReservationID)).Msg("Setting up public tap interface")
+func (n *networker) SetupPubTap(name string) (string, error) {
+	log.Info().Str("pubtap-name", string(name)).Msg("Setting up public tap interface")
 
 	if !n.ndmz.SupportsPubIPv4() {
 		return "", errors.New("can't create public tap on this node")
 	}
 
-	tapIface, err := pubTapName(pubIPReservationID)
+	tapIface, err := pubTapName(name)
 	if err != nil {
 		return "", errors.Wrap(err, "could not get network namespace tap device name")
 	}
 
-	hw := ifaceutil.HardwareAddrFromInputBytes([]byte(pubIPReservationID))
+	hw := ifaceutil.HardwareAddrFromInputBytes([]byte(name))
 	_, err = macvtap.CreateMACvTap(tapIface, public.PublicBridge, hw)
 
 	return tapIface, err
@@ -322,7 +322,7 @@ func (n *networker) SetupPubTap(pubIPReservationID string) (string, error) {
 
 // SetupYggTap sets up a tap device in the host namespace for the yggdrasil ip
 func (n *networker) SetupYggTap(name string) (tap pkg.YggdrasilTap, err error) {
-	log.Info().Str("pubip-res-id", string(name)).Msg("Setting up public tap interface")
+	log.Info().Str("pubtap-name", string(name)).Msg("Setting up public tap interface")
 
 	tapIface, err := tapName(name)
 	if err != nil {
@@ -358,10 +358,10 @@ func (n *networker) SetupYggTap(name string) (tap pkg.YggdrasilTap, err error) {
 }
 
 // PubTapExists checks if the tap device for the public network exists already
-func (n *networker) PubTapExists(pubIPReservationID string) (bool, error) {
-	log.Info().Str("pubip-res-id", string(pubIPReservationID)).Msg("Checking if public tap interface exists")
+func (n *networker) PubTapExists(name string) (bool, error) {
+	log.Info().Str("pubtap-name", string(name)).Msg("Checking if public tap interface exists")
 
-	tapIface, err := pubTapName(pubIPReservationID)
+	tapIface, err := pubTapName(name)
 	if err != nil {
 		return false, errors.Wrap(err, "could not get network namespace tap device name")
 	}
@@ -371,10 +371,10 @@ func (n *networker) PubTapExists(pubIPReservationID string) (bool, error) {
 
 // RemovePubTap removes the public tap device from the host namespace
 // of the networkID
-func (n *networker) RemovePubTap(pubIPReservationID string) error {
-	log.Info().Str("pubip-res-id", string(pubIPReservationID)).Msg("Removing public tap interface")
+func (n *networker) RemovePubTap(name string) error {
+	log.Info().Str("pubtap-name", string(name)).Msg("Removing public tap interface")
 
-	tapIface, err := pubTapName(pubIPReservationID)
+	tapIface, err := pubTapName(name)
 	if err != nil {
 		return errors.Wrap(err, "could not get network namespace tap device name")
 	}
@@ -458,10 +458,10 @@ nft 'delete chain arp filter handle '${a}`, filterName))
 
 // DisconnectPubTap disconnects the public tap from the network. The interface
 // itself is not removed and will need to be cleaned up later
-func (n *networker) DisconnectPubTap(pubIPReservationID string) error {
-	log.Info().Str("pubip-res-id", string(pubIPReservationID)).Msg("Disconnecting public tap interface")
+func (n *networker) DisconnectPubTap(name string) error {
+	log.Info().Str("pubtap-name", string(name)).Msg("Disconnecting public tap interface")
 
-	tapIfaceName, err := pubTapName(pubIPReservationID)
+	tapIfaceName, err := pubTapName(name)
 	if err != nil {
 		return errors.Wrap(err, "could not get network namespace tap device name")
 	}

--- a/pkg/primitives/public_ip.go
+++ b/pkg/primitives/public_ip.go
@@ -126,7 +126,8 @@ func (p *Primitives) publicIPDecomission(ctx context.Context, wl *gridtypes.Work
 	if err := network.RemovePubIPFilter(ctx, fName); err != nil {
 		log.Error().Err(err).Msg("could not remove filter rules")
 	}
-	return network.DisconnectPubTap(ctx, wl.ID.String())
+	tapName := tapNameFromName(wl.ID, "pub")
+	return network.DisconnectPubTap(ctx, tapName)
 }
 
 func filterName(reservationID string) string {

--- a/pkg/primitives/vm.go
+++ b/pkg/primitives/vm.go
@@ -114,14 +114,16 @@ func (p *Primitives) virtualMachineProvisionImpl(ctx context.Context, wl *gridty
 		Nameservers: []net.IP{net.ParseIP("8.8.8.8"), net.ParseIP("1.1.1.1"), net.ParseIP("2001:4860:4860::8888")},
 	}
 
+	var ifs []string
+	var pubIf string
+
 	defer func() {
 		if err != nil {
-			for _, nic := range networkInfo.Ifaces {
-				if nic.Public {
-					_ = network.DisconnectPubTap(ctx, nic.OriginalTapName)
-				} else {
-					_ = network.RemoveTap(ctx, nic.OriginalTapName)
-				}
+			for _, nic := range ifs {
+				_ = network.RemoveTap(ctx, nic)
+			}
+			if pubIf != "" {
+				_ = network.DisconnectPubTap(ctx, pubIf)
 			}
 		}
 	}()
@@ -131,6 +133,7 @@ func (p *Primitives) virtualMachineProvisionImpl(ctx context.Context, wl *gridty
 		if err != nil {
 			return result, err
 		}
+		ifs = append(ifs, tapNameFromName(wl.ID, string(nic.Network)))
 		networkInfo.Ifaces = append(networkInfo.Ifaces, inf)
 	}
 
@@ -139,6 +142,9 @@ func (p *Primitives) virtualMachineProvisionImpl(ctx context.Context, wl *gridty
 		if err != nil {
 			return result, err
 		}
+
+		ipWl, _ := deployment.Get(config.Network.PublicIP)
+		pubIf = tapNameFromName(ipWl.ID, "pub")
 		networkInfo.Ifaces = append(networkInfo.Ifaces, inf)
 	}
 
@@ -149,6 +155,7 @@ func (p *Primitives) virtualMachineProvisionImpl(ctx context.Context, wl *gridty
 		}
 
 		log.Debug().Msgf("Planetary: %+v", inf)
+		ifs = append(ifs, tapNameFromName(wl.ID, "ygg"))
 		networkInfo.Ifaces = append(networkInfo.Ifaces, inf)
 	}
 	// - mount flist RO

--- a/pkg/primitives/vm.go
+++ b/pkg/primitives/vm.go
@@ -118,9 +118,9 @@ func (p *Primitives) virtualMachineProvisionImpl(ctx context.Context, wl *gridty
 		if err != nil {
 			for _, nic := range networkInfo.Ifaces {
 				if nic.Public {
-					_ = network.DisconnectPubTap(ctx, nic.Tap)
+					_ = network.DisconnectPubTap(ctx, nic.OriginalTapName)
 				} else {
-					_ = network.RemoveTap(ctx, nic.Tap)
+					_ = network.RemoveTap(ctx, nic.OriginalTapName)
 				}
 			}
 		}
@@ -315,7 +315,7 @@ func (p *Primitives) vmDecomission(ctx context.Context, wl *gridtypes.WorkloadWi
 		if err != nil {
 			return err
 		}
-		ifName := ipWl.ID.String()
+		ifName := tapNameFromName(ipWl.ID, "pub")
 		if err := network.RemovePubTap(ctx, ifName); err != nil {
 			return errors.Wrap(err, "could not clean up public tap device")
 		}

--- a/pkg/primitives/vm_utils.go
+++ b/pkg/primitives/vm_utils.go
@@ -109,7 +109,6 @@ func (p *Primitives) newPrivNetworkInterface(ctx context.Context, dl gridtypes.D
 		IP4DefaultGateway: net.IP(gw4),
 		IP6DefaultGateway: gw6,
 		Public:            false,
-		OriginalTapName:   tapName,
 	}
 
 	return out, nil
@@ -144,8 +143,7 @@ func (p *Primitives) newPubNetworkInterface(ctx context.Context, deployment grid
 		},
 		IP4DefaultGateway: pubGw,
 		// for now we get ipv6 from slaac, so leave ipv6 stuffs this empty
-		Public:          true,
-		OriginalTapName: tapName,
+		Public: true,
 	}, nil
 }
 

--- a/pkg/primitives/vm_utils.go
+++ b/pkg/primitives/vm_utils.go
@@ -109,6 +109,7 @@ func (p *Primitives) newPrivNetworkInterface(ctx context.Context, dl gridtypes.D
 		IP4DefaultGateway: net.IP(gw4),
 		IP6DefaultGateway: gw6,
 		Public:            false,
+		OriginalTapName:   tapName,
 	}
 
 	return out, nil
@@ -120,14 +121,13 @@ func (p *Primitives) newPubNetworkInterface(ctx context.Context, deployment grid
 	if err != nil {
 		return pkg.VMIface{}, err
 	}
-	name := ipWl.ID.String()
+	tapName := tapNameFromName(ipWl.ID, "pub")
 
 	pubIP, pubGw, err := p.getPubIPConfig(ipWl)
 	if err != nil {
 		return pkg.VMIface{}, errors.Wrap(err, "could not get public ip config")
 	}
-
-	pubIface, err := network.SetupPubTap(ctx, name)
+	pubIface, err := network.SetupPubTap(ctx, tapName)
 	if err != nil {
 		return pkg.VMIface{}, errors.Wrap(err, "could not set up tap device for public network")
 	}
@@ -144,7 +144,8 @@ func (p *Primitives) newPubNetworkInterface(ctx context.Context, deployment grid
 		},
 		IP4DefaultGateway: pubGw,
 		// for now we get ipv6 from slaac, so leave ipv6 stuffs this empty
-		Public: true,
+		Public:          true,
+		OriginalTapName: tapName,
 	}, nil
 }
 

--- a/pkg/vm.go
+++ b/pkg/vm.go
@@ -35,6 +35,8 @@ type VMIface struct {
 	IP6DefaultGateway net.IP
 	// Private or public network
 	Public bool
+	// OriginalTapName without prefixes to help in decommissioning
+	OriginalTapName string
 }
 
 // VMNetworkInfo structure

--- a/pkg/vm.go
+++ b/pkg/vm.go
@@ -35,8 +35,6 @@ type VMIface struct {
 	IP6DefaultGateway net.IP
 	// Private or public network
 	Public bool
-	// OriginalTapName without prefixes to help in decommissioning
-	OriginalTapName string
 }
 
 // VMNetworkInfo structure


### PR DESCRIPTION
Fixes `could not get network namespace tap device name: tap name too long`,
- Hashing like for normal taps is done on the provisioning side.
- The prefixless original hashed tap names is storedin the VMIface to pass to DisconnectPubTap and RemoveTap.
- (Not tested) need help setting up v3 node