### PR TITLE
Zos3/qsfs non network part

### DIFF
--- a/cmds/modules/qsfsd/main.go
+++ b/cmds/modules/qsfsd/main.go
@@ -1,0 +1,84 @@
+package qsfsd
+
+import (
+	"context"
+
+	"github.com/pkg/errors"
+	"github.com/threefoldtech/zos/pkg/qsfsd"
+	"github.com/threefoldtech/zos/pkg/utils"
+	"github.com/urfave/cli/v2"
+
+	"github.com/rs/zerolog/log"
+
+	"github.com/threefoldtech/zbus"
+)
+
+const (
+	module = "qsfsd"
+)
+
+// Module is entry point for module
+var Module cli.Command = cli.Command{
+	Name:  "qsfsd",
+	Usage: "manage qsfsd",
+	Flags: []cli.Flag{
+		&cli.StringFlag{
+			Name:  "root",
+			Usage: "`ROOT` working directory of the module",
+			Value: "/var/cache/modules/qsfsd",
+		},
+		&cli.StringFlag{
+			Name:  "broker",
+			Usage: "connection string to the message `BROKER`",
+			Value: "unix:///var/run/redis.sock",
+		},
+		&cli.UintFlag{
+			Name:  "workers",
+			Usage: "number of workers `N`",
+			Value: 1,
+		},
+	},
+	Action: action,
+}
+
+func action(cli *cli.Context) error {
+	var (
+		moduleRoot   string = cli.String("root")
+		msgBrokerCon string = cli.String("broker")
+		workerNr     uint   = cli.Uint("workers")
+	)
+
+	server, err := zbus.NewRedisServer(module, msgBrokerCon, workerNr)
+	if err != nil {
+		return errors.Wrap(err, "fail to connect to message broker server")
+	}
+
+	client, err := zbus.NewRedisClient(msgBrokerCon)
+	if err != nil {
+		return errors.Wrap(err, "failed to connect to zbus broker")
+	}
+
+	mod, err := qsfsd.New(cli.Context, client, moduleRoot)
+	if err != nil {
+		return errors.Wrap(err, "failed to construct qsfsd object")
+	}
+	server.Register(zbus.ObjectID{Name: "manager", Version: "0.0.1"}, mod)
+
+	ctx, cancel := utils.WithSignal(context.Background())
+	defer cancel()
+
+	log.Info().
+		Str("broker", msgBrokerCon).
+		Uint("worker nr", workerNr).
+		Msg("starting qsfsd module")
+
+	utils.OnDone(ctx, func(_ error) {
+		log.Info().Msg("shutting down")
+	})
+
+	if err := server.Run(ctx); err != nil && err != context.Canceled {
+		return errors.Wrap(err, "unexpected error")
+	}
+
+	return nil
+}

--- a/cmds/zos/main.go
+++ b/cmds/zos/main.go
@@ -12,6 +12,7 @@ import (
 	"github.com/threefoldtech/zos/cmds/modules/gateway"
 	"github.com/threefoldtech/zos/cmds/modules/networkd"
 	"github.com/threefoldtech/zos/cmds/modules/provisiond"
+	"github.com/threefoldtech/zos/cmds/modules/qsfsd"
 	"github.com/threefoldtech/zos/cmds/modules/storaged"
 	"github.com/threefoldtech/zos/cmds/modules/vmd"
 	"github.com/threefoldtech/zos/cmds/modules/zbusdebug"
@@ -45,6 +46,7 @@ func main() {
 			&provisiond.Module,
 			&zbusdebug.Module,
 			&gateway.Module,
+			&qsfsd.Module,
 		},
 		Action: func(c *cli.Context) error {
 			if !c.Bool("list") {

--- a/etc/zinit/qsfsd.yaml
+++ b/etc/zinit/qsfsd.yaml
@@ -1,0 +1,3 @@
+exec: qsfsd --broker unix://var/run/redis.sock --root /var/cache/modules/qsfsd
+after:
+  - boot

--- a/go.sum
+++ b/go.sum
@@ -323,7 +323,6 @@ github.com/d2g/dhcp4client v1.0.0/go.mod h1:j0hNfjhrt2SxUOw55nL0ATM/z4Yt3t2Kd1mW
 github.com/d2g/dhcp4server v0.0.0-20181031114812-7d4a0a7f59a5/go.mod h1:Eo87+Kg/IX2hfWJfwxMzLyuSZyxSoAug2nGa1G2QAi8=
 github.com/d2g/hardwareaddr v0.0.0-20190221164911-e7d9fbe030e4/go.mod h1:bMl4RjIciD2oAxI7DmWRx6gbeqrkoLqv3MV0vzNad+I=
 github.com/dave/jennifer v1.2.0/go.mod h1:fIb+770HOpJ2fmN9EPPKOqm1vMGhB+TwXKMZhrIygKg=
-github.com/dave/jennifer v1.3.0 h1:p3tl41zjjCZTNBytMwrUuiAnherNUZktlhPTKoF/sEk=
 github.com/dave/jennifer v1.3.0/go.mod h1:fIb+770HOpJ2fmN9EPPKOqm1vMGhB+TwXKMZhrIygKg=
 github.com/davecgh/go-spew v0.0.0-20171005155431-ecdeabc65495/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=

--- a/go.sum
+++ b/go.sum
@@ -323,6 +323,7 @@ github.com/d2g/dhcp4client v1.0.0/go.mod h1:j0hNfjhrt2SxUOw55nL0ATM/z4Yt3t2Kd1mW
 github.com/d2g/dhcp4server v0.0.0-20181031114812-7d4a0a7f59a5/go.mod h1:Eo87+Kg/IX2hfWJfwxMzLyuSZyxSoAug2nGa1G2QAi8=
 github.com/d2g/hardwareaddr v0.0.0-20190221164911-e7d9fbe030e4/go.mod h1:bMl4RjIciD2oAxI7DmWRx6gbeqrkoLqv3MV0vzNad+I=
 github.com/dave/jennifer v1.2.0/go.mod h1:fIb+770HOpJ2fmN9EPPKOqm1vMGhB+TwXKMZhrIygKg=
+github.com/dave/jennifer v1.3.0 h1:p3tl41zjjCZTNBytMwrUuiAnherNUZktlhPTKoF/sEk=
 github.com/dave/jennifer v1.3.0/go.mod h1:fIb+770HOpJ2fmN9EPPKOqm1vMGhB+TwXKMZhrIygKg=
 github.com/davecgh/go-spew v0.0.0-20171005155431-ecdeabc65495/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=

--- a/pkg/container.go
+++ b/pkg/container.go
@@ -29,7 +29,6 @@ type NetworkInfo struct {
 type MountInfo struct {
 	Source string // source of the mount point on the host
 	Target string // target of mount inside the container
-	Shared bool
 }
 
 // Stats endpoints
@@ -68,6 +67,8 @@ type Container struct {
 	Elevated bool
 	// CreatedAt time
 	CreatedAt time.Time
+	// RootfsPropagation root fs propagation mode (rshared,shared,slave,...)
+	RootFsPropagation string
 }
 
 // ContainerModule defines rpc interface to containerd

--- a/pkg/container.go
+++ b/pkg/container.go
@@ -10,6 +10,18 @@ import (
 	"github.com/threefoldtech/zos/pkg/gridtypes"
 )
 
+const (
+	RootFSPropagationSlave    = "slave"
+	RootFSPropagationRslave   = "rslave"
+	RootFSPropagationShared   = "shared"
+	RootFSPropagationRshared  = "rshared"
+	RootFSPropagationPrivate  = "private"
+	RootFSPropagationRprivate = "rprivate"
+)
+
+// RootFSPropagation defines how the submounts are propagated to its mountpoint peers
+type RootFSPropagation string
+
 // ContainerID type
 type ContainerID string
 
@@ -68,7 +80,7 @@ type Container struct {
 	// CreatedAt time
 	CreatedAt time.Time
 	// RootfsPropagation root fs propagation mode (rshared,shared,slave,...)
-	RootFsPropagation string
+	RootFsPropagation RootFSPropagation
 }
 
 // ContainerModule defines rpc interface to containerd

--- a/pkg/container.go
+++ b/pkg/container.go
@@ -29,6 +29,7 @@ type NetworkInfo struct {
 type MountInfo struct {
 	Source string // source of the mount point on the host
 	Target string // target of mount inside the container
+	Shared bool
 }
 
 // Stats endpoints

--- a/pkg/container/container.go
+++ b/pkg/container/container.go
@@ -185,7 +185,9 @@ func (c *Module) Run(ns string, data pkg.Container) (id pkg.ContainerID, err err
 		WithMemoryLimit(uint64(data.Memory)),
 		WithCPUCount(data.CPU),
 	}
-
+	if data.RootFsPropagation != "" {
+		opts = append(opts, WithRootfsPropagation(data.RootFsPropagation))
+	}
 	if data.Elevated {
 		log.Warn().Msg("elevated container requested")
 

--- a/pkg/container/opts.go
+++ b/pkg/container/opts.go
@@ -71,9 +71,9 @@ func withMounts(mounts []pkg.MountInfo) oci.SpecOpts {
 }
 
 // WithRootfsPropagation makes the
-func WithRootfsPropagation(rootfsPropagation string) oci.SpecOpts {
+func WithRootfsPropagation(rootfsPropagation pkg.RootFSPropagation) oci.SpecOpts {
 	return func(_ context.Context, _ oci.Client, _ *containers.Container, s *oci.Spec) error {
-		s.Linux.RootfsPropagation = rootfsPropagation
+		s.Linux.RootfsPropagation = string(rootfsPropagation)
 		return nil
 	}
 }

--- a/pkg/container/opts.go
+++ b/pkg/container/opts.go
@@ -57,8 +57,6 @@ func withCoreX() oci.SpecOpts {
 }
 
 func withMounts(mounts []pkg.MountInfo) oci.SpecOpts {
-	var opts oci.SpecOpts
-	var shared bool
 	mnts := make([]specs.Mount, len(mounts))
 
 	for i, mount := range mounts {
@@ -68,22 +66,14 @@ func withMounts(mounts []pkg.MountInfo) oci.SpecOpts {
 			Source:      mount.Source,
 			Options:     []string{"rbind"},
 		}
-		if mount.Shared {
-			mnts[i].Options = append(mnts[i].Options, "rshared")
-			shared = true
-		}
 	}
-	opts = oci.WithMounts(mnts)
-	if shared {
-		opts = oci.Compose(opts, WithRootfsPropagation())
-	}
-	return opts
+	return oci.WithMounts(mnts)
 }
 
 // WithRootfsPropagation makes the
-func WithRootfsPropagation() oci.SpecOpts {
+func WithRootfsPropagation(rootfsPropagation string) oci.SpecOpts {
 	return func(_ context.Context, _ oci.Client, _ *containers.Container, s *oci.Spec) error {
-		s.Linux.RootfsPropagation = "shared"
+		s.Linux.RootfsPropagation = rootfsPropagation
 		return nil
 	}
 }

--- a/pkg/gridtypes/zos/qsfs.go
+++ b/pkg/gridtypes/zos/qsfs.go
@@ -212,7 +212,11 @@ func (q QuatumSafeFS) Challenge(w io.Writer) error {
 }
 
 func (q QuatumSafeFS) Capacity() (gridtypes.Capacity, error) {
-	return gridtypes.Capacity{}, nil
+	return gridtypes.Capacity{
+		CRU: 1,
+		MRU: 256 * gridtypes.Megabyte,
+		SRU: q.Cache, // is it HRU or SRU?
+	}, nil
 }
 
 type QuatumSafeFSResult struct {

--- a/pkg/network.go
+++ b/pkg/network.go
@@ -68,6 +68,9 @@ type Networker interface {
 	// for zdb is rewind. ns param is the namespace return by the ZDBPrepare
 	ZDBDestroy(ns string) error
 
+	// QSFSNamespace returns the namespace of the qsfs workload
+	QSFSNamespace(id string) string
+
 	// QSFSPrepare creates a network namespace with a macvlan interface into it
 	// to allow qsfs container to reach the internet but not be reachable itself
 	// it return the name of the network namespace created.

--- a/pkg/network/ndmz/ipam.go
+++ b/pkg/network/ndmz/ipam.go
@@ -6,6 +6,7 @@ import (
 	"github.com/containernetworking/cni/pkg/types"
 	"github.com/containernetworking/plugins/plugins/ipam/host-local/backend/allocator"
 	"github.com/containernetworking/plugins/plugins/ipam/host-local/backend/disk"
+	"github.com/rs/zerolog/log"
 )
 
 // allocateIPv4 allocates a unique IPv4 for the entity defines by the given id (for example container id, or a vm).
@@ -82,7 +83,10 @@ func deAllocateIPv4(networkID, leaseDir string) error {
 		return err
 	}
 
-	defer store.Unlock()
-
+	defer func() {
+		if err := store.Unlock(); err != nil {
+			log.Error().Err(err).Msg("failed to unlock store while deallocating ipv4")
+		}
+	}()
 	return store.ReleaseByID(networkID, "eth0")
 }

--- a/pkg/network/networker.go
+++ b/pkg/network/networker.go
@@ -234,12 +234,15 @@ func (n networker) ZDBDestroy(ns string) error {
 	// return n.destroy(ns)
 }
 
+func (n networker) QSFSNamespace(id string) string {
+	netId := "qsfs:" + id
+	hw := ifaceutil.HardwareAddrFromInputBytes([]byte(netId))
+	return qsfsNamespacePrefix + strings.Replace(hw.String(), ":", "", -1)
+}
+
 func (n networker) QSFSPrepare(id string) (string, error) {
 	netId := "qsfs:" + id
-
-	hw := ifaceutil.HardwareAddrFromInputBytes([]byte(netId))
-	netNSName := qsfsNamespacePrefix + strings.Replace(hw.String(), ":", "", -1)
-
+	netNSName := n.QSFSNamespace(id)
 	netNs, err := createNetNS(netNSName)
 	if err != nil {
 		return "", err
@@ -259,8 +262,7 @@ func (n networker) QSFSPrepare(id string) (string, error) {
 func (n networker) QSFSDestroy(id string) error {
 	netId := "qsfs:" + id
 
-	hw := ifaceutil.HardwareAddrFromInputBytes([]byte(netId))
-	netNSName := qsfsNamespacePrefix + strings.Replace(hw.String(), ":", "", -1)
+	netNSName := n.QSFSNamespace(id)
 
 	if err := n.ndmz.DetachNR(netId, n.ipamLeaseDir); err != nil {
 		log.Err(err).Str("namespace", netNSName).Msg("failed to detach qsfs namespace from ndmz")

--- a/pkg/network/networker.go
+++ b/pkg/network/networker.go
@@ -270,7 +270,10 @@ func (n networker) QSFSDestroy(id string) error {
 		return errors.Wrap(err, "didn't find qsfs namespace")
 	}
 	defer netNs.Close()
-	n.detachYgg(id, netNs)
+	if err := n.detachYgg(id, netNs); err != nil {
+		// log and continue cleaning up
+		log.Error().Err(err).Msg("couldn't detach ygg interface")
+	}
 	return n.destroy(netNSName)
 }
 

--- a/pkg/primitives/provisioner.go
+++ b/pkg/primitives/provisioner.go
@@ -30,6 +30,7 @@ func NewPrimitivesProvisioner(zbus zbus.Client) *Primitives {
 		zos.PublicIPType:         p.publicIPProvision,
 		zos.GatewayNameProxyType: p.gwProvision,
 		zos.GatewayFQDNProxyType: p.gwFQDNProvision,
+		zos.QuantumSafeFSType:    p.qsfsProvision,
 	}
 	decommissioners := map[gridtypes.WorkloadType]provision.RemoveFunction{
 		zos.ZMountType:           p.zMountDecommission,
@@ -39,6 +40,7 @@ func NewPrimitivesProvisioner(zbus zbus.Client) *Primitives {
 		zos.PublicIPType:         p.publicIPDecomission,
 		zos.GatewayNameProxyType: p.gwDecommission,
 		zos.GatewayFQDNProxyType: p.gwFQDNDecommission,
+		zos.QuantumSafeFSType:    p.qsfsDecommision,
 	}
 
 	// only network support update atm

--- a/pkg/primitives/qsfs.go
+++ b/pkg/primitives/qsfs.go
@@ -1,0 +1,41 @@
+package primitives
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+
+	"github.com/pkg/errors"
+	"github.com/threefoldtech/zos/pkg/gridtypes"
+	"github.com/threefoldtech/zos/pkg/gridtypes/zos"
+	"github.com/threefoldtech/zos/pkg/stubs"
+)
+
+const (
+	zstorSocket = "/var/run/zstor.sock"
+)
+
+func (p *Primitives) qsfsProvision(ctx context.Context, wl *gridtypes.WorkloadWithID) (interface{}, error) {
+	var result zos.QuatumSafeFSResult
+	var proxy zos.QuatumSafeFS
+	if err := json.Unmarshal(wl.Data, &proxy); err != nil {
+		return nil, fmt.Errorf("failed to unmarshal qsfs data from reservation: %w", err)
+	}
+	proxy.Config.Socket = zstorSocket
+	qsfs := stubs.NewQSFSDStub(p.zbus)
+	path, err := qsfs.Mount(ctx, wl.ID.String(), proxy)
+	if err != nil {
+		return nil, errors.Wrap(err, "failed to setup create qsfs mount")
+	}
+	result.Path = path
+	return result, nil
+}
+
+func (p *Primitives) qsfsDecommision(ctx context.Context, wl *gridtypes.WorkloadWithID) error {
+	qsfs := stubs.NewQSFSDStub(p.zbus)
+	err := qsfs.Unmount(ctx, wl.ID.String())
+	if err != nil {
+		return errors.Wrap(err, "failed to setup delete qsfs")
+	}
+	return nil
+}

--- a/pkg/qsfsd.go
+++ b/pkg/qsfsd.go
@@ -1,0 +1,12 @@
+package pkg
+
+import "github.com/threefoldtech/zos/pkg/gridtypes/zos"
+
+//go:generate mkdir -p stubs
+
+//go:generate zbusc -module qsfsd -version 0.0.1 -name manager -package stubs github.com/threefoldtech/zos/pkg+QSFSD stubs/qsfsd_stub.go
+
+type QSFSD interface {
+	Mount(wlID string, cfg zos.QuatumSafeFS) (string, error)
+	Unmount(wlID string) error
+}

--- a/pkg/qsfsd.go
+++ b/pkg/qsfsd.go
@@ -1,12 +1,27 @@
 package pkg
 
-import "github.com/threefoldtech/zos/pkg/gridtypes/zos"
+import (
+	"github.com/threefoldtech/zos/pkg/gridtypes/zos"
+)
 
 //go:generate mkdir -p stubs
 
 //go:generate zbusc -module qsfsd -version 0.0.1 -name manager -package stubs github.com/threefoldtech/zos/pkg+QSFSD stubs/qsfsd_stub.go
 
+type QSFSMetrics struct {
+	Consumption map[string]NetMetric
+}
+
+func (q *QSFSMetrics) Nu(wlID string) (result uint64) {
+	if v, ok := q.Consumption[wlID]; ok {
+		result += v.NetRxBytes
+		result += v.NetTxBytes
+	}
+	return
+}
+
 type QSFSD interface {
 	Mount(wlID string, cfg zos.QuatumSafeFS) (string, error)
 	Unmount(wlID string) error
+	Metrics() (QSFSMetrics, error)
 }

--- a/pkg/qsfsd/metrics.go
+++ b/pkg/qsfsd/metrics.go
@@ -1,0 +1,108 @@
+package qsfsd
+
+import (
+	"context"
+	"fmt"
+	"io/ioutil"
+	"os"
+	"path/filepath"
+	"strconv"
+	"strings"
+	"syscall"
+	"time"
+
+	"github.com/containernetworking/plugins/pkg/ns"
+	"github.com/pkg/errors"
+	"github.com/rs/zerolog/log"
+	"github.com/threefoldtech/zos/pkg"
+	"github.com/threefoldtech/zos/pkg/network/namespace"
+	"github.com/threefoldtech/zos/pkg/stubs"
+)
+
+// Metrics gets running qsfs network metrics
+func (m *QSFS) Metrics() (pkg.QSFSMetrics, error) {
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Minute)
+	defer cancel()
+	networker := stubs.NewNetworkerStub(m.cl)
+	result := make(map[string]pkg.NetMetric)
+
+	items, err := ioutil.ReadDir(m.mountsPath)
+	if err != nil {
+		return pkg.QSFSMetrics{}, errors.Wrap(err, "failed to list mounts directory")
+	}
+	for _, item := range items {
+		if item.IsDir() {
+			name := item.Name()
+			nsName := networker.QSFSNamespace(ctx, name)
+			netNs, err := namespace.GetByName(nsName)
+			if err != nil {
+				return pkg.QSFSMetrics{}, errors.Wrap(err, "didn't find qsfs namespace")
+			}
+			defer netNs.Close()
+			metrics := pkg.NetMetric{}
+			err = netNs.Do(func(_ ns.NetNS) error {
+				dir, err := ioutil.TempDir("/tmp", "qsfs-sysfs")
+				if err != nil {
+					return errors.Wrap(err, "coudln't create temp dir")
+				}
+				defer func() {
+					if err := os.RemoveAll(dir); err != nil {
+						log.Error().Err(err).Msg(fmt.Sprintf("qsfs metrics: couldn't remove: %s", dir))
+					}
+				}()
+				if err := syscall.Mount("newns", dir, "sysfs", 0, ""); err != nil {
+					return errors.Wrap(err, "couldn't mount sysfs")
+				}
+				defer func() {
+					if err := syscall.Unmount(dir, syscall.MNT_DETACH); err != nil {
+						log.Error().Err(err).Msg("qsfs metrics: couldn't detach sysfs: %s")
+					}
+				}()
+
+				metrics, err = metricsForNics(dir, []string{"public", "ygg0"})
+				return err
+			})
+			if err != nil {
+				log.Error().Err(err).Msg(fmt.Sprintf("failed to read workload %s's metrics", name))
+				continue
+			}
+			result[name] = metrics
+		}
+	}
+	return pkg.QSFSMetrics{Consumption: result}, nil
+}
+
+func readFileUint64(p string) (uint64, error) {
+	bytes, err := ioutil.ReadFile(p)
+	if err != nil {
+		// we do skip but may be this is not crre
+		return 0, err
+	}
+
+	return strconv.ParseUint(strings.TrimSpace(string(bytes)), 10, 64)
+}
+
+func metricsForNics(sysfsPath string, nics []string) (m pkg.NetMetric, err error) {
+	template := filepath.Join(sysfsPath, "class/net/%s/statistics/")
+	dict := map[string]*uint64{
+		"rx_bytes":   &m.NetRxBytes,
+		"rx_packets": &m.NetRxPackets,
+		"tx_bytes":   &m.NetTxBytes,
+		"tx_packets": &m.NetTxPackets,
+	}
+	for _, nic := range nics {
+		base := fmt.Sprintf(template, nic)
+		for metric, ptr := range dict {
+			path := filepath.Join(base, metric)
+			value, err := readFileUint64(path)
+			if err != nil {
+				log.Error().Err(err).Str("path", path).Msg("failed to read statistics")
+				continue
+			}
+
+			*ptr += value
+		}
+	}
+
+	return
+}

--- a/pkg/qsfsd/qsfs.go
+++ b/pkg/qsfsd/qsfs.go
@@ -64,9 +64,11 @@ func (q *QSFS) Mount(wlID string, cfg zos.QuatumSafeFS) (string, error) {
 		Limit:    cfg.Cache,
 		Storage:  "zdb://hub.grid.tf:9900",
 	})
-	q.writeQSFSConfig(flistPath, cfg.Config)
 	if err != nil {
 		return "", errors.Wrap(err, "failed to mount qsfs flist")
+	}
+	if err := q.writeQSFSConfig(flistPath, cfg.Config); err != nil {
+		return "", errors.Wrap(err, "couldn't write qsfs config")
 	}
 	mountPath := q.mountPath(wlID)
 	err = q.prepareMountPath(mountPath)
@@ -74,7 +76,7 @@ func (q *QSFS) Mount(wlID string, cfg zos.QuatumSafeFS) (string, error) {
 		return "", errors.Wrap(err, "failed to prepare mount path")
 	}
 	cont := pkg.Container{
-		Name:        wlID, // what should the name be?
+		Name:        wlID,
 		RootFS:      flistPath,
 		Entrypoint:  "/sbin/zinit init",
 		Interactive: false,
@@ -86,7 +88,7 @@ func (q *QSFS) Mount(wlID string, cfg zos.QuatumSafeFS) (string, error) {
 			},
 		},
 		Elevated: true,
-		// the default is rslave which recursively sets all mounts points to slave
+		// the default is rslave which recursively sets all mountpoints to slave
 		// we don't care about the rootfs propagation, it just has to be non-recursive
 		RootFsPropagation: "slave",
 	}

--- a/pkg/qsfsd/qsfs.go
+++ b/pkg/qsfsd/qsfs.go
@@ -17,8 +17,9 @@ import (
 )
 
 const (
-	qsfsFlist       = "https://hub.grid.tf/azmy.3bot/qsfs.flist"
-	qsfsContainerNS = "qsfs"
+	qsfsFlist             = "https://hub.grid.tf/azmy.3bot/qsfs.flist"
+	qsfsContainerNS       = "qsfs"
+	qsfsRootFsPropagation = pkg.RootFSPropagationSlave
 )
 
 type QSFS struct {
@@ -92,7 +93,7 @@ func (q *QSFS) Mount(wlID string, cfg zos.QuatumSafeFS) (mountPath string, err e
 		Elevated: true,
 		// the default is rslave which recursively sets all mountpoints to slave
 		// we don't care about the rootfs propagation, it just has to be non-recursive
-		RootFsPropagation: "slave",
+		RootFsPropagation: qsfsRootFsPropagation,
 	}
 	_, err = contd.Run(
 		ctx,

--- a/pkg/qsfsd/qsfs.go
+++ b/pkg/qsfsd/qsfs.go
@@ -1,0 +1,167 @@
+package qsfsd
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"syscall"
+	"time"
+
+	"github.com/BurntSushi/toml"
+	"github.com/pkg/errors"
+	"github.com/rs/zerolog/log"
+	"github.com/threefoldtech/zbus"
+	"github.com/threefoldtech/zos/pkg"
+	"github.com/threefoldtech/zos/pkg/gridtypes/zos"
+	"github.com/threefoldtech/zos/pkg/stubs"
+)
+
+const (
+	qsfsFlist       = "https://hub.grid.tf/azmy.3bot/qsfs.flist"
+	qsfsContainerNS = "qsfs"
+)
+
+type QSFS struct {
+	cl zbus.Client
+
+	mountsPath string
+}
+
+func New(ctx context.Context, cl zbus.Client, root string) (pkg.QSFSD, error) {
+	mountPath := filepath.Join(root, "mounts")
+	err := os.MkdirAll(mountPath, 0644)
+	if err != nil {
+		return nil, errors.Wrap(err, "couldn't make qsfs mounts dir")
+	}
+
+	return &QSFS{
+		cl:         cl,
+		mountsPath: mountPath,
+	}, nil
+}
+
+func (q *QSFS) Mount(wlID string, cfg zos.QuatumSafeFS) (string, error) {
+	networkd := stubs.NewNetworkerStub(q.cl)
+	flistd := stubs.NewFlisterStub(q.cl)
+	contd := stubs.NewContainerModuleStub(q.cl)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 1*time.Minute)
+	defer cancel()
+	netns, err := networkd.QSFSPrepare(ctx, wlID)
+	defer func() {
+		if err != nil {
+			err := networkd.QSFSDestroy(ctx, wlID)
+			if err != nil {
+				log.Error().Err(err).Msg("failed to cleanup qsfs after failure")
+			}
+		}
+	}()
+	if err != nil {
+		return "", errors.Wrap(err, "failed to prepare qsfs")
+	}
+	flistPath, err := flistd.Mount(ctx, wlID, qsfsFlist, pkg.MountOptions{
+		ReadOnly: false,
+		Limit:    cfg.Cache,
+		Storage:  "zdb://hub.grid.tf:9900",
+	})
+	q.writeQSFSConfig(flistPath, cfg.Config)
+	if err != nil {
+		return "", errors.Wrap(err, "failed to mount qsfs flist")
+	}
+	mountPath := q.mountPath(wlID)
+	fusePath, err := q.prepareMountPath(mountPath)
+	if err != nil {
+		return "", errors.Wrap(err, "failed to prepare mount path")
+	}
+	cont := pkg.Container{
+		Name:        wlID, // what should the name be?
+		RootFS:      flistPath,
+		Entrypoint:  "/sbin/zinit init",
+		Interactive: false,
+		Network:     pkg.NetworkInfo{Namespace: netns},
+		Mounts: []pkg.MountInfo{
+			{
+				Source: fusePath,
+				Target: "/mnt",
+				Shared: true,
+			},
+		},
+		Elevated: true,
+	}
+	_, err = contd.Run(
+		ctx,
+		qsfsContainerNS,
+		cont,
+	)
+	return fusePath, nil
+}
+func (q *QSFS) Unmount(wlID string) error {
+	networkd := stubs.NewNetworkerStub(q.cl)
+	flistd := stubs.NewFlisterStub(q.cl)
+	contd := stubs.NewContainerModuleStub(q.cl)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 1*time.Minute)
+	defer cancel()
+	// listing all containers and matching the name looks like a lot of work
+	if err := contd.Delete(ctx, qsfsContainerNS, pkg.ContainerID(wlID)); err != nil {
+		log.Error().Err(err).Msg("failed to delete qsfs container")
+	}
+	mountPath := q.mountPath(wlID)
+	fusePath := filepath.Join(mountPath, "mnt")
+	if err := syscall.Unmount(fusePath, 0); err != nil {
+		log.Error().Err(err).Msg("failed to unmount mount path")
+	}
+	if err := syscall.Unmount(mountPath, 0); err != nil {
+		log.Error().Err(err).Msg("failed to unmount mount path")
+	}
+	if err := os.RemoveAll(mountPath); err != nil {
+		log.Error().Err(err).Msg("failed to remove mountpath dir")
+	}
+	if err := flistd.Unmount(ctx, wlID); err != nil {
+		log.Error().Err(err).Msg("failed to unmount flist")
+	}
+
+	if err := networkd.QSFSDestroy(ctx, wlID); err != nil {
+		log.Error().Err(err).Msg("failed to unmount flist")
+	}
+	return nil
+}
+
+func (q *QSFS) mountPath(wlID string) string {
+	return filepath.Join(q.mountsPath, wlID)
+}
+
+func (q *QSFS) prepareMountPath(path string) (string, error) {
+	fusePath := filepath.Join(path, "mnt")
+	if err := os.Mkdir(path, 0644); err != nil {
+		return "", err
+	}
+	if err := os.Mkdir(fusePath, 0644); err != nil {
+		return "", err
+	}
+	if err := syscall.Mount(path, path, "bind", syscall.MS_BIND, ""); err != nil {
+		return "", err
+	}
+	if err := syscall.Mount("none", path, "", syscall.MS_SHARED, ""); err != nil {
+		if err := syscall.Unmount(path, 0); err != nil {
+			log.Error().Err(err).Msg("failed to unmount after failure")
+		}
+		return "", err
+	}
+	return fusePath, nil
+}
+
+func (q *QSFS) writeQSFSConfig(root string, cfg zos.QuantumSafeFSConfig) error {
+	cfgPath := filepath.Join(root, "data/zstor.toml")
+	f, err := os.OpenFile(cfgPath, os.O_WRONLY|os.O_CREATE, 0644)
+	if err != nil {
+		return errors.Wrap(err, "couldn't open zstor config file")
+	}
+	defer f.Close()
+
+	if err := toml.NewEncoder(f).Encode(cfg); err != nil {
+		return errors.Wrap(err, "failed to convert config to yaml")
+	}
+
+	return nil
+}

--- a/pkg/stubs/network_stub.go
+++ b/pkg/stubs/network_stub.go
@@ -283,6 +283,18 @@ func (s *NetworkerStub) QSFSDestroy(ctx context.Context, arg0 string) (ret0 erro
 	return
 }
 
+func (s *NetworkerStub) QSFSNamespace(ctx context.Context, arg0 string) (ret0 string) {
+	args := []interface{}{arg0}
+	result, err := s.client.RequestContext(ctx, s.module, s.object, "QSFSNamespace", args...)
+	if err != nil {
+		panic(err)
+	}
+	if err := result.Unmarshal(0, &ret0); err != nil {
+		panic(err)
+	}
+	return
+}
+
 func (s *NetworkerStub) QSFSPrepare(ctx context.Context, arg0 string) (ret0 string, ret1 error) {
 	args := []interface{}{arg0}
 	result, err := s.client.RequestContext(ctx, s.module, s.object, "QSFSPrepare", args...)

--- a/pkg/stubs/qsfsd_stub.go
+++ b/pkg/stubs/qsfsd_stub.go
@@ -1,0 +1,53 @@
+package stubs
+
+import (
+	"context"
+	zbus "github.com/threefoldtech/zbus"
+	zos "github.com/threefoldtech/zos/pkg/gridtypes/zos"
+)
+
+type QSFSDStub struct {
+	client zbus.Client
+	module string
+	object zbus.ObjectID
+}
+
+func NewQSFSDStub(client zbus.Client) *QSFSDStub {
+	return &QSFSDStub{
+		client: client,
+		module: "qsfsd",
+		object: zbus.ObjectID{
+			Name:    "manager",
+			Version: "0.0.1",
+		},
+	}
+}
+
+func (s *QSFSDStub) Mount(ctx context.Context, arg0 string, arg1 zos.QuatumSafeFS) (ret0 string, ret1 error) {
+	args := []interface{}{arg0, arg1}
+	result, err := s.client.RequestContext(ctx, s.module, s.object, "Mount", args...)
+	if err != nil {
+		panic(err)
+	}
+	if err := result.Unmarshal(0, &ret0); err != nil {
+		panic(err)
+	}
+	ret1 = new(zbus.RemoteError)
+	if err := result.Unmarshal(1, &ret1); err != nil {
+		panic(err)
+	}
+	return
+}
+
+func (s *QSFSDStub) Unmount(ctx context.Context, arg0 string) (ret0 error) {
+	args := []interface{}{arg0}
+	result, err := s.client.RequestContext(ctx, s.module, s.object, "Unmount", args...)
+	if err != nil {
+		panic(err)
+	}
+	ret0 = new(zbus.RemoteError)
+	if err := result.Unmarshal(0, &ret0); err != nil {
+		panic(err)
+	}
+	return
+}

--- a/pkg/stubs/qsfsd_stub.go
+++ b/pkg/stubs/qsfsd_stub.go
@@ -3,6 +3,7 @@ package stubs
 import (
 	"context"
 	zbus "github.com/threefoldtech/zbus"
+	pkg "github.com/threefoldtech/zos/pkg"
 	zos "github.com/threefoldtech/zos/pkg/gridtypes/zos"
 )
 
@@ -21,6 +22,22 @@ func NewQSFSDStub(client zbus.Client) *QSFSDStub {
 			Version: "0.0.1",
 		},
 	}
+}
+
+func (s *QSFSDStub) Metrics(ctx context.Context) (ret0 pkg.QSFSMetrics, ret1 error) {
+	args := []interface{}{}
+	result, err := s.client.RequestContext(ctx, s.module, s.object, "Metrics", args...)
+	if err != nil {
+		panic(err)
+	}
+	if err := result.Unmarshal(0, &ret0); err != nil {
+		panic(err)
+	}
+	ret1 = new(zbus.RemoteError)
+	if err := result.Unmarshal(1, &ret1); err != nil {
+		panic(err)
+	}
+	return
 }
 
 func (s *QSFSDStub) Mount(ctx context.Context, arg0 string, arg1 zos.QuatumSafeFS) (ret0 string, ret1 error) {

--- a/pkg/vm/metrics.go
+++ b/pkg/vm/metrics.go
@@ -92,6 +92,7 @@ func (m *Module) metrics(ps Process) (pkg.MachineMetric, error) {
 					Int("pid", ps.Pid).
 					Str("net", nic).
 					Msg("failed to get macvtap for public ip")
+				continue
 			}
 
 			pub = append(pub, tap)


### PR DESCRIPTION
1. QSFSPrepare => QSFSDestroy => QSFSPrepare, failed because of `can't set hw addr: already in use`. Fixed by deleting the ygg link explicitly before removing the namespace.
2. Add `RootfsPropagation` as the default one sets the mounts to `slave` recursively.