### PR TITLE
Add qsfs update method

### DIFF
--- a/cmds/zos/main.go
+++ b/cmds/zos/main.go
@@ -14,7 +14,6 @@ import (
 	"github.com/threefoldtech/zos/cmds/modules/provisiond"
 	"github.com/threefoldtech/zos/cmds/modules/qsfsd"
 	"github.com/threefoldtech/zos/cmds/modules/storaged"
-	"github.com/threefoldtech/zos/cmds/modules/test"
 	"github.com/threefoldtech/zos/cmds/modules/vmd"
 	"github.com/threefoldtech/zos/cmds/modules/zbusdebug"
 	"github.com/threefoldtech/zos/cmds/modules/zui"
@@ -48,7 +47,6 @@ func main() {
 			&zbusdebug.Module,
 			&gateway.Module,
 			&qsfsd.Module,
-			&test.Module,
 		},
 		Action: func(c *cli.Context) error {
 			if !c.Bool("list") {

--- a/cmds/zos/main.go
+++ b/cmds/zos/main.go
@@ -14,6 +14,7 @@ import (
 	"github.com/threefoldtech/zos/cmds/modules/provisiond"
 	"github.com/threefoldtech/zos/cmds/modules/qsfsd"
 	"github.com/threefoldtech/zos/cmds/modules/storaged"
+	"github.com/threefoldtech/zos/cmds/modules/test"
 	"github.com/threefoldtech/zos/cmds/modules/vmd"
 	"github.com/threefoldtech/zos/cmds/modules/zbusdebug"
 	"github.com/threefoldtech/zos/cmds/modules/zui"
@@ -47,6 +48,7 @@ func main() {
 			&zbusdebug.Module,
 			&gateway.Module,
 			&qsfsd.Module,
+			&test.Module,
 		},
 		Action: func(c *cli.Context) error {
 			if !c.Bool("list") {

--- a/go.sum
+++ b/go.sum
@@ -324,6 +324,7 @@ github.com/d2g/dhcp4client v1.0.0/go.mod h1:j0hNfjhrt2SxUOw55nL0ATM/z4Yt3t2Kd1mW
 github.com/d2g/dhcp4server v0.0.0-20181031114812-7d4a0a7f59a5/go.mod h1:Eo87+Kg/IX2hfWJfwxMzLyuSZyxSoAug2nGa1G2QAi8=
 github.com/d2g/hardwareaddr v0.0.0-20190221164911-e7d9fbe030e4/go.mod h1:bMl4RjIciD2oAxI7DmWRx6gbeqrkoLqv3MV0vzNad+I=
 github.com/dave/jennifer v1.2.0/go.mod h1:fIb+770HOpJ2fmN9EPPKOqm1vMGhB+TwXKMZhrIygKg=
+github.com/dave/jennifer v1.3.0 h1:p3tl41zjjCZTNBytMwrUuiAnherNUZktlhPTKoF/sEk=
 github.com/dave/jennifer v1.3.0/go.mod h1:fIb+770HOpJ2fmN9EPPKOqm1vMGhB+TwXKMZhrIygKg=
 github.com/davecgh/go-spew v0.0.0-20171005155431-ecdeabc65495/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=

--- a/pkg/container.go
+++ b/pkg/container.go
@@ -91,6 +91,9 @@ type ContainerModule interface {
 	// data: Container info
 	Run(ns string, data Container) (ContainerID, error)
 
+	// Exec executes a command in the container
+	// stdout and stderr is ignored
+	Exec(ns string, containerID string, timeout time.Duration, args ...string) error
 	// ListNS list the name of all the container namespaces
 	ListNS() ([]string, error)
 

--- a/pkg/container/watch.go
+++ b/pkg/container/watch.go
@@ -20,6 +20,11 @@ func (c *Module) handlerEventTaskExit(ctx context.Context, ns string, event *eve
 
 	log.Debug().Msg("task exited")
 
+	if event.ID != event.ContainerID {
+		// something other than the main container task, ignore it
+		return
+	}
+
 	marker, ok := c.failures.Get(event.ContainerID)
 	if !ok {
 		// no previous value. so this is the first failure
@@ -70,6 +75,7 @@ func (c *Module) handleEvent(ctx context.Context, ns string, event interface{}) 
 		// - we don't want the restarts to slow down the event stream processing
 		// - this method does not return any useful value anyway, so safe to run
 		//   it in the background.
+		log.Debug().Msgf("handled event: %+v", event)
 		go c.handlerEventTaskExit(ctx, ns, event)
 	default:
 		log.Debug().Msgf("unhandled event: %+v", event)

--- a/pkg/container/watch.go
+++ b/pkg/container/watch.go
@@ -75,7 +75,6 @@ func (c *Module) handleEvent(ctx context.Context, ns string, event interface{}) 
 		// - we don't want the restarts to slow down the event stream processing
 		// - this method does not return any useful value anyway, so safe to run
 		//   it in the background.
-		log.Debug().Msgf("handled event: %+v", event)
 		go c.handlerEventTaskExit(ctx, ns, event)
 	default:
 		log.Debug().Msgf("unhandled event: %+v", event)

--- a/pkg/flist.go
+++ b/pkg/flist.go
@@ -39,6 +39,9 @@ type Flister interface {
 	// mount is not needed anymore and clean it up
 	Mount(name, url string, opt MountOptions) (path string, err error)
 
+	// UpdateMountSize change the mount size
+	UpdateMountSize(name string, limit gridtypes.Unit) (path string, err error)
+
 	// Umount a RW mount. this only unmounts the RW layer and remove the assigned
 	// volume.
 	Unmount(name string) error

--- a/pkg/flist/flist.go
+++ b/pkg/flist/flist.go
@@ -384,6 +384,22 @@ func (f *flistModule) Mount(name, url string, opt pkg.MountOptions) (string, err
 	return mountpoint, f.mountOverlay(ctx, name, ro, opt.Limit)
 }
 
+func (f *flistModule) UpdateMountSize(name string, limit gridtypes.Unit) (string, error) {
+	// mount overlay
+	mountpoint, err := f.mountpath(name)
+	if err != nil {
+		return "", errors.Wrap(err, "invalid mountpoint")
+	}
+
+	if err := f.isMountpoint(mountpoint); err != nil {
+		return "", errors.Wrap(err, "flist not mounted")
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+	err = f.storage.VolumeUpdate(ctx, name, limit)
+	return mountpoint, err
+}
+
 func (f *flistModule) mountpath(name string) (string, error) {
 	mountpath := filepath.Join(f.mountpoint, name)
 	if filepath.Dir(mountpath) != f.mountpoint {

--- a/pkg/flist/flist.go
+++ b/pkg/flist/flist.go
@@ -356,9 +356,6 @@ func (f *flistModule) Mount(name, url string, opt pkg.MountOptions) (string, err
 	}
 
 	if err := f.valid(mountpoint); err == ErrAlreadyMounted {
-		ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
-		defer cancel()
-		err := f.storage.VolumeUpdate(ctx, name, opt.Limit)
 		return mountpoint, err
 	} else if err != nil {
 		return "", errors.Wrap(err, "validating of mount point failed")

--- a/pkg/flist/flist.go
+++ b/pkg/flist/flist.go
@@ -356,7 +356,7 @@ func (f *flistModule) Mount(name, url string, opt pkg.MountOptions) (string, err
 	}
 
 	if err := f.valid(mountpoint); err == ErrAlreadyMounted {
-		return mountpoint, err
+		return mountpoint, nil
 	} else if err != nil {
 		return "", errors.Wrap(err, "validating of mount point failed")
 	}

--- a/pkg/flist/flist_test.go
+++ b/pkg/flist/flist_test.go
@@ -38,6 +38,12 @@ func (s *StorageMock) VolumeCreate(ctx context.Context, name string, size gridty
 	}, args.Error(1)
 }
 
+// UpdateFilesystem update filesystem mock
+func (s *StorageMock) VolumeUpdate(ctx context.Context, name string, size gridtypes.Unit) error {
+	args := s.Called(ctx, name)
+	return args.Error(0)
+}
+
 // ReleaseFilesystem releases filesystem mock
 func (s *StorageMock) VolumeDelete(ctx context.Context, name string) error {
 	args := s.Called(ctx, name)

--- a/pkg/network.go
+++ b/pkg/network.go
@@ -72,7 +72,7 @@ type Networker interface {
 	QSFSNamespace(id string) string
 
 	// QSFSYggIP returns the ygg ip of the qsfs workload
-	QSFSYggIP(id string) (net.IPNet, error)
+	QSFSYggIP(id string) (string, error)
 
 	// QSFSPrepare creates a network namespace with a macvlan interface into it
 	// to allow qsfs container to reach the internet but not be reachable itself

--- a/pkg/network.go
+++ b/pkg/network.go
@@ -71,6 +71,9 @@ type Networker interface {
 	// QSFSNamespace returns the namespace of the qsfs workload
 	QSFSNamespace(id string) string
 
+	// QSFSYggIP returns the ygg ip of the qsfs workload
+	QSFSYggIP(id string) (net.IPNet, error)
+
 	// QSFSPrepare creates a network namespace with a macvlan interface into it
 	// to allow qsfs container to reach the internet but not be reachable itself
 	// it return the name of the network namespace created, and the ygg ip.

--- a/pkg/network/qsfs.go
+++ b/pkg/network/qsfs.go
@@ -1,6 +1,8 @@
 package network
 
 import (
+	"fmt"
+	"net"
 	"strings"
 
 	"github.com/pkg/errors"
@@ -54,7 +56,15 @@ func (n networker) QSFSNamespace(id string) string {
 	hw := ifaceutil.HardwareAddrFromInputBytes([]byte(netId))
 	return qsfsNamespacePrefix + strings.Replace(hw.String(), ":", "", -1)
 }
+func (n networker) QSFSYggIP(id string) (net.IPNet, error) {
+	hw := ifaceutil.HardwareAddrFromInputBytes([]byte("ygg:" + id))
 
+	ip, err := n.ygg.SubnetFor(hw)
+	if err != nil {
+		return net.IPNet{}, fmt.Errorf("failed to get ygg subnet IP: %w", err)
+	}
+	return ip, nil
+}
 func (n networker) QSFSPrepare(id string) (string, string, error) {
 	netId := "qsfs:" + id
 	netNSName := n.QSFSNamespace(id)

--- a/pkg/network/qsfs.go
+++ b/pkg/network/qsfs.go
@@ -2,7 +2,6 @@ package network
 
 import (
 	"fmt"
-	"net"
 	"strings"
 
 	"github.com/pkg/errors"
@@ -56,14 +55,14 @@ func (n networker) QSFSNamespace(id string) string {
 	hw := ifaceutil.HardwareAddrFromInputBytes([]byte(netId))
 	return qsfsNamespacePrefix + strings.Replace(hw.String(), ":", "", -1)
 }
-func (n networker) QSFSYggIP(id string) (net.IPNet, error) {
+func (n networker) QSFSYggIP(id string) (string, error) {
 	hw := ifaceutil.HardwareAddrFromInputBytes([]byte("ygg:" + id))
 
 	ip, err := n.ygg.SubnetFor(hw)
 	if err != nil {
-		return net.IPNet{}, fmt.Errorf("failed to get ygg subnet IP: %w", err)
+		return "", fmt.Errorf("failed to get ygg subnet IP: %w", err)
 	}
-	return ip, nil
+	return ip.IP.String(), nil
 }
 func (n networker) QSFSPrepare(id string) (string, string, error) {
 	netId := "qsfs:" + id
@@ -82,7 +81,7 @@ func (n networker) QSFSPrepare(id string) (string, string, error) {
 	}
 
 	if n.ygg == nil {
-		return netNSName, "", nil
+		return "", "", errors.New("no ygg server found")
 	}
 	ip, err := n.attachYgg(id, netNs)
 	if err != nil {

--- a/pkg/primitives/provisioner.go
+++ b/pkg/primitives/provisioner.go
@@ -45,7 +45,8 @@ func NewPrimitivesProvisioner(zbus zbus.Client) *Primitives {
 
 	// only network support update atm
 	updaters := map[gridtypes.WorkloadType]provision.DeployFunction{
-		zos.NetworkType: p.networkProvision,
+		zos.NetworkType:       p.networkProvision,
+		zos.QuantumSafeFSType: p.qsfsUpdate,
 	}
 
 	p.Provisioner = provision.NewMapProvisioner(provisioners, decommissioners, updaters)

--- a/pkg/primitives/qsfs.go
+++ b/pkg/primitives/qsfs.go
@@ -37,7 +37,6 @@ func (p *Primitives) qsfsDecommision(ctx context.Context, wl *gridtypes.Workload
 }
 
 func (p *Primitives) qsfsUpdate(ctx context.Context, wl *gridtypes.WorkloadWithID) (interface{}, error) {
-	// can i read the old workload data? cache is ignored until then
 	var result zos.QuatumSafeFSResult
 	var proxy zos.QuantumSafeFS
 	if err := json.Unmarshal(wl.Data, &proxy); err != nil {

--- a/pkg/primitives/qsfs.go
+++ b/pkg/primitives/qsfs.go
@@ -20,7 +20,7 @@ func (p *Primitives) qsfsProvision(ctx context.Context, wl *gridtypes.WorkloadWi
 	qsfs := stubs.NewQSFSDStub(p.zbus)
 	info, err := qsfs.Mount(ctx, wl.ID.String(), proxy)
 	if err != nil {
-		return nil, errors.Wrap(err, "failed to setup create qsfs mount")
+		return nil, errors.Wrap(err, "failed to create qsfs mount")
 	}
 	result.Path = info.Path
 	result.MetricsEndpoint = info.MetricsEndpoint
@@ -31,7 +31,24 @@ func (p *Primitives) qsfsDecommision(ctx context.Context, wl *gridtypes.Workload
 	qsfs := stubs.NewQSFSDStub(p.zbus)
 	err := qsfs.Unmount(ctx, wl.ID.String())
 	if err != nil {
-		return errors.Wrap(err, "failed to setup delete qsfs")
+		return errors.Wrap(err, "failed to delete qsfs")
 	}
 	return nil
+}
+
+func (p *Primitives) qsfsUpdate(ctx context.Context, wl *gridtypes.WorkloadWithID) (interface{}, error) {
+	// can i read the old workload data? cache is ignored until then
+	var result zos.QuatumSafeFSResult
+	var proxy zos.QuantumSafeFS
+	if err := json.Unmarshal(wl.Data, &proxy); err != nil {
+		return nil, fmt.Errorf("failed to unmarshal qsfs data from reservation: %w", err)
+	}
+	qsfs := stubs.NewQSFSDStub(p.zbus)
+	info, err := qsfs.UpdateMount(ctx, wl.ID.String(), proxy)
+	if err != nil {
+		return nil, errors.Wrap(err, "failed to update qsfs mount")
+	}
+	result.Path = info.Path
+	result.MetricsEndpoint = info.MetricsEndpoint
+	return result, nil
 }

--- a/pkg/qsfsd.go
+++ b/pkg/qsfsd.go
@@ -27,6 +27,7 @@ func (q *QSFSMetrics) Nu(wlID string) (result uint64) {
 
 type QSFSD interface {
 	Mount(wlID string, cfg zos.QuantumSafeFS) (QSFSInfo, error)
+	UpdateMount(wlID string, cfg zos.QuantumSafeFS) (QSFSInfo, error)
 	Unmount(wlID string) error
 	Metrics() (QSFSMetrics, error)
 }

--- a/pkg/qsfsd/qsfs.go
+++ b/pkg/qsfsd/qsfs.go
@@ -186,22 +186,16 @@ func (q *QSFS) UpdateMount(wlID string, cfg zos.QuantumSafeFS) (pkg.QSFSInfo, er
 	zstorConfig := setQSFSDefaults(&cfg)
 	networkd := stubs.NewNetworkerStub(q.cl)
 	flistd := stubs.NewFlisterStub(q.cl)
+	contd := stubs.NewContainerModuleStub(q.cl)
 
 	ctx, cancel := context.WithTimeout(context.Background(), 1*time.Minute)
 	defer cancel()
-	netns := networkd.QSFSNamespace(ctx, wlID)
-	ips, _, err := networkd.Addrs(ctx, "ygg0", netns)
+
+	yggIP, err := networkd.QSFSYggIP(ctx, wlID)
 	if err != nil {
 		return info, errors.Wrap(err, "failed to get ygg ip")
 	}
-	if len(ips) != 1 {
-		return info, errors.Wrap(err, "multiple ips found at ygg interface")
-	}
-	yggIP := ips[0]
-	flistPath, err := flistd.Mount(ctx, wlID, qsfsFlist, pkg.MountOptions{
-		ReadOnly: false,
-		Limit:    cfg.Cache,
-	})
+	flistPath, err := flistd.UpdateMountSize(ctx, wlID, cfg.Cache)
 	if err != nil {
 		return info, errors.Wrap(err, "failed to get qsfs flist mountpoint")
 	}
@@ -209,18 +203,9 @@ func (q *QSFS) UpdateMount(wlID string, cfg zos.QuantumSafeFS) (pkg.QSFSInfo, er
 		return info, errors.Wrap(err, "couldn't write qsfs config")
 	}
 	mountPath := q.mountPath(wlID)
-	cmd := exec.Command("runc", "--root", fmt.Sprintf("/run/containerd/runc/%s/", qsfsContainerNS), "exec", wlID, "/sbin/zinit", "kill", "zstor")
-	cmd.Stderr = cmd.Stdout
-	err = cmd.Run()
-	if err != nil {
-		op, _ := cmd.Output()
-		log.Error().Err(err).Str("stdout", string(op)).Msg("failed to restart zstor process inside qsfs")
+
+	if err := contd.Exec(ctx, qsfsContainerNS, wlID, 10*time.Second, "/sbin/zinit", "kill", "zstor", "SIGINT"); err != nil {
 		return info, errors.Wrap(err, "failed to restart zstor process")
-	}
-	// until threefoldtech/0-stor_v2#71 is fixed
-	out, err := exec.Command("rm", "-f", filepath.Join(flistPath, "var/run/zstor.sock")).Output()
-	if err != nil {
-		log.Warn().Err(err).Str("stdout", string(out)).Msg("failed to remove zstor socket")
 	}
 	info.Path = mountPath
 	info.MetricsEndpoint = fmt.Sprintf("http://[%s]:%d/metrics", yggIP, zstorMetricsPort)

--- a/pkg/stubs/container_stub.go
+++ b/pkg/stubs/container_stub.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	zbus "github.com/threefoldtech/zbus"
 	pkg "github.com/threefoldtech/zos/pkg"
+	"time"
 )
 
 type ContainerModuleStub struct {
@@ -26,6 +27,22 @@ func NewContainerModuleStub(client zbus.Client) *ContainerModuleStub {
 func (s *ContainerModuleStub) Delete(ctx context.Context, arg0 string, arg1 pkg.ContainerID) (ret0 error) {
 	args := []interface{}{arg0, arg1}
 	result, err := s.client.RequestContext(ctx, s.module, s.object, "Delete", args...)
+	if err != nil {
+		panic(err)
+	}
+	ret0 = new(zbus.RemoteError)
+	if err := result.Unmarshal(0, &ret0); err != nil {
+		panic(err)
+	}
+	return
+}
+
+func (s *ContainerModuleStub) Exec(ctx context.Context, arg0 string, arg1 string, arg2 time.Duration, arg3 ...string) (ret0 error) {
+	args := []interface{}{arg0, arg1, arg2}
+	for _, argv := range arg3 {
+		args = append(args, argv)
+	}
+	result, err := s.client.RequestContext(ctx, s.module, s.object, "Exec", args...)
 	if err != nil {
 		panic(err)
 	}

--- a/pkg/stubs/flist_stub.go
+++ b/pkg/stubs/flist_stub.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	zbus "github.com/threefoldtech/zbus"
 	pkg "github.com/threefoldtech/zos/pkg"
+	gridtypes "github.com/threefoldtech/zos/pkg/gridtypes"
 )
 
 type FlisterStub struct {
@@ -95,6 +96,22 @@ func (s *FlisterStub) Unmount(ctx context.Context, arg0 string) (ret0 error) {
 	}
 	ret0 = new(zbus.RemoteError)
 	if err := result.Unmarshal(0, &ret0); err != nil {
+		panic(err)
+	}
+	return
+}
+
+func (s *FlisterStub) UpdateMountSize(ctx context.Context, arg0 string, arg1 gridtypes.Unit) (ret0 string, ret1 error) {
+	args := []interface{}{arg0, arg1}
+	result, err := s.client.RequestContext(ctx, s.module, s.object, "UpdateMountSize", args...)
+	if err != nil {
+		panic(err)
+	}
+	if err := result.Unmarshal(0, &ret0); err != nil {
+		panic(err)
+	}
+	ret1 = new(zbus.RemoteError)
+	if err := result.Unmarshal(1, &ret1); err != nil {
 		panic(err)
 	}
 	return

--- a/pkg/stubs/network_stub.go
+++ b/pkg/stubs/network_stub.go
@@ -317,6 +317,22 @@ func (s *NetworkerStub) QSFSPrepare(ctx context.Context, arg0 string) (ret0 stri
 	return
 }
 
+func (s *NetworkerStub) QSFSYggIP(ctx context.Context, arg0 string) (ret0 net.IPNet, ret1 error) {
+	args := []interface{}{arg0}
+	result, err := s.client.RequestContext(ctx, s.module, s.object, "QSFSYggIP", args...)
+	if err != nil {
+		panic(err)
+	}
+	if err := result.Unmarshal(0, &ret0); err != nil {
+		panic(err)
+	}
+	ret1 = new(zbus.RemoteError)
+	if err := result.Unmarshal(1, &ret1); err != nil {
+		panic(err)
+	}
+	return
+}
+
 func (s *NetworkerStub) Ready(ctx context.Context) (ret0 error) {
 	args := []interface{}{}
 	result, err := s.client.RequestContext(ctx, s.module, s.object, "Ready", args...)

--- a/pkg/stubs/network_stub.go
+++ b/pkg/stubs/network_stub.go
@@ -317,7 +317,7 @@ func (s *NetworkerStub) QSFSPrepare(ctx context.Context, arg0 string) (ret0 stri
 	return
 }
 
-func (s *NetworkerStub) QSFSYggIP(ctx context.Context, arg0 string) (ret0 net.IPNet, ret1 error) {
+func (s *NetworkerStub) QSFSYggIP(ctx context.Context, arg0 string) (ret0 string, ret1 error) {
 	args := []interface{}{arg0}
 	result, err := s.client.RequestContext(ctx, s.module, s.object, "QSFSYggIP", args...)
 	if err != nil {

--- a/pkg/stubs/qsfsd_stub.go
+++ b/pkg/stubs/qsfsd_stub.go
@@ -68,3 +68,19 @@ func (s *QSFSDStub) Unmount(ctx context.Context, arg0 string) (ret0 error) {
 	}
 	return
 }
+
+func (s *QSFSDStub) UpdateMount(ctx context.Context, arg0 string, arg1 zos.QuantumSafeFS) (ret0 pkg.QSFSInfo, ret1 error) {
+	args := []interface{}{arg0, arg1}
+	result, err := s.client.RequestContext(ctx, s.module, s.object, "UpdateMount", args...)
+	if err != nil {
+		panic(err)
+	}
+	if err := result.Unmarshal(0, &ret0); err != nil {
+		panic(err)
+	}
+	ret1 = new(zbus.RemoteError)
+	if err := result.Unmarshal(1, &ret1); err != nil {
+		panic(err)
+	}
+	return
+}


### PR DESCRIPTION
Stuff to figure out:
1. is there a way to get the old workload result as is to avoid recomputing it?
2. is there a way to get the old workload config to check if a non-destructive update is possible?

Update:
A1. Requires embedding the engine in the provisioner object and fetching the old deployment, or modifying the engine code to pass the old workload data.
A2. This was for the cache. Turns out it can be updated by storaged on the fly.