### PR TITLE
only allow updates for supported types

### DIFF
--- a/pkg/gridtypes/deployment.go
+++ b/pkg/gridtypes/deployment.go
@@ -483,13 +483,13 @@ func (d *Deployment) Upgrade(n *Deployment) ([]UpgradeOp, error) {
 
 type UpgradeOp struct {
 	WlID *WorkloadWithID
-	Op   jobOperation
+	Op   JobOperation
 }
 
-type jobOperation int
+type JobOperation int
 
 const (
-	OpRemove jobOperation = iota
+	OpRemove JobOperation = iota
 	OpAdd
 	OpUpdate
 )


### PR DESCRIPTION
To avoid issues because of no update implementation to most of the resources, this will always return an error if an update is attempted on a resource that does not support udpate.