### PR TITLE
Shareable workloads

### DIFF
--- a/pkg/gridtypes/common.go
+++ b/pkg/gridtypes/common.go
@@ -57,6 +57,11 @@ func Min(u, v Unit) Unit {
 // Timestamp type
 type Timestamp int64
 
+// Now returns timestamp of now
+func Now() Timestamp {
+	return Timestamp(time.Now().Unix())
+}
+
 // Time gets time from timestamp
 func (t *Timestamp) Time() time.Time {
 	return time.Unix(int64(*t), 0)

--- a/pkg/gridtypes/common.go
+++ b/pkg/gridtypes/common.go
@@ -15,6 +15,10 @@ func (n Name) IsEmpty() bool {
 	return len(string(n)) == 0
 }
 
+func (n Name) String() string {
+	return string(n)
+}
+
 // Unit defines a capacity unit in "bytes"
 // Any "value" of type Unit must be in bytes only
 // hence use the Unit mutliplies below to set the

--- a/pkg/gridtypes/deployment.go
+++ b/pkg/gridtypes/deployment.go
@@ -433,6 +433,30 @@ func (d *Deployment) GetType(name Name, typ WorkloadType) (*WorkloadWithID, erro
 	return wl, nil
 }
 
+func (d *Deployment) GetShareables() []*WorkloadWithID {
+	var results []*WorkloadWithID
+	for i := range d.Workloads {
+		wl := &d.Workloads[i]
+		if _, ok := sharableWorkloadTypes[wl.Type]; ok {
+			id, err := NewWorkloadID(d.TwinID, d.ContractID, wl.Name)
+			if err != nil {
+				log.Warn().Err(err).Msg("deployment has invalid name. please run validation")
+				continue
+			}
+
+			results = append(
+				results,
+				&WorkloadWithID{
+					Workload: wl,
+					ID:       id,
+				},
+			)
+		}
+	}
+
+	return results
+}
+
 // ByType gets all workloads from this reservation by type.
 func (d *Deployment) ByType(typ ...WorkloadType) []*WorkloadWithID {
 	in := func(t WorkloadType) bool {

--- a/pkg/gridtypes/id.go
+++ b/pkg/gridtypes/id.go
@@ -48,7 +48,7 @@ func (i WorkloadID) String() string {
 }
 
 // Parts split id into building parts
-func (i WorkloadID) Parts() (twin uint32, deployment uint64, name string, err error) {
+func (i WorkloadID) Parts() (twin uint32, deployment uint64, name Name, err error) {
 	_, err = fmt.Sscanf(string(i), "%d-%d-%s", &twin, &deployment, &name)
 	return
 }
@@ -76,4 +76,8 @@ func NewWorkloadID(twin uint32, deployment uint64, name Name) (WorkloadID, error
 	}
 
 	return WorkloadID(fmt.Sprintf("%d-%d-%s", twin, deployment, name)), nil
+}
+
+func NewUncheckedWorkloadID(twin uint32, deployment uint64, name Name) WorkloadID {
+	return WorkloadID(fmt.Sprintf("%d-%d-%s", twin, deployment, name))
 }

--- a/pkg/gridtypes/workload.go
+++ b/pkg/gridtypes/workload.go
@@ -251,7 +251,7 @@ func (r *Result) IsNil() bool {
 	// (like the type)
 	// so instead we gonna check the Data and the Created filed
 
-	return r.Created == 0 && (len(r.Data) == 0 || bytes.Equal(r.Data, nullRaw))
+	return r.State == "" && r.Created == 0 && (len(r.Data) == 0 || bytes.Equal(r.Data, nullRaw))
 }
 
 var (

--- a/pkg/gridtypes/workload.go
+++ b/pkg/gridtypes/workload.go
@@ -16,6 +16,10 @@ type WorkloadType string
 var (
 	// workloadTypes with built in known types
 	workloadTypes = map[WorkloadType]WorkloadData{}
+	// sharableWorkloadTypes are workload types that can be
+	// accessed from other deployments (as read only)
+	// but only modifiable from deployments that creates it.
+	sharableWorkloadTypes = map[WorkloadType]struct{}{}
 )
 
 // RegisterType register a new workload type. This is used by zos to "declare"
@@ -31,6 +35,15 @@ func RegisterType(t WorkloadType, d WorkloadData) {
 	}
 
 	workloadTypes[t] = d
+}
+
+// RegisterSharableType same as RegisterType, but also register
+// this type as sharable, which means this type can be accessed (referenced)
+// from other deploments. But only modifiable from the type deployment
+// that created it.
+func RegisterSharableType(t WorkloadType, d WorkloadData) {
+	RegisterType(t, d)
+	sharableWorkloadTypes[t] = struct{}{}
 }
 
 //Types return a list of all registered types

--- a/pkg/gridtypes/zos/types.go
+++ b/pkg/gridtypes/zos/types.go
@@ -29,8 +29,11 @@ const (
 )
 
 func init() {
+	// network is a sharable type, which means for a single
+	// twin, the network objects can be 'used' from different
+	// deployments.
+	gridtypes.RegisterSharableType(NetworkType, Network{})
 	gridtypes.RegisterType(ZMountType, ZMount{})
-	gridtypes.RegisterType(NetworkType, Network{})
 	gridtypes.RegisterType(ZDBType, ZDB{})
 	gridtypes.RegisterType(ZMachineType, ZMachine{})
 	gridtypes.RegisterType(PublicIPv4Type, PublicIP4{})

--- a/pkg/provision/engine.go
+++ b/pkg/provision/engine.go
@@ -485,7 +485,7 @@ func (e *NativeEngine) uninstallWorkload(ctx context.Context, wl *gridtypes.Work
 	log := log.With().
 		Uint32("twin", twin).
 		Uint64("deployment", deployment).
-		Str("name", name).
+		Stringer("name", name).
 		Str("type", wl.Type.String()).
 		Logger()
 
@@ -525,7 +525,7 @@ func (e *NativeEngine) installWorkload(ctx context.Context, wl *gridtypes.Worklo
 	log := log.With().
 		Uint32("twin", twin).
 		Uint64("deployment", deployment).
-		Str("name", name).
+		Stringer("name", name).
 		Str("type", wl.Type.String()).
 		Logger()
 
@@ -558,7 +558,7 @@ func (e *NativeEngine) updateWorkload(ctx context.Context, wl *gridtypes.Workloa
 	log := log.With().
 		Uint32("twin", twin).
 		Uint64("deployment", deployment).
-		Str("name", name).
+		Stringer("name", name).
 		Str("type", wl.Type.String()).
 		Logger()
 

--- a/pkg/provision/interface.go
+++ b/pkg/provision/interface.go
@@ -60,6 +60,10 @@ type Storage interface {
 	Get(twin uint32, deployment uint64) (gridtypes.Deployment, error)
 	Twins() ([]uint32, error)
 	ByTwin(twin uint32) ([]uint64, error)
+
+	// manage of shared workloads
+	GetShared(twinID uint32, name gridtypes.Name) (gridtypes.WorkloadID, error)
+	SharedByTwin(twinID uint32) ([]gridtypes.WorkloadID, error)
 }
 
 // Janitor interface

--- a/pkg/provision/interface.go
+++ b/pkg/provision/interface.go
@@ -36,8 +36,11 @@ type Provisioner interface {
 // Filter is filtering function for Purge method
 
 var (
-	//ErrDeploymentExists returned if object exist
+	// ErrDeploymentExists returned if object exist
 	ErrDeploymentExists = fmt.Errorf("exists")
+	// ErrDeploymentConflict returned if deployment cannot be stored because
+	// it conflicts with another deployment
+	ErrDeploymentConflict = fmt.Errorf("conflict")
 	//ErrDeploymentNotExists returned if object not exists
 	ErrDeploymentNotExists = fmt.Errorf("not exists")
 	// ErrDidNotChange special error that can be returned by the provisioner

--- a/pkg/provision/storage/shared.go
+++ b/pkg/provision/storage/shared.go
@@ -1,0 +1,98 @@
+package storage
+
+import (
+	"fmt"
+	"io/fs"
+	"io/ioutil"
+	"os"
+	"path/filepath"
+	"strconv"
+
+	"github.com/pkg/errors"
+	"github.com/rs/zerolog/log"
+	"github.com/threefoldtech/zos/pkg/gridtypes"
+)
+
+// Shared, returns a workload id that reference the workload with that
+// name. The workload type must be of a `Shared` type.
+// A Shared workload type means that the workload (of that type) can be
+// accessed by other deployments for the same twin. A shared workload
+// should be only updatable only via the deployment that creates it
+func (s *Fs) GetShared(twinID uint32, name gridtypes.Name) (gridtypes.WorkloadID, error) {
+	s.m.RLock()
+	defer s.m.RUnlock()
+
+	return s.shared(twinID, name)
+}
+
+func (s *Fs) SharedByTwin(twinID uint32) ([]gridtypes.WorkloadID, error) {
+	s.m.RLock()
+	defer s.m.RUnlock()
+
+	return s.sharedByTwin(twinID)
+}
+
+func (s *Fs) sharedByTwin(twinID uint32) ([]gridtypes.WorkloadID, error) {
+	root := filepath.Join(s.root, sharedSubDir, fmt.Sprint(twinID))
+	infos, err := ioutil.ReadDir(root)
+	if os.IsNotExist(err) {
+		return nil, nil
+	} else if err != nil {
+		return nil, errors.Wrap(err, "failed to list shared user workloads")
+	}
+	var ids []gridtypes.WorkloadID
+	for _, info := range infos {
+		if info.Mode().Type() != fs.ModeSymlink {
+			log.Warn().
+				Uint32("twin", twinID).
+				Str("name", info.Name()).
+				Msg("found non symlink file in twin shared workloads")
+			continue
+		}
+
+		id, err := s.shared(twinID, gridtypes.Name(info.Name()))
+		if err != nil {
+			return nil, err
+		}
+
+		ids = append(ids, id)
+	}
+
+	return ids, nil
+}
+func (s *Fs) shared(twinID uint32, name gridtypes.Name) (id gridtypes.WorkloadID, err error) {
+	link := s.rooted(s.sharedLinkPath(twinID, name))
+	target, err := os.Readlink(link)
+	if err != nil {
+		return id, errors.Wrapf(err, "failed to read link to deployment from '%s'", link)
+	}
+	// target has base name as the 'contract id'
+	dl, err := strconv.ParseUint(filepath.Base(target), 10, 32)
+	if err != nil {
+		return id, errors.Wrapf(err, "invalid link '%s' to target '%s'", link, target)
+	}
+
+	return gridtypes.NewUncheckedWorkloadID(twinID, dl, name), nil
+}
+
+func (s *Fs) sharedCreate(d *gridtypes.Deployment, name gridtypes.Name) error {
+	target := s.rooted(s.deploymentPath(d))
+	src := s.rooted(s.sharedLinkPath(d.TwinID, name))
+
+	dir := filepath.Dir(src)
+	if err := os.MkdirAll(dir, 0755); err != nil {
+		return errors.Wrap(err, "failed to create shared twin directory")
+	}
+
+	target, err := filepath.Rel(dir, target)
+	if err != nil {
+		return err
+	}
+
+	return os.Symlink(target, src)
+}
+
+func (s *Fs) sharedDelete(d *gridtypes.Deployment, name gridtypes.Name) error {
+	src := s.rooted(s.sharedLinkPath(d.TwinID, name))
+	return os.Remove(src)
+}

--- a/pkg/provision/storage/storage.go
+++ b/pkg/provision/storage/storage.go
@@ -21,6 +21,8 @@ var (
 	deploymentSchemaV1 = versioned.MustParse("1.0.0")
 	// ReservationSchemaLastVersion link to latest version
 	deploymentSchemaLastVersion = deploymentSchemaV1
+
+	sharedSubDir = "shared"
 )
 
 // Fs is a in reservation cache using the filesystem as backend
@@ -37,11 +39,17 @@ func NewFSStore(root string) (*Fs, error) {
 		root: root,
 	}
 
-	if err := os.MkdirAll(root, 0770); err != nil {
-		return nil, err
+	for _, dir := range []string{sharedSubDir} {
+		if err := os.MkdirAll(filepath.Join(root, dir), 0770); err != nil {
+			return nil, err
+		}
 	}
 
 	return store, nil
+}
+
+func (s *Fs) sharedLinkPath(twinID uint32, name gridtypes.Name) string {
+	return filepath.Join(sharedSubDir, fmt.Sprint(twinID), string(name))
 }
 
 func (s *Fs) deploymentPath(d *gridtypes.Deployment) string {
@@ -60,6 +68,20 @@ func (s *Fs) Add(d gridtypes.Deployment) error {
 	path := s.rooted(s.deploymentPath(&d))
 	if err := os.MkdirAll(filepath.Dir(path), 0755); err != nil {
 		return errors.Wrap(err, "failed to crate directory")
+	}
+
+	// make sure that this deployment does not actually
+	// redefine a "sharable" workload.
+	for _, wl := range d.GetShareables() {
+		conflict, err := s.shared(d.TwinID, wl.Name)
+		if err == nil {
+			return errors.Wrapf(
+				provision.ErrDeploymentConflict,
+				"sharable workload '%s' is conflicting with another workload '%s'",
+				string(wl.Name), conflict)
+		} else if err != nil && !errors.Is(err, os.ErrNotExist) {
+			return errors.Wrap(err, "failed to check conflicts")
+		}
 	}
 
 	file, err := os.OpenFile(
@@ -84,6 +106,14 @@ func (s *Fs) Add(d gridtypes.Deployment) error {
 		return errors.Wrap(err, "failed to write workload data")
 	}
 
+	// make sure that this deployment does not actually
+	// redefine a "sharable" workload.
+	for _, wl := range d.GetShareables() {
+		if err := s.sharedCreate(&d, wl.Name); err != nil {
+			return errors.Wrap(err, "failed to store sharable workloads")
+		}
+	}
+
 	return nil
 }
 
@@ -92,6 +122,34 @@ func (s *Fs) Add(d gridtypes.Deployment) error {
 func (s *Fs) Set(dl gridtypes.Deployment) error {
 	s.m.Lock()
 	defer s.m.Unlock()
+
+	sharedIDs, err := s.sharedByTwin(dl.TwinID)
+	if err != nil {
+		return errors.Wrap(err, "failed to get all sharable user workloads")
+	}
+
+	this := map[gridtypes.Name]gridtypes.WorkloadID{}
+	taken := map[gridtypes.Name]gridtypes.WorkloadID{}
+	for _, shared := range sharedIDs {
+		_, contract, name, _ := shared.Parts()
+		if contract == dl.ContractID {
+			this[name] = shared
+		} else {
+			taken[name] = shared
+		}
+	}
+
+	// does this workload defines a new sharable workload. In that case
+	// we need to make sure that this does not conflict with the current
+	// set of twin sharable workloads. but should not conflict with itself
+	for _, wl := range dl.GetShareables() {
+		if conflict, ok := taken[wl.Name]; ok {
+			return errors.Wrapf(
+				provision.ErrDeploymentConflict,
+				"sharable workload '%s' is conflicting with another workload '%s'",
+				string(wl.Name), conflict)
+		}
+	}
 
 	path := s.rooted(s.deploymentPath(&dl))
 	file, err := os.OpenFile(
@@ -114,14 +172,45 @@ func (s *Fs) Set(dl gridtypes.Deployment) error {
 		return errors.Wrap(err, "failed to write workload data")
 	}
 
+	// now we make sure that all sharable (and active) workloads
+	// on this deployment is referenced correctly
+	var tolink []gridtypes.Name
+	for _, wl := range dl.GetShareables() {
+		// if workload result is not set yet. or if the state is OK
+		// it means the workload still need to be treated as shared object
+		if wl.Result.IsNil() || wl.Result.State == gridtypes.StateOk {
+			// workload with no results, so we
+			if _, ok := this[wl.Name]; ok {
+				// avoid unlinking
+				delete(this, wl.Name)
+			} else {
+				tolink = append(tolink, wl.Name)
+			}
+		}
+	}
+	// we either removed the names that should be kept (state = ok or no result yet)
+	// and new ones have been added to tolink. so it's safe to clean up all links
+	// in this.
+	for name := range this {
+		if err := s.sharedDelete(&dl, name); err != nil {
+			log.Error().Err(err).
+				Uint64("contract", dl.ContractID).
+				Stringer("name", name).
+				Msg("failed to clean up shared workload '%d.%s'")
+		}
+	}
+
+	for _, new := range tolink {
+		if err := s.sharedCreate(&dl, new); err != nil {
+			return err
+		}
+	}
+
 	return nil
 }
 
 // Get gets a workload by id
 func (s *Fs) get(path string) (gridtypes.Deployment, error) {
-	s.m.RLock()
-	defer s.m.RUnlock()
-
 	var wl gridtypes.Deployment
 	file, err := os.Open(path)
 	if os.IsNotExist(err) {
@@ -148,6 +237,9 @@ func (s *Fs) get(path string) (gridtypes.Deployment, error) {
 
 // Get gets a workload by id
 func (s *Fs) Get(twin uint32, deployment uint64) (gridtypes.Deployment, error) {
+	s.m.RLock()
+	defer s.m.RUnlock()
+
 	path := s.rooted(filepath.Join(fmt.Sprint(twin), fmt.Sprint(deployment)))
 
 	return s.get(path)

--- a/pkg/provision/storage/storage.go
+++ b/pkg/provision/storage/storage.go
@@ -179,14 +179,18 @@ func (s *Fs) Set(dl gridtypes.Deployment) error {
 		// if workload result is not set yet. or if the state is OK
 		// it means the workload still need to be treated as shared object
 		if wl.Result.IsNil() || wl.Result.State == gridtypes.StateOk {
-			// workload with no results, so we
+			// workload with no results, so we should keep the link
 			if _, ok := this[wl.Name]; ok {
 				// avoid unlinking
 				delete(this, wl.Name)
 			} else {
+				// or if new, add to tolink
 				tolink = append(tolink, wl.Name)
 			}
 		}
+		// if result state is set to anything else (deleted, or error)
+		// we then leave it in the `this` map which means they
+		// get to be unlinked. so the name can be used again by the same twin
 	}
 	// we either removed the names that should be kept (state = ok or no result yet)
 	// and new ones have been added to tolink. so it's safe to clean up all links

--- a/pkg/provision/storage/storage_test.go
+++ b/pkg/provision/storage/storage_test.go
@@ -15,6 +15,7 @@ import (
 )
 
 var TestType = gridtypes.WorkloadType("test")
+var TestSharableType = gridtypes.WorkloadType("sharable")
 
 type TestData struct{}
 
@@ -32,7 +33,9 @@ func (t TestData) Capacity() (gridtypes.Capacity, error) {
 
 func init() {
 	gridtypes.RegisterType(TestType, TestData{})
+	gridtypes.RegisterSharableType(TestSharableType, TestData{})
 }
+
 func TestStorageAdd(t *testing.T) {
 	require := require.New(t)
 	root, err := ioutil.TempDir("", "storage-")
@@ -62,6 +65,96 @@ func TestStorageAdd(t *testing.T) {
 	stat, err := os.Lstat(filepath.Join(root, fmt.Sprint(twin), fmt.Sprint(id)))
 	require.NoError(err)
 	require.True(stat.Mode().IsRegular())
+}
+
+func TestStorageAddSharable(t *testing.T) {
+	require := require.New(t)
+	root, err := ioutil.TempDir("", "storage-")
+	require.NoError(err)
+	defer os.RemoveAll(root)
+
+	store, err := NewFSStore(root)
+	require.NoError(err)
+
+	twin := uint32(1)
+	id := uint64(1)
+	err = store.Add(gridtypes.Deployment{
+		TwinID:      twin,
+		ContractID:  id,
+		Metadata:    "meta",
+		Description: "descriptions",
+		Workloads: []gridtypes.Workload{
+			{
+				Name: "volume",
+				Type: TestType,
+				Data: gridtypes.MustMarshal(TestData{}),
+			},
+			{
+				Name: "shared",
+				Type: TestSharableType,
+				Data: gridtypes.MustMarshal(TestData{}),
+			},
+		},
+	})
+
+	require.NoError(err)
+	stat, err := os.Lstat(filepath.Join(root, fmt.Sprint(twin), fmt.Sprint(id)))
+	require.NoError(err)
+	require.True(stat.Mode().IsRegular())
+}
+
+func TestStorageAddConflictingSharable(t *testing.T) {
+	require := require.New(t)
+	root, err := ioutil.TempDir("", "storage-")
+	require.NoError(err)
+	defer os.RemoveAll(root)
+
+	store, err := NewFSStore(root)
+	require.NoError(err)
+
+	twin := uint32(1)
+	id := uint64(1)
+	err = store.Add(gridtypes.Deployment{
+		TwinID:      twin,
+		ContractID:  id,
+		Metadata:    "meta",
+		Description: "descriptions",
+		Workloads: []gridtypes.Workload{
+			{
+				Name: "volume",
+				Type: TestType,
+				Data: gridtypes.MustMarshal(TestData{}),
+			},
+			{
+				Name: "shared",
+				Type: TestSharableType,
+				Data: gridtypes.MustMarshal(TestData{}),
+			},
+		},
+	})
+
+	require.NoError(err)
+
+	err = store.Add(gridtypes.Deployment{
+		TwinID:      twin,
+		ContractID:  2,
+		Metadata:    "meta",
+		Description: "descriptions",
+		Workloads: []gridtypes.Workload{
+			{
+				Name: "shared",
+				Type: TestSharableType,
+				Data: gridtypes.MustMarshal(TestData{}),
+			},
+		},
+	})
+
+	require.Error(err)
+	require.True(errors.Is(err, provision.ErrDeploymentConflict))
+
+	wlID, err := store.GetShared(twin, "shared")
+	require.NoError(err)
+	require.Equal(gridtypes.NewUncheckedWorkloadID(twin, id, "shared"), wlID)
 }
 
 func TestStorageSet(t *testing.T) {


### PR DESCRIPTION
DO NOT MERGER:

This change allow zos to define a category of workloads (sharable) that are workloads in a deployment that can be accessed from other user deployment. This is mainly the network workload.

Defining network workload as sharable will enforce the system to prevent redefining this network name in other deployments. and that it can only be modified and/or deleted in the workload that created it.

Why we shouldn't merge this right now. 
Merging this PR will break some clients that uses the way network workloads works right now. These need to be refactored first to do network modifications properly (in the original deployment) before this is merged.

#1365 