### PR TITLE
Fix ygg peers selection

### DIFF
--- a/pkg/network/latency/latency_test.go
+++ b/pkg/network/latency/latency_test.go
@@ -3,7 +3,6 @@ package latency_test
 import (
 	"context"
 	"fmt"
-	"net"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -34,24 +33,12 @@ func TestLatencySorter(t *testing.T) {
 	assert.Equal(t, 2, len(results))
 }
 
-func TestLatencySorterIPV4Only(t *testing.T) {
-	ls := latency.NewSorter([]string{
-		"tcp://[2a00:1450:400e:806::200e]:443",
-		"tcp://172.217.17.78:443",
-	}, 1, latency.IPV4Only)
-
-	ctx, cancel := context.WithCancel(context.Background())
-	defer cancel()
-
-	results := ls.Run(ctx)
-	assert.Equal(t, 1, len(results))
-}
-
 func TestYggPeering(t *testing.T) {
 	pl, err := yggdrasil.FetchPeerList()
 	require.NoError(t, err)
 
-	peersUp := pl.Ups()
+	peersUp, err := pl.Ups()
+	require.NoError(t, err)
 	endpoints := make([]string, len(peersUp))
 	for i, p := range peersUp {
 		endpoints[i] = p.Endpoint
@@ -66,48 +53,4 @@ func TestYggPeering(t *testing.T) {
 	for _, r := range results {
 		fmt.Printf("%30s %v\n", r.Endpoint, r.Latency)
 	}
-}
-
-func TestIPV4Only(t *testing.T) {
-	for _, tc := range []struct {
-		ip   net.IP
-		ipv4 bool
-	}{
-		{
-			ip:   net.ParseIP("2a00:1450:400e:80a::2004"),
-			ipv4: false,
-		},
-		{
-			ip:   net.ParseIP("82.118.227.155"),
-			ipv4: true,
-		},
-	} {
-		t.Run(tc.ip.String(), func(t *testing.T) {
-			assert.Equal(t, tc.ipv4, latency.IPV4Only(tc.ip))
-		})
-	}
-}
-
-func TestExcludePrefix(t *testing.T) {
-	for _, tc := range []struct {
-		ip     net.IP
-		prefix []byte
-		expect bool
-	}{
-		{
-			ip:     net.ParseIP("2a00:1450:400e:80a::2004"),
-			prefix: net.ParseIP("2a02:1802:5e:0::"),
-			expect: true,
-		},
-		{
-			ip:     net.ParseIP("2a02:1802:5e:0:18d2:e2ff:fe44:17d2"),
-			prefix: net.ParseIP("2a02:1802:5e:0::"),
-			expect: false,
-		},
-	} {
-		t.Run(tc.ip.String(), func(t *testing.T) {
-			assert.Equal(t, tc.expect, latency.ExcludePrefix(tc.prefix[:8])(tc.ip))
-		})
-	}
-
 }

--- a/pkg/network/yggdrasil/public_peerlist.go
+++ b/pkg/network/yggdrasil/public_peerlist.go
@@ -43,7 +43,7 @@ type Filter func(ip net.IP) bool
 // Ranges is a list of net.IPNet
 type Ranges []net.IPNet
 
-// Excluse ranges, return IPs that are NOT in the given ranges
+// Exclude ranges, return IPs that are NOT in the given ranges
 func Exclude(ranges Ranges) Filter {
 	return func(ip net.IP) bool {
 		for _, n := range ranges {

--- a/pkg/network/yggdrasil/public_peerlist_test.go
+++ b/pkg/network/yggdrasil/public_peerlist_test.go
@@ -10,8 +10,9 @@ import (
 func TestFetchPeerList(t *testing.T) {
 	pl, err := FetchPeerList()
 	require.NoError(t, err)
-
-	for _, peer := range pl.Ups() {
+	peers, err := pl.Ups()
+	require.NoError(t, err)
+	for _, peer := range peers {
 		assert.True(t, peer.Up)
 	}
 }
@@ -20,7 +21,10 @@ func TestUps(t *testing.T) {
 	pl, err := FetchPeerList()
 	require.NoError(t, err)
 
-	for _, peer := range pl.Ups() {
+	peers, err := pl.Ups()
+	require.NoError(t, err)
+
+	for _, peer := range peers {
 		assert.True(t, peer.Up)
 	}
 }


### PR DESCRIPTION
This fixes many issues
- Support peers that uses hostnames, not ips
- Drop unecessary ipv4 only filter, if the node can't connect to ipv6,
  it will fail to connect during latency test anyway.
- make sure yggdrasil reload it's config always