### PR TITLE
use filesystem usage insead of filesystem df

### DIFF
--- a/pkg/storage/filesystem/btrfs.go
+++ b/pkg/storage/filesystem/btrfs.go
@@ -254,12 +254,7 @@ func (p *btrfsPool) Usage() (usage Usage, err error) {
 		return Usage{}, err
 	}
 
-	info, err := p.device.Info()
-	if err != nil {
-		return Usage{}, err
-	}
-
-	return Usage{Size: info.Size, Used: du.Data.Used}, nil
+	return Usage{Size: du.Total, Used: du.Used}, nil
 }
 
 // Type of the physical storage used for this pool

--- a/pkg/storage/storage.go
+++ b/pkg/storage/storage.go
@@ -110,6 +110,12 @@ func (s *Module) dump() {
 		path, err := pool.Mounted()
 		if err == nil {
 			log.Debug().Msgf("pool %s is mounted at: %s", pool.Name(), path)
+			usage, err := pool.Usage()
+			if err != nil {
+				log.Error().Err(err).Str("pool", pool.Name()).Msg("failed to get pool usage")
+			} else {
+				log.Debug().Msgf("pool %s capacity %+v", pool.Name(), usage)
+			}
 		}
 		device := pool.Device()
 		log.Debug().Str("path", device.Path()).Str("label", pool.Name()).Str("type", string(zos.SSDDevice)).Send()
@@ -119,6 +125,12 @@ func (s *Module) dump() {
 		path, err := pool.Mounted()
 		if err == nil {
 			log.Debug().Msgf("pool %s is mounted at: %s", pool.Name(), path)
+			usage, err := pool.Usage()
+			if err != nil {
+				log.Error().Err(err).Str("pool", pool.Name()).Msg("failed to get pool usage")
+			} else {
+				log.Debug().Msgf("pool %s capacity %+v", pool.Name(), usage)
+			}
 		}
 		device := pool.Device()
 		log.Debug().Str("path", device.Path()).Str("label", pool.Name()).Str("type", string(zos.HDDDevice)).Send()


### PR DESCRIPTION
This is switching using `filesystem usage` instead of `filesystem df` to get disk usage information. But actually i am not sure if this is an improvement, because allocation calculations depends on the theoretical reserved space on the disk (volume quota or actual allocated files)

Fixes #1508  