### PR TITLE
persisted vm rootfs volume

### DIFF
--- a/pkg/flist.go
+++ b/pkg/flist.go
@@ -27,8 +27,14 @@ type MountOptions struct {
 	ReadOnly bool
 	// Limit size of read-write layer
 	Limit gridtypes.Unit
-	// optional storage url
+	// optional storage url (default to hub storage)
 	Storage string
+	// PersistedVolume used in RW mode. If not provided
+	// one that will be created automatically with `Limit` that uses the same mount
+	// name, and will be delete (by name) on Unmount. If provided, make sure
+	// use use a different name than the mount id, or it will also get deleted
+	// on unmount.
+	PersistedVolume string
 }
 
 //Flister is the interface for the flist module

--- a/pkg/primitives/vm.go
+++ b/pkg/primitives/vm.go
@@ -348,6 +348,7 @@ func (p *Primitives) vmDecomission(ctx context.Context, wl *gridtypes.WorkloadWi
 		flist   = stubs.NewFlisterStub(p.zbus)
 		network = stubs.NewNetworkerStub(p.zbus)
 		vm      = stubs.NewVMModuleStub(p.zbus)
+		storage = stubs.NewStorageModuleStub(p.zbus)
 
 		cfg ZMachine
 	)
@@ -364,6 +365,11 @@ func (p *Primitives) vmDecomission(ctx context.Context, wl *gridtypes.WorkloadWi
 
 	if err := flist.Unmount(ctx, wl.ID.String()); err != nil {
 		log.Error().Err(err).Msg("failed to unmount machine flist")
+	}
+
+	volName := fmt.Sprintf("rootfs:%s", wl.ID.String())
+	if err := storage.VolumeDelete(ctx, volName); err != nil {
+		log.Error().Err(err).Str("name", volName).Msg("failed to delete rootfs volume")
 	}
 
 	for _, inf := range cfg.Network.Interfaces {

--- a/pkg/storage/storage.go
+++ b/pkg/storage/storage.go
@@ -296,6 +296,15 @@ func (s *Module) VolumeCreate(name string, size gridtypes.Unit) (pkg.Volume, err
 		return pkg.Volume{}, fmt.Errorf("invalid volume name. zdb prefix is reserved")
 	}
 
+	volume, err := s.VolumeLookup(name)
+	if err == nil {
+		return volume, nil
+	} else if err != nil && !errors.Is(err, os.ErrNotExist) {
+		return pkg.Volume{}, err
+	}
+
+	// otherwise, create a new volume
+
 	fs, err := s.createSubvolWithQuota(size, name)
 	if err != nil {
 		return pkg.Volume{}, err


### PR DESCRIPTION
This will make the rootfs persiste as long as the vm is deployed, even if the VM or node rebooted.

This happens by making the writable layer managed by the VM provision logic, not the rootfs mount, so the writable volume is only delete when the VM is deleted, not when the rootfs is unmounted, hence a remount of the rootfs will not wipe out the writable layer.

Fixes #1511