### PR TITLE
Create a global debug flag

### DIFF
--- a/cmds/identityd/main.go
+++ b/cmds/identityd/main.go
@@ -9,8 +9,6 @@ import (
 	"syscall"
 	"time"
 
-	"github.com/shirou/gopsutil/host"
-
 	"github.com/pkg/errors"
 	"github.com/threefoldtech/zos/pkg/app"
 	"github.com/threefoldtech/zos/pkg/stubs"
@@ -20,8 +18,6 @@ import (
 	"github.com/threefoldtech/zos/pkg"
 	"github.com/threefoldtech/zos/pkg/environment"
 	"github.com/threefoldtech/zos/pkg/identity"
-
-	"github.com/threefoldtech/zos/pkg/zinit"
 
 	"flag"
 
@@ -40,25 +36,10 @@ const (
 	seedName = "seed.txt"
 )
 
-// setup is a sanity check function, the whole purpose of this
-// is to make sure at least required services are running in case
-// of upgrade failure
-// for example, in case of upgraded crash after it already stopped all
-// the services for upgrade.
-func setup(zinit *zinit.Client) error {
-	for _, required := range []string{"redis"} {
-		if err := zinit.StartWait(5*time.Second, required); err != nil {
-			return err
-		}
-	}
-
-	return nil
-}
-
 // Safe makes sure function call not interrupted
 // with a signal while exection
 func Safe(fn func() error) error {
-	ch := make(chan os.Signal)
+	ch := make(chan os.Signal, 4)
 	defer close(ch)
 	defer signal.Stop(ch)
 
@@ -379,13 +360,4 @@ func getIdentityMgr(root string) (pkg.IdentityManager, error) {
 		Msg("farmer identified")
 
 	return manager, nil
-}
-
-// hostUptime returns the uptime of the node
-func hostUptime() (uint64, error) {
-	info, err := host.Info()
-	if err != nil {
-		return 0, err
-	}
-	return info.Uptime, nil
 }

--- a/cmds/zos/main.go
+++ b/cmds/zos/main.go
@@ -5,6 +5,7 @@ import (
 	"os"
 	"path/filepath"
 
+	"github.com/rs/zerolog"
 	"github.com/rs/zerolog/log"
 	"github.com/threefoldtech/zos/cmds/modules/contd"
 	"github.com/threefoldtech/zos/cmds/modules/flistd"
@@ -28,11 +29,17 @@ func main() {
 	exe := cli.App{
 		Name:    "ZOS",
 		Version: version.Current().String(),
+
 		Flags: []cli.Flag{
 			&cli.BoolFlag{
 				Name:   "list",
 				Hidden: true,
 				Usage:  "print all available clients names",
+			},
+			&cli.BoolFlag{
+				Name:    "debug",
+				Aliases: []string{"d"},
+				Usage:   "force debug level",
 			},
 		},
 		Commands: []*cli.Command{
@@ -47,6 +54,13 @@ func main() {
 			&zbusdebug.Module,
 			&gateway.Module,
 			&qsfsd.Module,
+		},
+		Before: func(c *cli.Context) error {
+			if c.Bool("debug") {
+				zerolog.SetGlobalLevel(zerolog.DebugLevel)
+				log.Debug().Msg("setting log level to debug")
+			}
+			return nil
 		},
 		Action: func(c *cli.Context) error {
 			if !c.Bool("list") {

--- a/pkg/app/log.go
+++ b/pkg/app/log.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/rs/zerolog"
 	"github.com/rs/zerolog/log"
+	"github.com/threefoldtech/zos/pkg/kernel"
 )
 
 //nolint
@@ -61,6 +62,14 @@ func formatLevel(i interface{}) string {
 
 // Initialize Configure a zos app
 func Initialize() {
+	level := zerolog.InfoLevel
+	params := kernel.GetParams()
+	if params.IsDebug() {
+		level = zerolog.DebugLevel
+	}
+
+	zerolog.SetGlobalLevel(level)
+
 	log.Logger = log.Output(zerolog.ConsoleWriter{
 		TimeFormat:  time.RFC3339,
 		Out:         os.Stdout,

--- a/pkg/container/container.go
+++ b/pkg/container/container.go
@@ -139,7 +139,7 @@ func (c *Module) upgrade() error {
 
 // Run creates and starts a container
 func (c *Module) Run(ns string, data pkg.Container) (id pkg.ContainerID, err error) {
-	log.Info().Str("ns", ns).Msg("starting container")
+	log.Debug().Str("ns", ns).Msg("starting container")
 
 	// create a new client connected to the default socket path for containerd
 	client, err := containerd.New(c.containerd)
@@ -224,7 +224,7 @@ func (c *Module) Run(ns string, data pkg.Container) (id pkg.ContainerID, err err
 		opts = append(opts, oci.WithProcessArgs(args...))
 	}
 
-	log.Info().
+	log.Debug().
 		Str("namespace", ns).
 		Str("data", fmt.Sprintf("%+v", data)).
 		Msgf("create new container")
@@ -246,13 +246,13 @@ func (c *Module) Run(ns string, data pkg.Container) (id pkg.ContainerID, err err
 	if err != nil {
 		return id, err
 	}
-	log.Info().Msgf("args %+v", spec.Process.Args)
-	log.Info().Msgf("env %+v", spec.Process.Env)
-	log.Info().Msgf("root %+v", spec.Root)
+	log.Debug().Msgf("args %+v", spec.Process.Args)
+	log.Debug().Msgf("env %+v", spec.Process.Env)
+	log.Debug().Msgf("root %+v", spec.Root)
 	for _, linxNS := range spec.Linux.Namespaces {
-		log.Info().Msgf("namespace %+v", linxNS.Type)
+		log.Debug().Msgf("namespace %+v", linxNS.Type)
 	}
-	log.Info().Msgf("mounts %+v", spec.Mounts)
+	log.Debug().Msgf("mounts %+v", spec.Mounts)
 
 	defer func() {
 		// if any of the next steps below fails, make sure
@@ -271,7 +271,7 @@ func (c *Module) Run(ns string, data pkg.Container) (id pkg.ContainerID, err err
 
 	// creating and serializing logs settings for external logger
 	confpath := path.Join(cfgs, fmt.Sprintf("%s-logs.json", container.ID()))
-	log.Info().Str("cfg", confpath).Msg("writing logs settings")
+	log.Debug().Str("cfg", confpath).Msg("writing logs settings")
 
 	err = logger.Serialize(confpath, data.Logs)
 	if err != nil {
@@ -388,7 +388,7 @@ func (c *Module) ensureTask(ctx context.Context, container containerd.Container)
 		return err
 	}
 
-	log.Info().Str("loguri", uri.String()).Msg("external logging process")
+	log.Debug().Str("loguri", uri.String()).Msg("external logging process")
 	task, err := container.Task(ctx, nil)
 
 	if err != nil && !errdefs.IsNotFound(err) {
@@ -429,7 +429,7 @@ func (c *Module) start(ns, id string) error {
 
 // Inspect returns the detail about a running container
 func (c *Module) Inspect(ns string, id pkg.ContainerID) (result pkg.Container, err error) {
-	log.Info().Str("id", string(id)).Str("ns", ns).Msg("inspect container")
+	log.Debug().Str("id", string(id)).Str("ns", ns).Msg("inspect container")
 
 	client, err := containerd.New(c.containerd)
 	if err != nil {
@@ -489,7 +489,7 @@ func (c *Module) Inspect(ns string, id pkg.ContainerID) (result pkg.Container, e
 
 // ListNS list the name of all the container namespaces
 func (c *Module) ListNS() ([]string, error) {
-	log.Info().Msg("list namespaces")
+	log.Debug().Msg("list namespaces")
 
 	client, err := containerd.New(c.containerd)
 	if err != nil {
@@ -503,7 +503,7 @@ func (c *Module) ListNS() ([]string, error) {
 
 // List all the existing container IDs from a certain namespace ns
 func (c *Module) List(ns string) ([]pkg.ContainerID, error) {
-	log.Info().Str("ns", ns).Msg("list containers")
+	log.Debug().Str("ns", ns).Msg("list containers")
 
 	client, err := containerd.New(c.containerd)
 	if err != nil {
@@ -530,7 +530,7 @@ func (c *Module) List(ns string) ([]pkg.ContainerID, error) {
 
 // Delete stops and remove a container
 func (c *Module) Delete(ns string, id pkg.ContainerID) error {
-	log.Info().Str("id", string(id)).Str("ns", ns).Msg("delete container")
+	log.Debug().Str("id", string(id)).Str("ns", ns).Msg("delete container")
 
 	client, err := containerd.New(c.containerd)
 	if err != nil {
@@ -618,7 +618,7 @@ func applyStartup(data *pkg.Container, path string) error {
 	}
 	defer f.Close()
 
-	log.Info().Msg("startup file found")
+	log.Debug().Msg("startup file found")
 
 	startup := startup{}
 	if _, err := toml.DecodeReader(f, &startup); err != nil {

--- a/pkg/kernel/kernel.go
+++ b/pkg/kernel/kernel.go
@@ -9,6 +9,15 @@ import (
 	"github.com/google/shlex"
 )
 
+const (
+	// Debug means zos is running in debug mode
+	// applications can handle this flag differently
+	Debug = "zos-debug"
+	// VirtualMachine forces zos to think it's running
+	// on a virtual machine. used mainly for development
+	VirtualMachine = "zos-debug-vm"
+)
+
 // Params represent the parameters passed to the kernel at boot
 type Params map[string][]string
 
@@ -25,6 +34,16 @@ func (k Params) Exists(key string) bool {
 func (k Params) Get(key string) ([]string, bool) {
 	v, ok := k[key]
 	return v, ok
+}
+
+func (k Params) IsDebug() bool {
+	_, ok := k.Get(Debug)
+	return ok
+}
+
+func (k Params) IsVirtualMachine() bool {
+	_, ok := k.Get(VirtualMachine)
+	return ok
 }
 
 func parseParams(content string) Params {

--- a/pkg/storage/storage.go
+++ b/pkg/storage/storage.go
@@ -140,8 +140,8 @@ func (s *Module) initialize() error {
 	defer s.mu.Unlock()
 	log.Info().Msgf("Initializing storage module")
 
-	vm := kernel.GetParams().Exists("zos-debug")
-	log.Debug().Bool("is-vm", vm).Msg("virtualization detection")
+	vm := kernel.GetParams().IsVirtualMachine()
+	log.Debug().Bool("is-vm", vm).Msg("debugging virtualization detection")
 
 	// Make sure we finish in 1 minute
 	ctx, cancel := context.WithTimeout(context.Background(), time.Minute*1)

--- a/qemu/vm.sh
+++ b/qemu/vm.sh
@@ -47,7 +47,7 @@ done
 shift $(($OPTIND - 1))
 
 
-cmdline="console=ttyS1,115200n8 $kernelargs"
+cmdline="console=ttyS1,115200n8 zos-debug zos-debug-vm $kernelargs"
 basepath=$(dirname $0)
 vmdir="$basepath/$name"
 md5=$(echo -n $name | md5sum | awk '{print $1}')


### PR DESCRIPTION
Using this flag `zos-debug` the node will enable debug logging for all binaries.

You still can force a debug log level with `-d` flag when starting a separate command manually like `zos -d <sub-command>` 