### PR TITLE
add multi destination client

### DIFF
--- a/client/multi.go
+++ b/client/multi.go
@@ -1,0 +1,55 @@
+package client
+
+import (
+	"context"
+	"encoding/json"
+
+	"github.com/threefoldtech/zos/pkg/gridtypes"
+	"github.com/threefoldtech/zos/pkg/rmb"
+)
+
+// NodeClient struct
+type MultiNodeClient struct {
+	twins []uint32
+	bus   rmb.MultiDestinationClient
+}
+
+func NewMultiNodeClient(twins []uint32, bus rmb.MultiDestinationClient) MultiNodeClient {
+	return MultiNodeClient{twins, bus}
+}
+
+type CountersResult struct {
+	*rmb.ResponseMetadata `json:"-"`
+	Total                 gridtypes.Capacity `json:"total"`
+	Used                  gridtypes.Capacity `json:"used"`
+}
+
+func NewCountersResult() rmb.Response {
+	return &CountersResult{
+		ResponseMetadata: &rmb.ResponseMetadata{},
+		Total:            gridtypes.Capacity{},
+		Used:             gridtypes.Capacity{},
+	}
+}
+func (r *CountersResult) SetResponse(bs []byte) error {
+	return json.Unmarshal(bs, r)
+}
+
+// Counters returns some node statistics. Including total and available cpu, memory, storage, etc...
+func (n *MultiNodeClient) Counters(ctx context.Context) (chan CountersResult, error) {
+	const cmd = "zos.statistics.get"
+
+	ch, err := n.bus.Call(ctx, n.twins, cmd, nil, NewCountersResult)
+	if err != nil {
+		return nil, err
+	}
+	ch2 := make(chan CountersResult)
+	go func() {
+		defer close(ch2)
+		// ctx is handled inside n.bus.Call
+		for elem := range ch {
+			ch2 <- *elem.(*CountersResult)
+		}
+	}()
+	return ch2, nil
+}

--- a/pkg/rmb/interface.go
+++ b/pkg/rmb/interface.go
@@ -23,7 +23,20 @@ type Router interface {
 	Use(Middleware)
 }
 
+type Response interface {
+	SetError(err error)
+	SetTwin(twin uint32)
+	Error() error
+	Twin() uint32
+
+	SetResponse(bs []byte) error
+}
+
 // Client is an rmb abstract client interface.
 type Client interface {
 	Call(ctx context.Context, twin uint32, fn string, data interface{}, result interface{}) error
+}
+
+type MultiDestinationClient interface {
+	Call(ctx context.Context, twins []uint32, fn string, data interface{}, constructor func() Response) (chan Response, error)
 }

--- a/pkg/rmb/multi.go
+++ b/pkg/rmb/multi.go
@@ -1,0 +1,165 @@
+package rmb
+
+import (
+	"context"
+	"encoding/base64"
+	"encoding/json"
+	"fmt"
+
+	"github.com/gomodule/redigo/redis"
+	"github.com/google/uuid"
+	"github.com/pkg/errors"
+	"github.com/rs/zerolog/log"
+)
+
+type ResponseMetadata struct {
+	err  error
+	twin uint32
+}
+
+func NewResponseMetadata() ResponseMetadata {
+	return ResponseMetadata{nil, 0}
+}
+func (r *ResponseMetadata) SetError(err error) {
+	r.err = err
+}
+func (r *ResponseMetadata) SetTwin(twin uint32) {
+	r.twin = twin
+}
+func (r *ResponseMetadata) Twin() uint32 {
+	return r.twin
+}
+func (r *ResponseMetadata) Error() error {
+	return r.err
+}
+
+type MultiRMB struct {
+	pool *redis.Pool
+}
+
+func DefaultMultiRMB() (MultiDestinationClient, error) {
+	return NewMultiRMBClient(DefaultAddress)
+}
+
+func NewMultiRMBClient(address string, poolSize ...uint32) (MultiDestinationClient, error) {
+
+	if len(address) == 0 {
+		address = DefaultAddress
+	}
+
+	pool, err := newRedisPool(address, poolSize...)
+	if err != nil {
+		return nil, err
+	}
+
+	return &MultiRMB{
+		pool: pool,
+	}, nil
+}
+
+func (c *MultiRMB) Call(ctx context.Context, twins []uint32, fn string, data interface{}, constructor func() Response) (chan Response, error) {
+	bytes, err := json.Marshal(data)
+	if err != nil {
+		return nil, errors.Wrap(err, "failed to serialize request data")
+	}
+
+	queue := uuid.NewString()
+	msg := Message{
+		Version:    1,
+		Expiration: 3600,
+		Command:    fn,
+		TwinDest:   twins,
+		Data:       base64.StdEncoding.EncodeToString(bytes),
+		Retqueue:   queue,
+	}
+
+	bytes, err = json.Marshal(msg)
+	if err != nil {
+		return nil, errors.Wrap(err, "failed to serialize message")
+	}
+	con := c.pool.Get()
+
+	_, err = con.Do("RPUSH", systemLocalBus, bytes)
+	if err != nil {
+		return nil, errors.Wrap(err, "failed to push message to local twin")
+	}
+	result := make(chan Response)
+	go func() {
+		defer close(result)
+		defer con.Close()
+		remaining := make(map[uint32]struct{})
+		for _, twin := range twins {
+			remaining[twin] = struct{}{}
+		}
+		// now wait for response.
+		for {
+			select {
+			case <-ctx.Done():
+				for twin := range remaining {
+					response := constructor()
+					response.SetTwin(twin)
+					response.SetError(ctx.Err())
+					result <- response
+				}
+				return
+			default:
+			}
+
+			slice, err := redis.ByteSlices(con.Do("BLPOP", queue, 5))
+			if err != nil && err != redis.ErrNil {
+				log.Error().Err(err).Msg("unexpected error during waiting for the response")
+				break
+			}
+
+			if err == redis.ErrNil || slice == nil {
+				//timeout, just try again immediately
+				continue
+			}
+			response := constructor()
+			// found a response
+			bytes = slice[1]
+
+			twin, data, err := processResponse(bytes)
+			response.SetTwin(twin)
+			if err != nil {
+				response.SetError(err)
+			} else if data != nil {
+				if err := response.SetResponse(data); err != nil {
+					response.SetError(errors.Wrap(err, "couldn't decode response"))
+				}
+			}
+			result <- response
+			delete(remaining, twin)
+			log.Debug().Uint32("twin", twin).Int("remaining_count", len(remaining)).Str("remaining", fmt.Sprintf("%v", remaining)).Msg("sending response")
+			if len(remaining) == 0 {
+				break
+			}
+		}
+	}()
+	return result, nil
+
+}
+
+func processResponse(bytes []byte) (uint32, []byte, error) {
+	var msg Message
+	// we have a response, so load or fail
+	if err := json.Unmarshal(bytes, &msg); err != nil {
+		return msg.TwinSrc, nil, errors.Wrap(err, "failed to load response message")
+	}
+
+	// errorred ?
+	if len(msg.Err) != 0 {
+		return msg.TwinSrc, nil, errors.New(msg.Err)
+	}
+
+	if len(msg.Data) == 0 {
+		return msg.TwinSrc, nil, fmt.Errorf("no response body was returned")
+	}
+
+	bytes, err := base64.StdEncoding.DecodeString(msg.Data)
+	if err != nil {
+		return msg.TwinSrc, nil, errors.Wrap(err, "invalid data body encoding")
+	}
+
+	return msg.TwinSrc, bytes, nil
+}


### PR DESCRIPTION
Usage:
```go
	x, err := rmb.DefaultMultiRMB()
	if err != nil {
		panic(err)
	}
	cl := client.NewMultiNodeClient([]uint32{
		64, 93, 90, 7, 8, 67, 65, 19, 18, 58, 5, 66, 84, 94, 85, 86, 78, 92, 81, 48, 79, 38, 16, 13, 15, 80, 88, 89, 87, 91, 82, 122, 123, 124, 125, 95, 96, 115, 102, 103, 104, 116, 117, 118, 105, 106, 107, 108, 128, 134, 119, 120, 121, 135, 141, 126, 136, 130, 139, 129, 131, 127, 137, 138, 11, 142, 140, 143, 144, 12, 112, 147, 148, 149, 150, 151, 152, 154, 145, 146, 155, 156, 157, 158, 174, 175, 160, 161, 159, 162, 163, 164, 165, 180, 184, 176, 177, 186, 168, 172, 173, 181, 183, 187, 189, 182, 171, 185, 190, 191, 193, 192, 194, 195, 197, 198, 199, 200, 201, 202, 203, 220, 209, 212, 222, 221, 223, 224, 214, 205, 206, 207, 208, 210, 211, 215, 216, 218, 219, 217, 232, 225, 226, 234, 227, 228, 229, 230, 231, 233, 235, 237, 238, 239, 240, 251, 252, 255, 263, 264, 265, 266, 246, 247, 274, 267, 236, 248, 249, 250, 261, 268, 269, 253, 276, 254, 256, 257, 258, 259, 270, 271, 272, 273, 275, 262, 277, 278, 279, 280, 281, 282, 294, 284, 285, 286, 287, 4, 17, 6, 20, 14, 9, 10, 83, 325, 305, 310, 306,
	}, x)
	ch, err := cl.Counters(context.Background())
	if err != nil {
		panic(err)
	}
	for res := range ch {
		if res.Error() != nil {
			fmt.Printf("error sending to %d: %s", res.Twin(), res.Error().Error())
		} else {
			fmt.Printf("twin: %d, total: %v, used: %v\n", res.Twin(), res.Total, res.Used)
		}

	}

```