### PR TITLE
fix initial version and context in stats reporting

### DIFF
--- a/cmds/identityd/main.go
+++ b/cmds/identityd/main.go
@@ -223,6 +223,7 @@ func upgradeLoop(
 		debugReinstall(boot, upgrader)
 	}
 
+	monitor.C <- boot.MustVersion()
 	var hub upgrade.HubClient
 
 	flist := boot.Name()

--- a/cmds/modules/noded/main.go
+++ b/cmds/modules/noded/main.go
@@ -216,7 +216,7 @@ func action(cli *cli.Context) error {
 	go func() {
 		for {
 			if err := reportStatistics(ctx, msgBrokerCon, redis); err != nil {
-				log.Error().Err(err).Msg("sending uptime failed")
+				log.Error().Err(err).Msg("sending stats report failed")
 				<-time.After(10 * time.Second)
 			}
 		}


### PR DESCRIPTION
The context used for zbus version request was outside the loop, so all requests after a minute uses a timed out context. It didn't cause issue because zbus checks the response periodically every second. And since the result almost always returns before a second, the context is not checked.