### PR TITLE
New reporting

### DIFF
--- a/cmds/modules/noded/main.go
+++ b/cmds/modules/noded/main.go
@@ -227,6 +227,7 @@ func action(cli *cli.Context) error {
 	identityd := stubs.NewIdentityManagerStub(redis)
 	sk := ed25519.PrivateKey(identityd.PrivateKey(ctx))
 	id, err := substrate.NewIdentityFromEd25519Key(sk)
+	log.Info().Str("address", id.Address()).Msg("node address")
 	if err != nil {
 		return err
 	}

--- a/cmds/modules/provisiond/events.go
+++ b/cmds/modules/provisiond/events.go
@@ -1,0 +1,144 @@
+package provisiond
+
+import (
+	"context"
+	"time"
+
+	"github.com/pkg/errors"
+	"github.com/rs/zerolog/log"
+	"github.com/threefoldtech/substrate-client"
+	"github.com/threefoldtech/zbus"
+	"github.com/threefoldtech/zos/pkg"
+	"github.com/threefoldtech/zos/pkg/provision"
+	"github.com/threefoldtech/zos/pkg/stubs"
+)
+
+type ContractEventHandler struct {
+	node   uint32
+	pool   substrate.Manager
+	engine provision.Engine
+	cl     zbus.Client
+}
+
+func NewContractEventHandler(node uint32, mgr substrate.Manager, engine provision.Engine, cl zbus.Client) ContractEventHandler {
+	return ContractEventHandler{node: node, pool: mgr, engine: engine, cl: cl}
+}
+
+func (r *ContractEventHandler) current() (map[uint64]uint32, error) {
+	// we need to build a list of all supposedly active contracts on this node
+	storage := r.engine.Storage()
+	twins, err := storage.Twins()
+	if err != nil {
+		return nil, err
+	}
+	active := make(map[uint64]uint32)
+	for _, twin := range twins {
+		deployments, err := storage.ByTwin(twin)
+		if err != nil {
+			return nil, err
+		}
+		for _, id := range deployments {
+			deployment, err := storage.Get(twin, id)
+			if err != nil {
+				return nil, err
+			}
+
+			if len(deployment.Workloads) > 0 {
+				active[deployment.ContractID] = twin
+			}
+		}
+	}
+
+	return active, nil
+}
+
+func (r *ContractEventHandler) sync(ctx context.Context) error {
+	log.Debug().Msg("synchronizing contracts with the chain")
+
+	active, err := r.current()
+	if err != nil {
+		return errors.Wrap(err, "failed to get current active contracts")
+	}
+	sub, err := r.pool.Substrate()
+	if err != nil {
+		return err
+	}
+
+	defer sub.Close()
+	onchain, err := sub.GetNodeContracts(r.node)
+	if err != nil {
+		return errors.Wrap(err, "failed to get active node contracts")
+	}
+
+	for _, contract := range onchain {
+		delete(active, uint64(contract))
+	}
+
+	for contract, twin := range active {
+		// those contracts exits on node but not on chain.
+		// need to be deleted
+		if err := r.engine.Deprovision(ctx, twin, contract, "contract not active on chain"); err != nil {
+			log.Error().Err(err).
+				Uint32("twin", twin).
+				Uint64("contract", contract).
+				Msg("failed to decomission contract")
+		}
+	}
+
+	log.Debug().Msg("synchronization complete")
+	return nil
+}
+
+// Run runs the reporter
+func (r *ContractEventHandler) Run(ctx context.Context) error {
+	// go over all user reservations
+	// take into account the following:
+	// every is in seconds.
+	events := stubs.NewEventsStub(r.cl)
+	stream, err := events.ContractCancelledEvent(ctx)
+	if err != nil {
+		return errors.Wrap(err, "failed to register to node events")
+	}
+
+	if err := r.sync(ctx); err != nil {
+		return errors.Wrap(err, "failed to synchronize active contracts")
+	}
+
+	ticker := time.NewTicker(1 * time.Hour)
+	defer ticker.Stop()
+
+	for {
+		select {
+		case <-ctx.Done():
+			return ctx.Err()
+		case <-ticker.C:
+			go func() {
+				if err := r.sync(ctx); err != nil {
+					log.Error().Err(err).Msg("failed to synchronize contracts with the chain")
+				}
+			}()
+		case event := <-stream:
+			if event.Kind == pkg.EventSubscribed {
+				// we run this in a go routine because we don't
+				// want synchronization of contracts on the chain (that can take some time)
+				// to block
+				go func() {
+					if err := r.sync(ctx); err != nil {
+						log.Error().Err(err).Msg("failed to synchronize contracts with the chain")
+					}
+				}()
+				continue
+			}
+
+			log.Debug().Msgf("received a cancel contract event %+v", event)
+
+			// otherwise we know what contract to be deleted
+			if err := r.engine.Deprovision(ctx, event.TwinId, event.Contract, "contract canceled"); err != nil {
+				log.Error().Err(err).
+					Uint32("twin", event.TwinId).
+					Uint64("contract", event.Contract).
+					Msg("failed to decomission contract")
+			}
+		}
+	}
+}

--- a/cmds/modules/provisiond/main.go
+++ b/cmds/modules/provisiond/main.go
@@ -316,17 +316,25 @@ func action(cli *cli.Context) error {
 		log.Error().Err(err).Msg("failed to mark module as booted")
 	}
 
-	reporter, err := NewReporter(engine, node, cl, queues)
-	if err != nil {
-		return errors.Wrap(err, "failed to setup capacity reporter")
-	}
-	// also spawn the capacity reporter
+	handler := NewContractEventHandler(node, mgr, engine, cl)
+
 	go func() {
-		if err := reporter.Run(ctx); err != nil && err != context.Canceled {
-			log.Fatal().Err(err).Msg("capacity reported stopped unexpectedely")
+		if err := handler.Run(ctx); err != nil {
+			log.Fatal().Err(err).Msg("handling contracts events failed")
 		}
-		log.Info().Msg("capacity reported stopped")
 	}()
+
+	// reporter, err := NewReporter(engine, node, cl, queues)
+	// if err != nil {
+	// 	return errors.Wrap(err, "failed to setup capacity reporter")
+	// }
+	// // also spawn the capacity reporter
+	// go func() {
+	// 	if err := reporter.Run(ctx); err != nil && err != context.Canceled {
+	// 		log.Fatal().Err(err).Msg("capacity reported stopped unexpectedely")
+	// 	}
+	// 	log.Info().Msg("capacity reported stopped")
+	// }()
 
 	// and start the zbus server in the background
 	go func() {

--- a/go.mod
+++ b/go.mod
@@ -90,3 +90,5 @@ require (
 replace github.com/docker/distribution v2.7.1+incompatible => github.com/docker/distribution v2.7.1-0.20190205005809-0d3efadf0154+incompatible
 
 replace github.com/centrifuge/go-substrate-rpc-client/v4 v4.0.0 => github.com/threefoldtech/go-substrate-rpc-client/v4 v4.0.1-0.20220224103912-af82b63a1bda
+
+replace github.com/threefoldtech/substrate-client => ../substrate-client

--- a/go.mod
+++ b/go.mod
@@ -62,7 +62,7 @@ require (
 	github.com/stretchr/testify v1.7.0
 	github.com/threefoldtech/0-fs v1.3.1-0.20201203163303-d963de9adea7
 	github.com/threefoldtech/go-rmb v0.1.11-0.20220224131627-825c23c921d3
-	github.com/threefoldtech/substrate-client v0.0.0-20220308140931-04dc2e0dad45
+	github.com/threefoldtech/substrate-client v0.0.0-20220311155549-b19ac3fcada8
 	github.com/threefoldtech/zbus v0.1.5
 	github.com/tinylib/msgp v1.1.5 // indirect
 	github.com/tyler-smith/go-bip39 v1.1.0
@@ -90,5 +90,3 @@ require (
 replace github.com/docker/distribution v2.7.1+incompatible => github.com/docker/distribution v2.7.1-0.20190205005809-0d3efadf0154+incompatible
 
 replace github.com/centrifuge/go-substrate-rpc-client/v4 v4.0.0 => github.com/threefoldtech/go-substrate-rpc-client/v4 v4.0.1-0.20220224103912-af82b63a1bda
-
-replace github.com/threefoldtech/substrate-client => ../substrate-client

--- a/go.sum
+++ b/go.sum
@@ -1070,6 +1070,8 @@ github.com/threefoldtech/substrate-client v0.0.0-20220307082230-d63a6e0ece52 h1:
 github.com/threefoldtech/substrate-client v0.0.0-20220307082230-d63a6e0ece52/go.mod h1:Lpsz7gVNSdbWD8erfVh1AZv2wnProc7g/QHJiYp5lP8=
 github.com/threefoldtech/substrate-client v0.0.0-20220308140931-04dc2e0dad45 h1:2rIq8aNpQqIc8++41l4w0joOUKwI7beh9CY6sJzFBDI=
 github.com/threefoldtech/substrate-client v0.0.0-20220308140931-04dc2e0dad45/go.mod h1:Lpsz7gVNSdbWD8erfVh1AZv2wnProc7g/QHJiYp5lP8=
+github.com/threefoldtech/substrate-client v0.0.0-20220311155549-b19ac3fcada8 h1:uYfTsfBbk4DIsEmM6dKlqQC/a8HpN+aECK61uiddrFQ=
+github.com/threefoldtech/substrate-client v0.0.0-20220311155549-b19ac3fcada8/go.mod h1:Lpsz7gVNSdbWD8erfVh1AZv2wnProc7g/QHJiYp5lP8=
 github.com/threefoldtech/zbus v0.1.5 h1:S9kXbjejoRRnJw1yKHEXFGF2vqL+Drae2n4vpj0pGHo=
 github.com/threefoldtech/zbus v0.1.5/go.mod h1:ZtiRpcqzEBJetVQDsEbw0p48h/AF3O1kf0tvd30I0BU=
 github.com/tinylib/msgp v1.0.2/go.mod h1:+d+yLhGm8mzTaHzB+wgMYrodPfmZrzkirds8fDWklFE=

--- a/pkg/rrd/rrd.go
+++ b/pkg/rrd/rrd.go
@@ -1,0 +1,202 @@
+package rrd
+
+import (
+	"encoding/binary"
+	"math"
+	"time"
+
+	"github.com/boltdb/bolt"
+	"github.com/pkg/errors"
+)
+
+// RRD is a round robin database of fixed size which is specified on creation
+// RRD stores `counter` values. Which means values that can only go UP.
+// then it's easy to compute the increase of this counter over a given window
+// The database only keep history based on retention.
+type RRD interface {
+	// Slot returns the current window (slot) to store values.
+	Slot() (Slot, error)
+	// Counters, return all stored counters since the given time (since) until now.
+	Counters(since time.Time) (map[string]float64, error)
+}
+
+type Slot interface {
+	// Counter sets (or overrides) the current stored value for this key,
+	// with value
+	Counter(key string, value float64) error
+	// Key return the key of the slot which is the window timestamp
+	Key() uint64
+}
+
+type rrdBolt struct {
+	db        *bolt.DB
+	window    uint64
+	retention uint64
+}
+
+type rrdSlot struct {
+	db  *bolt.DB
+	key uint64
+}
+
+// NewRRDBolt creates a new rrd database that uses bolt as a storage. if window or retention are 0
+// the function will panic. If retnetion is smaller then window the function will panic.
+// retention and window must be multiple of 1 minute.
+func NewRRDBolt(path string, window time.Duration, retention time.Duration) (RRD, error) {
+	return newRRDBolt(path, window, retention)
+}
+
+func newRRDBolt(path string, window time.Duration, retention time.Duration) (*rrdBolt, error) {
+	window = (window / time.Minute) * time.Minute
+	retention = (retention / time.Minute) * time.Minute
+
+	if window == 0 {
+		panic("invalid window, can't be zero")
+	}
+	if retention == 0 {
+		panic("invalid retention, can't be zero")
+	}
+	if retention < window {
+		panic("retention can't be smaller than window")
+	}
+
+	db, err := bolt.Open(path, 0644, bolt.DefaultOptions)
+	if err != nil {
+		return nil, errors.Wrap(err, "failed to open bolt db")
+	}
+
+	return &rrdBolt{
+		db:        db,
+		window:    uint64(window / time.Second),
+		retention: uint64(retention / time.Second),
+	}, nil
+}
+
+func (r *rrdBolt) retain(now uint64) error {
+	retain := now - r.retention
+	return r.db.Update(func(tx *bolt.Tx) error {
+		cur := tx.Cursor()
+
+		for k, _ := cur.First(); k != nil; k, _ = cur.Next() {
+			if len(k) != 8 {
+				continue // uknown key size
+			}
+
+			if lu64(k) <= retain {
+				// delete the bucket
+				// are we sure this is safe to do while iterating ?
+				_ = tx.DeleteBucket(k)
+			}
+		}
+
+		return nil
+	})
+}
+
+func (r *rrdBolt) Slots() ([]uint64, error) {
+	var slots []uint64
+	err := r.db.View(func(tx *bolt.Tx) error {
+		cur := tx.Cursor()
+		for k, _ := cur.First(); k != nil; k, _ = cur.Next() {
+			slots = append(slots, lu64(k))
+		}
+
+		return nil
+	})
+
+	return slots, err
+}
+
+// Counters return increase in counter value since the given
+// start time.
+func (r *rrdBolt) Counters(since time.Time) (map[string]float64, error) {
+	ts := uint64(since.Unix())
+	ts = (ts / r.window) * r.window
+
+	// we start from the previous slot so we check from the last value.
+	ts -= r.window
+	change := make(map[string]float64)
+
+	err := r.db.View(func(tx *bolt.Tx) error {
+		last := make(map[string]float64)
+		first := true
+		cur := tx.Cursor()
+		for k, _ := cur.Seek(u64(ts)); k != nil; k, _ = cur.Next() {
+			bucket := tx.Bucket(k)
+			values := bucket.Cursor()
+			for k, v := values.First(); k != nil; k, v = values.Next() {
+				vf := lf64(v)
+				key := string(k)
+
+				if !first {
+					prev := last[key]
+					if prev > vf {
+						change[key] += vf
+					} else {
+						change[key] += vf - prev
+					}
+				}
+
+				last[key] = vf
+			}
+
+			first = false
+		}
+
+		return nil
+	})
+
+	return change, err
+}
+
+func (r *rrdBolt) slotAt(ts uint64) (*rrdSlot, error) {
+	ts = (ts / r.window) * r.window
+
+	if err := r.retain(ts); err != nil {
+		return nil, errors.Wrap(err, "failed to apply retnetion policy")
+	}
+
+	if err := r.db.Update(func(tx *bolt.Tx) error {
+		_, err := tx.CreateBucketIfNotExists(u64(ts))
+		return errors.Wrap(err, "failed to create slot bucket")
+
+	}); err != nil {
+		return nil, err
+	}
+
+	return &rrdSlot{db: r.db, key: ts}, nil
+}
+
+func (r *rrdBolt) Slot() (Slot, error) {
+	ts := uint64(time.Now().Unix())
+	return r.slotAt(ts)
+}
+
+func lu64(v []byte) uint64 {
+	return binary.BigEndian.Uint64(v)
+}
+
+func u64(u uint64) []byte {
+	var v [8]byte
+	binary.BigEndian.PutUint64(v[:], u)
+	return v[:]
+}
+
+func f64(f float64) []byte {
+	return u64(math.Float64bits(f))
+}
+
+func lf64(v []byte) float64 {
+	return math.Float64frombits(lu64(v))
+}
+
+func (r *rrdSlot) Counter(key string, value float64) error {
+	return r.db.Update(func(tx *bolt.Tx) error {
+		bucket := tx.Bucket(u64(r.key))
+		return bucket.Put([]byte(key), f64(value))
+	})
+}
+
+func (r *rrdSlot) Key() uint64 {
+	return r.key
+}

--- a/pkg/rrd/rrd_test.go
+++ b/pkg/rrd/rrd_test.go
@@ -79,7 +79,7 @@ func TestCountersSeries(t *testing.T) {
 		slot, err := db.slotAt(uint64(first.Add(time.Duration(i) * time.Minute).Unix()))
 		require.NoError(err)
 
-		slot.Counter("test-1", float64(i))
+		require.NoError(slot.Counter("test-1", float64(i)))
 	}
 
 	// i get all the values over the last 10 minutes
@@ -116,7 +116,7 @@ func TestCountersRandomIncrese(t *testing.T) {
 		if i != 0 {
 			expected += v
 		}
-		slot.Counter("test-1", float64(expected))
+		require.NoError(slot.Counter("test-1", float64(expected)))
 	}
 
 	// i get all the values over the last 10 minutes
@@ -176,7 +176,7 @@ func TestCountersRetention(t *testing.T) {
 		slot, err := db.slotAt(uint64(first.Add(time.Duration(i) * time.Minute).Unix()))
 		require.NoError(err)
 
-		slot.Counter("test-1", float64(i))
+		require.NoError(slot.Counter("test-1", float64(i)))
 	}
 
 	slots, err := db.Slots()

--- a/pkg/rrd/rrd_test.go
+++ b/pkg/rrd/rrd_test.go
@@ -1,0 +1,187 @@
+package rrd
+
+import (
+	"fmt"
+	"math/rand"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestAddSlot(t *testing.T) {
+	require := require.New(t)
+	path := filepath.Join(os.TempDir(), fmt.Sprint(rand.Int63()))
+	defer os.RemoveAll(path)
+
+	window := 1 * time.Minute
+	db, err := NewRRDBolt(path, window, 10*time.Minute)
+	require.NoError(err)
+
+	now := time.Now()
+	slot, err := db.Slot()
+	require.NoError(err)
+
+	w := uint64(window / time.Second) // window in seconds
+	require.Equal((uint64(now.Unix())/w)*w, slot.Key())
+
+	err = slot.Counter("test-1", 120)
+	require.NoError(err)
+}
+
+func TestCountersTwoValues(t *testing.T) {
+	require := require.New(t)
+	path := filepath.Join(os.TempDir(), fmt.Sprint(rand.Int63()))
+	defer os.RemoveAll(path)
+
+	window := 1 * time.Minute
+	db, err := newRRDBolt(path, window, 10*time.Minute)
+	require.NoError(err)
+
+	now := time.Now()
+	slot1, err := db.slotAt(uint64(now.Add(-time.Minute).Unix()))
+	require.NoError(err)
+
+	slotNow, err := db.slotAt(uint64(now.Unix()))
+	require.NoError(err)
+
+	err = slot1.Counter("test-1", 100)
+	require.NoError(err)
+
+	err = slotNow.Counter("test-1", 120)
+	require.NoError(err)
+
+	counters, err := db.Counters(now.Add(-5 * time.Minute))
+	require.NoError(err)
+	require.Len(counters, 1)
+
+	require.EqualValues(20, counters["test-1"])
+}
+
+func TestCountersSeries(t *testing.T) {
+	require := require.New(t)
+	path := filepath.Join(os.TempDir(), fmt.Sprint(rand.Int63()))
+	defer os.RemoveAll(path)
+
+	window := 1 * time.Minute
+	// note retention is only 10 minutes
+	db, err := newRRDBolt(path, window, 10*time.Minute)
+	require.NoError(err)
+
+	over := 20
+	now := time.Now()
+	first := now.Add(-time.Duration(over) * time.Minute)
+
+	// we insert values over the last 20 minutes
+	for i := 0; i <= over; i++ {
+		slot, err := db.slotAt(uint64(first.Add(time.Duration(i) * time.Minute).Unix()))
+		require.NoError(err)
+
+		slot.Counter("test-1", float64(i))
+	}
+
+	// i get all the values over the last 10 minutes
+	counters, err := db.Counters(now.Add(-10 * time.Minute))
+	require.NoError(err)
+	require.Len(counters, 1)
+
+	// we go up by one for each slot. so query last 10 blocks (including now) should return 9
+	require.EqualValues(9, counters["test-1"])
+}
+
+func TestCountersRandomIncrese(t *testing.T) {
+	require := require.New(t)
+	path := filepath.Join(os.TempDir(), fmt.Sprint(rand.Int63()))
+	defer os.RemoveAll(path)
+
+	window := 1 * time.Minute
+	// note retention is only 10 minutes
+	db, err := newRRDBolt(path, window, 10*time.Minute)
+	require.NoError(err)
+
+	over := 5
+	now := time.Now()
+	//slot, _ := db.slotAt(uint64(now.Add(-5 * time.Microsecond).Unix()))
+
+	first := now.Add(-time.Duration(over) * time.Minute)
+
+	// we insert values over the last 20 minutes
+	var expected int64
+	for i := 0; i <= over; i++ {
+		slot, err := db.slotAt(uint64(first.Add(time.Duration(i) * time.Minute).Unix()))
+		require.NoError(err)
+		v := rand.Int63n(10)
+		if i != 0 {
+			expected += v
+		}
+		slot.Counter("test-1", float64(expected))
+	}
+
+	// i get all the values over the last 10 minutes
+	counters, err := db.Counters(now.Add(-10 * time.Minute))
+	require.NoError(err)
+	require.Len(counters, 1)
+
+	// we go up by one for each slot. so query last 10 blocks should return 10
+	require.EqualValues(expected, counters["test-1"])
+}
+
+func TestCountersGap(t *testing.T) {
+	require := require.New(t)
+	path := filepath.Join(os.TempDir(), fmt.Sprint(rand.Int63()))
+	defer os.RemoveAll(path)
+
+	window := 1 * time.Minute
+	db, err := newRRDBolt(path, window, 10*time.Minute)
+	require.NoError(err)
+
+	now := time.Now()
+	slot1, err := db.slotAt(uint64(now.Add(3 - time.Minute).Unix()))
+	require.NoError(err)
+
+	slotNow, err := db.slotAt(uint64(now.Unix()))
+	require.NoError(err)
+
+	err = slot1.Counter("test-1", 100)
+	require.NoError(err)
+
+	err = slotNow.Counter("test-1", 120)
+	require.NoError(err)
+
+	counters, err := db.Counters(now.Add(-5 * time.Minute))
+	require.NoError(err)
+	require.Len(counters, 1)
+
+	require.EqualValues(20, counters["test-1"])
+}
+
+func TestCountersRetention(t *testing.T) {
+	require := require.New(t)
+	path := filepath.Join(os.TempDir(), fmt.Sprint(rand.Int63()))
+	defer os.RemoveAll(path)
+
+	window := 1 * time.Minute
+	// note retention is only 10 minutes
+	db, err := newRRDBolt(path, window, 10*time.Minute)
+	require.NoError(err)
+
+	over := 20
+	now := time.Now()
+	first := now.Add(-time.Duration(over) * time.Minute)
+
+	// we insert values over the last 20 minutes
+	for i := 0; i <= over; i++ {
+		slot, err := db.slotAt(uint64(first.Add(time.Duration(i) * time.Minute).Unix()))
+		require.NoError(err)
+
+		slot.Counter("test-1", float64(i))
+	}
+
+	slots, err := db.Slots()
+	require.NoError(err)
+
+	require.Len(slots, 10)
+	require.EqualValues((now.Add(-9*time.Minute).Unix()/60)*60, slots[0])
+}

--- a/pkg/vm.go
+++ b/pkg/vm.go
@@ -209,7 +209,7 @@ func (n *NetMetric) Nu() float64 {
 	const (
 		// weights knobs for nu calculations
 		bytes   float64 = 1.0
-		packets float64 = 0.2
+		packets float64 = 0.0
 		rx      float64 = 1.0
 		tx      float64 = 1.0
 	)


### PR DESCRIPTION
- Track all VMs consumption every 5 min, create a report of the total consumption during a window every hour 
- Report include 
  - Contract ID
  - Report window
  - Report timestap
  - Network consumption only.
- It introduce only a new way to synchronize contracts with the grid, and to handle cancellation events. 

To be done
- Set contract used capacity on creation/update
