### PR TITLE
Cache detected device type on boot

### DIFF
--- a/pkg/cache/cache.go
+++ b/pkg/cache/cache.go
@@ -5,23 +5,17 @@ import (
 	"os"
 	"path/filepath"
 	"syscall"
-
-	"github.com/threefoldtech/zos/pkg/storage"
 )
 
-// ForeverDir creates a new cache directory that is stored on the persistent cache.
-// This means data stored in this directory will survive reboot
-// It is the caller's responsibility to remove the directory when no longer needed.
-func ForeverDir(name string) (string, error) {
-	name = filepath.Join(storage.CacheTarget, "cache", name)
-	return name, os.MkdirAll(name, 0700)
-}
+const (
+	Megabyte = 1024 * 1024
+)
 
 // VolatileDir creates a new cache directory that is stored on a tmpfs.
 // This means data stored in this directory will NOT survive a reboot.
 // Use this when you need to store data that needs to survice deamon reboot but not between reboots
 // It is the caller's responsibility to remove the directory when no longer needed.
-// If the directory already exist, the the function does nothing and return successfully
+// If the directory already exist error of type os.IsExist will be returned
 func VolatileDir(name string, size uint64) (string, error) {
 	const volatileBaseDir = "/var/run/cache"
 	name = filepath.Join(volatileBaseDir, name)


### PR DESCRIPTION
The idea is we create a voltaile cache. will be gone
if machine is rebooted. we will store all detected devices
types in that cache, and use that from now on. On reboot
the device types will always be detected again before any
workload is active