### PR TITLE
Implement zlogs workload

### DIFF
--- a/cmds/modules/provisiond/main.go
+++ b/cmds/modules/provisiond/main.go
@@ -296,6 +296,8 @@ func action(cli *cli.Context) error {
 			zos.NetworkType,
 			zos.PublicIPv4Type,
 			zos.PublicIPType,
+			zos.ZMachineType,
+			zos.ZLogsType, //make sure zlogs comes after zmachine
 		),
 		// if this is a node reboot, the node needs to
 		// recreate all reservations. so we set rerun = true

--- a/pkg/gridtypes/zos/types.go
+++ b/pkg/gridtypes/zos/types.go
@@ -26,6 +26,8 @@ const (
 	GatewayFQDNProxyType gridtypes.WorkloadType = "gateway-fqdn-proxy"
 	// QuantumSafeFSType type
 	QuantumSafeFSType gridtypes.WorkloadType = "qsfs"
+	// ZLogsType type
+	ZLogsType gridtypes.WorkloadType = "zlogs"
 )
 
 func init() {
@@ -41,6 +43,7 @@ func init() {
 	gridtypes.RegisterType(GatewayNameProxyType, GatewayNameProxy{})
 	gridtypes.RegisterType(GatewayFQDNProxyType, GatewayFQDNProxy{})
 	gridtypes.RegisterType(QuantumSafeFSType, QuantumSafeFS{})
+	gridtypes.RegisterType(ZLogsType, ZLogs{})
 }
 
 // DeviceType is the actual type of hardware that the storage device runs on,

--- a/pkg/gridtypes/zos/zlogs.go
+++ b/pkg/gridtypes/zos/zlogs.go
@@ -1,0 +1,59 @@
+package zos
+
+import (
+	"fmt"
+	"io"
+	"net/url"
+
+	"github.com/pkg/errors"
+	"github.com/threefoldtech/zos/pkg/gridtypes"
+)
+
+var (
+	validLogSchemes = map[string]struct{}{
+		"redis": {},
+		"ws":    {},
+		"wss":   {},
+	}
+)
+
+type ZLogs struct {
+	// ZMachine stream logs for which zmachine
+	ZMachine gridtypes.Name
+	// Output url
+	Output string
+}
+
+func (z ZLogs) Valid(getter gridtypes.WorkloadGetter) error {
+	wl, err := getter.Get(z.ZMachine)
+	if err != nil || wl.Type != ZMachineType {
+		return fmt.Errorf("no zmachine with name '%s' found", z.ZMachine)
+	}
+
+	u, err := url.Parse(z.Output)
+	if err != nil {
+		return errors.Wrap(err, "invalid url supplied in output")
+	}
+
+	if _, ok := validLogSchemes[u.Scheme]; !ok {
+		return fmt.Errorf("invalid output schema '%s' not supported", u.Scheme)
+	}
+
+	return nil
+}
+
+func (z ZLogs) Challenge(w io.Writer) error {
+	if _, err := fmt.Fprintf(w, "%s", z.ZMachine); err != nil {
+		return err
+	}
+
+	if _, err := fmt.Fprintf(w, "%s", z.Output); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func (z ZLogs) Capacity() (gridtypes.Capacity, error) {
+	return gridtypes.Capacity{}, nil
+}

--- a/pkg/gridtypes/zos/zlogs.go
+++ b/pkg/gridtypes/zos/zlogs.go
@@ -19,9 +19,9 @@ var (
 
 type ZLogs struct {
 	// ZMachine stream logs for which zmachine
-	ZMachine gridtypes.Name
+	ZMachine gridtypes.Name `json:"zmachine"`
 	// Output url
-	Output string
+	Output string `json:"output"`
 }
 
 func (z ZLogs) Valid(getter gridtypes.WorkloadGetter) error {

--- a/pkg/network.go
+++ b/pkg/network.go
@@ -47,6 +47,9 @@ type Networker interface {
 	// Delete a network resource
 	DeleteNR(Network) error
 
+	// Namespace returns the namespace name for given netid.
+	// it doesn't check if network exists.
+	Namespace(id zos.NetID) string
 	// deprecated all uses taps now
 
 	// // Join a network (with network id) will create a new isolated namespace

--- a/pkg/network/networker.go
+++ b/pkg/network/networker.go
@@ -17,6 +17,7 @@ import (
 	"github.com/blang/semver"
 
 	"github.com/threefoldtech/zos/pkg/cache"
+	"github.com/threefoldtech/zos/pkg/gridtypes/zos"
 	"github.com/threefoldtech/zos/pkg/network/ndmz"
 	"github.com/threefoldtech/zos/pkg/network/public"
 	"github.com/threefoldtech/zos/pkg/network/tuntap"
@@ -823,6 +824,10 @@ func (n *networker) DeleteNR(netNR pkg.Network) error {
 	}
 
 	return nil
+}
+
+func (n *networker) Namespace(id zos.NetID) string {
+	return fmt.Sprintf("n-%s", id)
 }
 
 // Set node public namespace config

--- a/pkg/primitives/provisioner.go
+++ b/pkg/primitives/provisioner.go
@@ -32,6 +32,7 @@ func NewPrimitivesProvisioner(zbus zbus.Client) *Primitives {
 		zos.GatewayNameProxyType: p.gwProvision,
 		zos.GatewayFQDNProxyType: p.gwFQDNProvision,
 		zos.QuantumSafeFSType:    p.qsfsProvision,
+		zos.ZLogsType:            p.zlogsProvision,
 	}
 	decommissioners := map[gridtypes.WorkloadType]provision.RemoveFunction{
 		zos.ZMountType:           p.zMountDecommission,
@@ -43,6 +44,7 @@ func NewPrimitivesProvisioner(zbus zbus.Client) *Primitives {
 		zos.GatewayNameProxyType: p.gwDecommission,
 		zos.GatewayFQDNProxyType: p.gwFQDNDecommission,
 		zos.QuantumSafeFSType:    p.qsfsDecommision,
+		zos.ZLogsType:            p.zlogsDecomission,
 	}
 
 	// only network support update atm

--- a/pkg/primitives/zlogs.go
+++ b/pkg/primitives/zlogs.go
@@ -1,0 +1,66 @@
+package primitives
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+
+	"github.com/pkg/errors"
+	"github.com/threefoldtech/zos/pkg"
+	"github.com/threefoldtech/zos/pkg/gridtypes"
+	"github.com/threefoldtech/zos/pkg/gridtypes/zos"
+	"github.com/threefoldtech/zos/pkg/provision"
+	"github.com/threefoldtech/zos/pkg/stubs"
+)
+
+func (p *Primitives) zlogsProvision(ctx context.Context, wl *gridtypes.WorkloadWithID) (interface{}, error) {
+
+	var (
+		vm      = stubs.NewVMModuleStub(p.zbus)
+		network = stubs.NewNetworkerStub(p.zbus)
+	)
+
+	var cfg zos.ZLogs
+	if err := json.Unmarshal(wl.Data, &cfg); err != nil {
+		return nil, errors.Wrap(err, "failed to decode zlogs config")
+	}
+
+	machine, err := provision.GetWorkload(ctx, cfg.ZMachine)
+	if err != nil || machine.Type != zos.ZMachineType {
+		return nil, errors.Wrapf(err, "no zmachine with name '%s'", cfg.ZMachine)
+	}
+
+	if !machine.Result.State.IsAny(gridtypes.StateOk) {
+		return nil, errors.Wrapf(err, "machine state is not ok")
+	}
+
+	var machineCfg zos.ZMachine
+	if err := json.Unmarshal(machine.Data, &machineCfg); err != nil {
+		return nil, errors.Wrap(err, "failed to decode zlogs config")
+	}
+
+	var net gridtypes.Name
+
+	if len(machineCfg.Network.Interfaces) > 0 {
+		net = machineCfg.Network.Interfaces[0].Network
+	} else {
+		return nil, fmt.Errorf("invalid zmachine network configuration")
+	}
+
+	twin, _ := provision.GetDeploymentID(ctx)
+
+	return nil, vm.StreamCreate(ctx, machine.ID.String(), pkg.Stream{
+		ID:        wl.ID.String(),
+		Namespace: network.Namespace(ctx, zos.NetworkID(twin, net)),
+		Output:    cfg.Output,
+	})
+
+}
+
+func (p *Primitives) zlogsDecomission(ctx context.Context, wl *gridtypes.WorkloadWithID) error {
+	var (
+		vm = stubs.NewVMModuleStub(p.zbus)
+	)
+
+	return vm.StreamDelete(ctx, wl.ID.String())
+}

--- a/pkg/stubs/network_stub.go
+++ b/pkg/stubs/network_stub.go
@@ -209,6 +209,18 @@ func (s *NetworkerStub) GetSubnet(ctx context.Context, arg0 zos.NetID) (ret0 net
 	return
 }
 
+func (s *NetworkerStub) Namespace(ctx context.Context, arg0 zos.NetID) (ret0 string) {
+	args := []interface{}{arg0}
+	result, err := s.client.RequestContext(ctx, s.module, s.object, "Namespace", args...)
+	if err != nil {
+		panic(err)
+	}
+	if err := result.Unmarshal(0, &ret0); err != nil {
+		panic(err)
+	}
+	return
+}
+
 func (s *NetworkerStub) PubIPFilterExists(ctx context.Context, arg0 string) (ret0 bool) {
 	args := []interface{}{arg0}
 	result, err := s.client.RequestContext(ctx, s.module, s.object, "PubIPFilterExists", args...)

--- a/pkg/stubs/vmd_stub.go
+++ b/pkg/stubs/vmd_stub.go
@@ -124,3 +124,29 @@ func (s *VMModuleStub) Run(ctx context.Context, arg0 pkg.VM) (ret0 error) {
 	}
 	return
 }
+
+func (s *VMModuleStub) StreamCreate(ctx context.Context, arg0 string, arg1 pkg.Stream) (ret0 error) {
+	args := []interface{}{arg0, arg1}
+	result, err := s.client.RequestContext(ctx, s.module, s.object, "StreamCreate", args...)
+	if err != nil {
+		panic(err)
+	}
+	ret0 = new(zbus.RemoteError)
+	if err := result.Unmarshal(0, &ret0); err != nil {
+		panic(err)
+	}
+	return
+}
+
+func (s *VMModuleStub) StreamDelete(ctx context.Context, arg0 string) (ret0 error) {
+	args := []interface{}{arg0}
+	result, err := s.client.RequestContext(ctx, s.module, s.object, "StreamDelete", args...)
+	if err != nil {
+		panic(err)
+	}
+	ret0 = new(zbus.RemoteError)
+	if err := result.Unmarshal(0, &ret0); err != nil {
+		panic(err)
+	}
+	return
+}

--- a/pkg/vm.go
+++ b/pkg/vm.go
@@ -232,6 +232,24 @@ type MachineMetric struct {
 // MachineMetrics container for metrics from multiple machines
 type MachineMetrics map[string]MachineMetric
 
+type Stream struct {
+	//ID stream ID must be unique
+	ID string
+	// Network namespace where the streamer will
+	// run
+	Namespace string
+	// Output URL as accepted by the streamer tool
+	Output string
+}
+
+func (s *Stream) Valid() error {
+	if len(s.ID) == 0 {
+		return fmt.Errorf("missing stream id")
+	}
+
+	return nil
+}
+
 // VMModule defines the virtual machine module interface
 type VMModule interface {
 	Run(vm VM) error
@@ -241,4 +259,11 @@ type VMModule interface {
 	Logs(name string) (string, error)
 	List() ([]string, error)
 	Metrics() (MachineMetrics, error)
+
+	// VM Log streams
+
+	// StreamCreate creates a stream for vm `name`
+	StreamCreate(name string, stream Stream) error
+	// delete stream by stream id.
+	StreamDelete(id string) error
 }

--- a/pkg/vm/logs.go
+++ b/pkg/vm/logs.go
@@ -1,0 +1,67 @@
+package vm
+
+import (
+	"fmt"
+	"time"
+
+	"github.com/pkg/errors"
+	"github.com/threefoldtech/zos/pkg"
+	"github.com/threefoldtech/zos/pkg/zinit"
+)
+
+const (
+	streamPrefix = "stream:"
+)
+
+// StreamCreate creates a stream for vm `name`
+func (m *Module) StreamCreate(name string, stream pkg.Stream) error {
+	if err := stream.Valid(); err != nil {
+		return err
+	}
+
+	id := fmt.Sprintf("%s%s", streamPrefix, stream.ID)
+
+	_, err := Find(name)
+	if err != nil {
+		return err
+	}
+
+	file := m.logsPath(name)
+
+	cl := zinit.Default()
+	if _, err := cl.Get(stream.ID); err == nil {
+		return fmt.Errorf("stream with same id '%s' already exists", id)
+	}
+
+	cmd := fmt.Sprintf("tailstream -o %s %s", stream.Output, file)
+	if stream.Namespace != "" {
+		cmd = fmt.Sprintf("ip netns exec %s %s", stream.Namespace, cmd)
+	}
+
+	service := zinit.InitService{
+		Exec: cmd,
+		Log:  zinit.NoneLogType,
+	}
+
+	if err := zinit.AddService(id, service); err != nil {
+		return errors.Wrapf(err, "failed to add stream service '%s'", id)
+	}
+
+	return cl.Monitor(id)
+}
+
+// delete stream by stream id.
+func (m *Module) StreamDelete(id string) error {
+	id = fmt.Sprintf("%s%s", streamPrefix, id)
+	cl := zinit.Default()
+
+	defer zinit.RemoveService(id)
+
+	_, err := cl.Get(id)
+	if errors.Is(err, zinit.ErrUnknownService) {
+		return nil
+	}
+
+	cl.StopWait(30*time.Second, id)
+	return cl.Forget(id)
+}

--- a/pkg/zinit/service.go
+++ b/pkg/zinit/service.go
@@ -27,6 +27,7 @@ func (s *LogType) UnmarshalYAML(unmarshal func(interface{}) error) error {
 const (
 	StdoutLogType LogType = "stdout"
 	RingLogType   LogType = "ring"
+	NoneLogType   LogType = "none"
 )
 
 // InitService represent a Zinit service file


### PR DESCRIPTION
Introduce a new workload type `zlogs`. The Zlogs runs as a separate workload so this allow:
- Reconfigure logging forwarding for a vm without having to updating the VM workload itself
- It allows multiple protocols, hence you can run multiple instance that stream logs of the same ZMachine to different locations.
- zlogs runs inside the same network as the node. Which means you can stream the logs to another VM in the same network (will use wireguard). Hence you can run redis, or a compatible websocket server to receive the logs. Then make other zmachine stream the logs there

  
Zlogs config is
```json
{
   "zmachine": "name of zmachine to forward logs",
   "output": "output url as supported by tailstream tool"
}
```
Check supported stream protocol by https://github.com/threefoldtech/tailstream