### PR TITLE
Fix vm rootfs disk persistence issue

### DIFF
--- a/pkg/primitives/vm.go
+++ b/pkg/primitives/vm.go
@@ -314,8 +314,10 @@ func (p *Primitives) virtualMachineProvisionImpl(ctx context.Context, wl *gridty
 			return result, errors.Wrap(err, "disk does not exist")
 		}
 
-		//TODO: this should not happen if disk image was written before !!
-		// fs detection must be done here
+		//TODO: DiskWrite will not override the disk if it already has a partition table
+		// or a filesystem. this means that if later the disk is assigned to a new VM with
+		// a different flist it will have the same old operating system copied from previous
+		// setup.
 		if err = storage.DiskWrite(ctx, disk.ID.String(), imageInfo.ImagePath); err != nil {
 			return result, errors.Wrap(err, "failed to write image to disk")
 		}

--- a/pkg/storage/disk.go
+++ b/pkg/storage/disk.go
@@ -110,12 +110,19 @@ func (s *Module) DiskFormat(name string) error {
 	return s.ensureFS(path)
 }
 
-// DiskWrite writes image to disk
+// DiskWrite writes image to disk. Disk will not be changed
+// if it already has a filesystem or partition table.
 func (s *Module) DiskWrite(name string, image string) error {
 	path, err := s.findDisk(name)
 	if err != nil {
 		return errors.Wrapf(err, "couldn't find disk with id: %s", name)
 	}
+
+	if !s.isEmptyDisk(path) {
+		log.Debug().Str("disk", path).Msg("disk already has a filesystem. no write")
+		return nil
+	}
+
 	source, err := os.Open(image)
 	if err != nil {
 		return errors.Wrap(err, "failed to open image")
@@ -221,6 +228,18 @@ func (s *Module) ensureFS(disk string) error {
 	}
 
 	return errors.Wrapf(err, "unknown btrfs error '%s'", string(output))
+}
+
+// isEmptyDisk return true, if disk file has no partition table or filesystem
+// else, returns false
+func (s *Module) isEmptyDisk(disk string) bool {
+	err := exec.Command("blkid", disk).Run()
+
+	if err != nil {
+		return true
+	}
+
+	return false
 }
 
 func (s *Module) safePath(base, id string) (string, error) {

--- a/pkg/storage/disk.go
+++ b/pkg/storage/disk.go
@@ -235,11 +235,7 @@ func (s *Module) ensureFS(disk string) error {
 func (s *Module) isEmptyDisk(disk string) bool {
 	err := exec.Command("blkid", disk).Run()
 
-	if err != nil {
-		return true
-	}
-
-	return false
+	return err != nil
 }
 
 func (s *Module) safePath(base, id string) (string, error) {


### PR DESCRIPTION
This make sure that if the node reported, that it will not override the VM rootfs disk with the image again. If the disk already has a parition table, and or filesystem it's not overriden


Fixes #1672