### PR TITLE
Safer upgrade managment

### DIFF
--- a/.github/workflows/grid-deploy.yaml
+++ b/.github/workflows/grid-deploy.yaml
@@ -1,0 +1,30 @@
+name: Deploy
+
+on:
+  workflow_dispatch:
+    inputs:
+      grid:
+        description: "grid to deploy"
+        required: true
+        default: "testing"
+        type: choice
+        options:
+          - testing
+          - production
+      version:
+        description: "version to release"
+        required: true
+        type: string
+jobs:
+  link-release:
+    name: linking
+    runs-on: ubuntu-latest
+    steps:
+      - name: Symlink flist (development)
+        uses: threefoldtech/publish-flist@master
+        with:
+          token: ${{ secrets.HUB_JWT }}
+          action: crosslink
+          user: tf-zos
+          name: zos:${{ github.event.inputs.grid }}-3:latest.flist
+          target: tf-autobuilder/zos:${{ github.event.inputs.version }}.flist

--- a/.github/workflows/publish-pre-release.yaml
+++ b/.github/workflows/publish-pre-release.yaml
@@ -58,23 +58,3 @@ jobs:
           user: tf-autobuilder
           name: zos-${{ github.ref }}.flist
           target: zos:${{ github.ref }}.flist
-
-      - name: Symlink flist (development)
-        if: success()
-        uses: threefoldtech/publish-flist@master
-        with:
-          token: ${{ secrets.HUB_JWT }}
-          action: crosslink
-          user: tf-zos
-          name: zos:development-3:latest.flist
-          target: tf-autobuilder/zos:${{ github.ref }}.flist
-
-      - name: Symlink flist (testing)
-        if: success()
-        uses: threefoldtech/publish-flist@master
-        with:
-          token: ${{ secrets.HUB_JWT }}
-          action: crosslink
-          user: tf-zos
-          name: zos:testing-3:latest.flist
-          target: tf-autobuilder/zos:${{ github.ref }}.flist

--- a/.github/workflows/publish-release.yaml
+++ b/.github/workflows/publish-release.yaml
@@ -59,33 +59,3 @@ jobs:
           user: tf-autobuilder
           name: zos-${{ github.ref }}.flist
           target: zos:${{ github.ref }}.flist
-
-      - name: Symlink flist (development)
-        if: success()
-        uses: threefoldtech/publish-flist@master
-        with:
-          token: ${{ secrets.HUB_JWT }}
-          action: crosslink
-          user: tf-zos
-          name: zos:development-3:latest.flist
-          target: tf-autobuilder/zos:${{ github.ref }}.flist
-
-      - name: Symlink flist (testing)
-        if: success()
-        uses: threefoldtech/publish-flist@master
-        with:
-          token: ${{ secrets.HUB_JWT }}
-          action: crosslink
-          user: tf-zos
-          name: zos:testing-3:latest.flist
-          target: tf-autobuilder/zos:${{ github.ref }}.flist
-
-      - name: Symlink flist (production)
-        if: success()
-        uses: threefoldtech/publish-flist@master
-        with:
-          token: ${{ secrets.HUB_JWT }}
-          action: crosslink
-          user: tf-zos
-          name: zos:production-3:latest.flist
-          target: tf-autobuilder/zos:${{ github.ref }}.flist


### PR DESCRIPTION
Thanks to @delandtj we have to rethink our strategy to deploy
zos updates on the grid. This is separate the release creation
from the actual upgrade. While creating a release will build everything
but only on deploy workflow that has to be triggered manually the
release is going to be installed on the selected grid