### PR TITLE
Polka signing

### DIFF
--- a/pkg/gridtypes/sign_test.go
+++ b/pkg/gridtypes/sign_test.go
@@ -1,0 +1,71 @@
+package gridtypes
+
+import (
+	"bytes"
+	"crypto/ed25519"
+	"crypto/rand"
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"github.com/threefoldtech/substrate-client"
+)
+
+type polkaSigner struct {
+	Signer
+}
+
+func (s *polkaSigner) Sign(msg []byte) ([]byte, error) {
+	var buf bytes.Buffer
+	if _, err := buf.WriteString("<Bytes>"); err != nil {
+		return nil, err
+	}
+
+	if _, err := buf.Write(msg); err != nil {
+		return nil, err
+	}
+
+	if _, err := buf.WriteString("</Bytes>"); err != nil {
+		return nil, err
+	}
+
+	return s.Signer.Sign(buf.Bytes())
+}
+
+type keyGetter struct {
+	twin uint32
+	key  []byte
+}
+
+func (k *keyGetter) GetKey(twin uint32) ([]byte, error) {
+	if k.twin != twin {
+		return nil, fmt.Errorf("unknown twin")
+	}
+
+	return k.key, nil
+}
+
+func TestSignVerify(t *testing.T) {
+	pk, sk, err := ed25519.GenerateKey(rand.Reader)
+	require.NoError(t, err)
+
+	id, err := substrate.NewIdentityFromEd25519Key(sk)
+	require.NoError(t, err)
+
+	signer := polkaSigner{id}
+
+	dl := Deployment{
+		TwinID: 1,
+		SignatureRequirement: SignatureRequirement{
+			Requests: []SignatureRequest{
+				{TwinID: 1, Required: true, Weight: 1},
+			},
+			SignatureStyle: SignatureStylePolka,
+		},
+	}
+
+	require.NoError(t, dl.Sign(1, &signer))
+
+	getter := keyGetter{twin: 1, key: pk}
+	require.NoError(t, dl.Verify(&getter))
+}


### PR DESCRIPTION
Add `signature-style` flag on the signature requirements object. this to allow signing directly from the polka-wallet. Notice that the style flag must be part of the challenge hash. 

If set, verification is done against `<Bytes>$hash</Bytes>` instead of `$hash`