### PR TITLE
Fix a bug related to storing deletion reason

### DIFF
--- a/cmds/modules/provisiond/events.go
+++ b/cmds/modules/provisiond/events.go
@@ -133,7 +133,7 @@ func (r *ContractEventHandler) Run(ctx context.Context) error {
 			log.Debug().Msgf("received a cancel contract event %+v", event)
 
 			// otherwise we know what contract to be deleted
-			if err := r.engine.Deprovision(ctx, event.TwinId, event.Contract, "contract canceled"); err != nil {
+			if err := r.engine.Deprovision(ctx, event.TwinId, event.Contract, "contract canceled event received"); err != nil {
 				log.Error().Err(err).
 					Uint32("twin", event.TwinId).
 					Uint64("contract", event.Contract).

--- a/pkg/provision/engine.go
+++ b/pkg/provision/engine.go
@@ -335,14 +335,16 @@ func (e *NativeEngine) Deprovision(ctx context.Context, twin uint32, id uint64, 
 		return err
 	}
 
-	log.Debug().
+	log.Info().
 		Uint32("twin", deployment.TwinID).
 		Uint64("contract", deployment.ContractID).
+		Str("reason", reason).
 		Msg("schedule for deprovision")
 
 	job := engineJob{
-		Target: deployment,
-		Op:     opDeprovision,
+		Target:  deployment,
+		Op:      opDeprovision,
+		Message: reason,
 	}
 
 	return e.queue.Enqueue(&job)
@@ -793,7 +795,9 @@ func (e *NativeEngine) DecommissionCached(id string, reason string) error {
 	ctx, cancel := context.WithTimeout(ctx, 3*time.Minute)
 	defer cancel()
 
-	err = e.uninstallWorkload(ctx, &gridtypes.WorkloadWithID{Workload: &wl, ID: globalID}, reason)
+	err = e.uninstallWorkload(ctx, &gridtypes.WorkloadWithID{Workload: &wl, ID: globalID},
+		fmt.Sprintf("workload decommissioned by system, reason: %s", reason),
+	)
 
 	return err
 }

--- a/pkg/provision/mbus/api.go
+++ b/pkg/provision/mbus/api.go
@@ -2,6 +2,7 @@ package mbus
 
 import (
 	"context"
+	"fmt"
 
 	"github.com/threefoldtech/zos/pkg/provision"
 	"github.com/threefoldtech/zos/pkg/rmb"
@@ -51,11 +52,15 @@ func (d *Deployments) deployHandler(ctx context.Context, payload []byte) (interf
 }
 
 func (d *Deployments) deleteHandler(ctx context.Context, payload []byte) (interface{}, error) {
-	data, err := d.delete(ctx, payload)
-	if err != nil {
-		return nil, err.Err()
-	}
-	return data, nil
+	return nil, fmt.Errorf("deletion over the api is disabled, please cancel your contract instead")
+
+	// code disabled.
+
+	// data, err := d.delete(ctx, payload)
+	// if err != nil {
+	// 	return nil, err.Err()
+	// }
+	// return data, nil
 }
 
 func (d *Deployments) getHandler(ctx context.Context, payload []byte) (interface{}, error) {

--- a/pkg/provision/mbus/reservation.go
+++ b/pkg/provision/mbus/reservation.go
@@ -63,29 +63,29 @@ func (d *Deployments) createOrUpdate(ctx context.Context, payload []byte, update
 	return nil, mw.Accepted()
 }
 
-func (d *Deployments) delete(ctx context.Context, payload []byte) (interface{}, mw.Response) {
-	var args idArgs
-	err := json.Unmarshal(payload, &args)
-	if err != nil {
-		return nil, mw.Error(err)
-	}
+// func (d *Deployments) delete(ctx context.Context, payload []byte) (interface{}, mw.Response) {
+// 	var args idArgs
+// 	err := json.Unmarshal(payload, &args)
+// 	if err != nil {
+// 		return nil, mw.Error(err)
+// 	}
 
-	ctx, cancel := context.WithTimeout(ctx, 3*time.Minute)
-	defer cancel()
+// 	ctx, cancel := context.WithTimeout(ctx, 3*time.Minute)
+// 	defer cancel()
 
-	err = d.engine.Deprovision(ctx, rmb.GetTwinID(ctx), args.ContractID,
-		fmt.Sprintf("requested by twin %d over rmb api", rmb.GetTwinID(ctx)),
-	)
-	if err == context.DeadlineExceeded {
-		return nil, mw.Unavailable(ctx.Err())
-	} else if errors.Is(err, provision.ErrDeploymentNotExists) {
-		return nil, mw.NotFound(err)
-	} else if err != nil {
-		return nil, mw.Error(err)
-	}
+// 	err = d.engine.Deprovision(ctx, rmb.GetTwinID(ctx), args.ContractID,
+// 		fmt.Sprintf("requested by twin %d over rmb api", rmb.GetTwinID(ctx)),
+// 	)
+// 	if err == context.DeadlineExceeded {
+// 		return nil, mw.Unavailable(ctx.Err())
+// 	} else if errors.Is(err, provision.ErrDeploymentNotExists) {
+// 		return nil, mw.NotFound(err)
+// 	} else if err != nil {
+// 		return nil, mw.Error(err)
+// 	}
 
-	return nil, mw.Accepted()
-}
+// 	return nil, mw.Accepted()
+// }
 
 func (d *Deployments) get(ctx context.Context, payload []byte) (interface{}, mw.Response) {
 	var args idArgs

--- a/pkg/provision/mbus/reservation.go
+++ b/pkg/provision/mbus/reservation.go
@@ -73,7 +73,9 @@ func (d *Deployments) delete(ctx context.Context, payload []byte) (interface{}, 
 	ctx, cancel := context.WithTimeout(ctx, 3*time.Minute)
 	defer cancel()
 
-	err = d.engine.Deprovision(ctx, rmb.GetTwinID(ctx), args.ContractID, "requested by user")
+	err = d.engine.Deprovision(ctx, rmb.GetTwinID(ctx), args.ContractID,
+		fmt.Sprintf("requested by twin %d over rmb api", rmb.GetTwinID(ctx)),
+	)
 	if err == context.DeadlineExceeded {
 		return nil, mw.Unavailable(ctx.Err())
 	} else if errors.Is(err, provision.ErrDeploymentNotExists) {


### PR DESCRIPTION
Also we should disable the rmb api call to delete a deployment.
Deletion should be only possible with contract cancelation