### PR TITLE
Fix usage calculation to find disks candidate

### DIFF
--- a/pkg/storage/disk.go
+++ b/pkg/storage/disk.go
@@ -8,6 +8,7 @@ import (
 	"os/exec"
 	"path/filepath"
 	"strings"
+	"syscall"
 
 	"github.com/g0rbe/go-chattr"
 	"github.com/pkg/errors"
@@ -176,6 +177,8 @@ func (s *Module) DiskCreate(name string, size gridtypes.Unit) (disk pkg.VDisk, e
 			os.RemoveAll(path)
 		}
 	}()
+
+	defer syscall.Sync()
 
 	var file *os.File
 	file, err = os.Create(path)

--- a/pkg/storage/filesystem/btrfs.go
+++ b/pkg/storage/filesystem/btrfs.go
@@ -262,26 +262,6 @@ func (p *btrfsPool) Usage() (usage Usage, err error) {
 	return Usage{Size: p.device.Size, Used: used}, nil
 }
 
-// Reserved is reserved size of the devices in bytes
-func (p *btrfsPool) Reserved() (uint64, error) {
-
-	volumes, err := p.Volumes()
-	if err != nil {
-		return 0, err
-	}
-
-	var total uint64
-	for _, volume := range volumes {
-		usage, err := volume.Usage()
-		if err != nil {
-			return 0, err
-		}
-		total += usage.Size
-	}
-
-	return total, nil
-}
-
 func (p *btrfsPool) maintenance() error {
 	// this method cleans up all the unused
 	// qgroups that could exists on a filesystem

--- a/pkg/storage/filesystem/btrfs.go
+++ b/pkg/storage/filesystem/btrfs.go
@@ -243,12 +243,23 @@ func (p *btrfsPool) Usage() (usage Usage, err error) {
 		return usage, err
 	}
 
-	du, err := p.utils.GetDiskUsage(context.Background(), mnt)
+	volumes, err := p.Volumes()
+
 	if err != nil {
-		return Usage{}, err
+		return usage, errors.Wrapf(err, "failed to list pool '' volumes", mnt)
 	}
 
-	return Usage{Size: p.device.Size, Used: du.Data.Used}, nil
+	var used uint64
+	for _, volume := range volumes {
+		usage, err := volume.Usage()
+		if err != nil {
+			return Usage{}, errors.Wrapf(err, "failed to calculate volume '%s' usage", volume.Path())
+		}
+
+		used += usage.Used
+	}
+
+	return Usage{Size: p.device.Size, Used: used}, nil
 }
 
 // Reserved is reserved size of the devices in bytes
@@ -369,19 +380,20 @@ func (v *btrfsVolume) Usage() (usage Usage, err error) {
 		return
 	}
 
-	size := group.MaxRfer
-	if size == 0 {
+	// used is basically amount of space reserved for this
+	// volume. We assume that's total usage of the volume
+	used := group.MaxRfer
+
+	if used == 0 {
 		// in case no limit is set on the subvolume, we assume
 		// it's size is the size of the files on that volumes
-		size, err = FilesUsage(v.Path())
+		used, err = FilesUsage(v.Path())
 		if err != nil {
 			return usage, errors.Wrap(err, "failed to get subvolume usage")
 		}
 	}
-	// otherwise, we return the size as maxrefer and usage as the rfer of the
-	// associated group
-	// todo: size should be the size of the pool, if maxrfer is 0
-	return Usage{Used: group.Rfer, Size: size}, nil
+
+	return Usage{Used: used, Size: group.MaxRfer}, nil
 }
 
 // Limit size of volume, setting size to 0 means unlimited

--- a/pkg/storage/filesystem/btrfs.go
+++ b/pkg/storage/filesystem/btrfs.go
@@ -246,7 +246,7 @@ func (p *btrfsPool) Usage() (usage Usage, err error) {
 	volumes, err := p.Volumes()
 
 	if err != nil {
-		return usage, errors.Wrapf(err, "failed to list pool '' volumes", mnt)
+		return usage, errors.Wrapf(err, "failed to list pool '%s' volumes", mnt)
 	}
 
 	var used uint64

--- a/pkg/storage/filesystem/filesystem.go
+++ b/pkg/storage/filesystem/filesystem.go
@@ -38,8 +38,6 @@ type Pool interface {
 	Mount() (string, error)
 	// UnMount the pool
 	UnMount() error
-	// Reserved is reserved size of the devices in bytes
-	Reserved() (uint64, error)
 	// Volumes are all subvolumes of this volume
 	Volumes() ([]Volume, error)
 	// AddVolume adds a new subvolume with the given name

--- a/pkg/storage/storage.go
+++ b/pkg/storage/storage.go
@@ -715,7 +715,7 @@ func (s *Module) checkForCandidates(size gridtypes.Unit, mounted bool) ([]candid
 
 		candidates = append(candidates, candidate{
 			Pool:      pool,
-			Available: usage.Size - (usage.Size + uint64(size)),
+			Available: usage.Size*SSDOverProvisionFactor - (usage.Used + uint64(size)),
 		})
 
 		// if we are looking for not mounted pools, break here
@@ -723,7 +723,6 @@ func (s *Module) checkForCandidates(size gridtypes.Unit, mounted bool) ([]candid
 			return candidates, nil
 		}
 	}
-
 	sort.Slice(candidates, func(i, j int) bool {
 		// reverse sorting so most available is at beginning
 		return candidates[i].Available > candidates[j].Available

--- a/pkg/storage/storage_test.go
+++ b/pkg/storage/storage_test.go
@@ -44,10 +44,9 @@ func (p *testVolume) FsType() string {
 
 type testPool struct {
 	mock.Mock
-	name     string
-	usage    filesystem.Usage
-	reserved uint64
-	ptype    zos.DeviceType
+	name  string
+	usage filesystem.Usage
+	ptype zos.DeviceType
 }
 
 var _ filesystem.Pool = &testPool{}
@@ -96,10 +95,6 @@ func (p *testPool) Type() zos.DeviceType {
 	return p.ptype
 }
 
-func (p *testPool) Reserved() (uint64, error) {
-	return p.reserved, nil
-}
-
 func (p *testPool) Volumes() ([]filesystem.Volume, error) {
 	args := p.Called()
 	return args.Get(0).([]filesystem.Volume), args.Error(1)
@@ -127,18 +122,16 @@ func TestCreateSubvol(t *testing.T) {
 	require := require.New(t)
 
 	pool1 := &testPool{
-		name:     "pool-1",
-		reserved: 2000,
+		name: "pool-1",
 		usage: filesystem.Usage{
 			Size: 10000,
-			Used: 100,
+			Used: 300,
 		},
 		ptype: zos.SSDDevice,
 	}
 
 	pool2 := &testPool{
-		name:     "pool-2",
-		reserved: 1000,
+		name: "pool-2",
 		usage: filesystem.Usage{
 			Size: 10000,
 			Used: 100,
@@ -171,18 +164,16 @@ func TestCreateSubvolUnlimited(t *testing.T) {
 	require := require.New(t)
 
 	pool1 := &testPool{
-		name:     "pool-1",
-		reserved: 2000,
+		name: "pool-1",
 		usage: filesystem.Usage{
 			Size: 10000,
-			Used: 100,
+			Used: 200,
 		},
 		ptype: zos.SSDDevice,
 	}
 
 	pool2 := &testPool{
-		name:     "pool-2",
-		reserved: 1000,
+		name: "pool-2",
 		usage: filesystem.Usage{
 			Size: 10000,
 			Used: 100,
@@ -191,8 +182,7 @@ func TestCreateSubvolUnlimited(t *testing.T) {
 	}
 
 	pool3 := &testPool{
-		name:     "pool-3",
-		reserved: 0,
+		name: "pool-3",
 		usage: filesystem.Usage{
 			Size: 100000,
 			Used: 0,
@@ -229,8 +219,7 @@ func TestCreateSubvolNoSpaceLeft(t *testing.T) {
 	require := require.New(t)
 
 	pool1 := &testPool{
-		name:     "pool-1",
-		reserved: 2000,
+		name: "pool-1",
 		usage: filesystem.Usage{
 			Size: 10000,
 			Used: 100,
@@ -239,8 +228,7 @@ func TestCreateSubvolNoSpaceLeft(t *testing.T) {
 	}
 
 	pool2 := &testPool{
-		name:     "pool-2",
-		reserved: 1000,
+		name: "pool-2",
 		usage: filesystem.Usage{
 			Size: 10000,
 			Used: 100,
@@ -249,8 +237,7 @@ func TestCreateSubvolNoSpaceLeft(t *testing.T) {
 	}
 
 	pool3 := &testPool{
-		name:     "pool-3",
-		reserved: 0,
+		name: "pool-3",
 		usage: filesystem.Usage{
 			Size: 100000,
 			Used: 0,
@@ -279,8 +266,7 @@ func TestVDiskFindCandidatesHasEnoughSpace(t *testing.T) {
 	require := require.New(t)
 
 	pool1 := &testPool{
-		name:     "pool-1",
-		reserved: 2000,
+		name: "pool-1",
 		usage: filesystem.Usage{
 			Size: 10000,
 			Used: 100,
@@ -289,8 +275,7 @@ func TestVDiskFindCandidatesHasEnoughSpace(t *testing.T) {
 	}
 
 	pool2 := &testPool{
-		name:     "pool-2",
-		reserved: 1000,
+		name: "pool-2",
 		usage: filesystem.Usage{
 			Size: 10000,
 			Used: 100,
@@ -299,8 +284,7 @@ func TestVDiskFindCandidatesHasEnoughSpace(t *testing.T) {
 	}
 
 	pool3 := &testPool{
-		name:     "pool-3",
-		reserved: 0,
+		name: "pool-3",
 		usage: filesystem.Usage{
 			Size: 100000,
 			Used: 0,
@@ -334,8 +318,7 @@ func TestVDiskFindCandidatesNoSpace(t *testing.T) {
 	require := require.New(t)
 
 	pool1 := &testPool{
-		name:     "pool-1",
-		reserved: 2000,
+		name: "pool-1",
 		usage: filesystem.Usage{
 			Size: 5000,
 			Used: 100,
@@ -344,8 +327,7 @@ func TestVDiskFindCandidatesNoSpace(t *testing.T) {
 	}
 
 	pool2 := &testPool{
-		name:     "pool-2",
-		reserved: 1000,
+		name: "pool-2",
 		usage: filesystem.Usage{
 			Size: 5000,
 			Used: 100,
@@ -354,8 +336,7 @@ func TestVDiskFindCandidatesNoSpace(t *testing.T) {
 	}
 
 	pool3 := &testPool{
-		name:     "pool-3",
-		reserved: 0,
+		name: "pool-3",
 		usage: filesystem.Usage{
 			Size: 100000,
 			Used: 0,
@@ -391,8 +372,7 @@ func TestVDiskFindCandidatesOverProvision(t *testing.T) {
 	require := require.New(t)
 
 	pool1 := &testPool{
-		name:     "pool-1",
-		reserved: 2000,
+		name: "pool-1",
 		usage: filesystem.Usage{
 			Size: 5000,
 			Used: 100,


### PR DESCRIPTION
After switching vdisks allocations from fallocate to truncate. to suport
ssd over-provisioning. we needed to change and fix how we calculate
used space on a disk as follows

- subvolume with quota limit is assumed to be full usage of the
  subvolume
- subvolume with no-quota limit, we sum total size of all files in that
  subvolume

to find if disk has enough space for allocation, we calculate it as
 used + (requested) < ssd.size * 2

Fixes #1693