### PR TITLE
Unset public config

### DIFF
--- a/cmds/modules/networkd/main.go
+++ b/cmds/modules/networkd/main.go
@@ -87,7 +87,7 @@ func action(cli *cli.Context) error {
 	public.SetPersistence(root)
 
 	pub, err := public.LoadPublicConfig()
-	log.Debug().Err(err).Msgf("public interface configred: %+v", pub)
+	log.Debug().Err(err).Msgf("public interface configured: %+v", pub)
 	if err != nil && err != public.ErrNoPublicConfig {
 		return errors.Wrap(err, "failed to get node public_config")
 	}

--- a/cmds/modules/noded/public.go
+++ b/cmds/modules/noded/public.go
@@ -52,6 +52,12 @@ func public(ctx context.Context, nodeID uint32, env environment.Environment, cl 
 		return sub.GetNode(nodeID)
 	}
 
+	// this to check if the config actually is holding any values
+	// because chain right now doesn't support setting back to None
+	isEmpty := func(cfg *substrate.PublicConfig) bool {
+		return cfg.IPv4 == "" && cfg.IPv6 == ""
+	}
+
 reapply:
 	for {
 		node, err := getNode()
@@ -60,9 +66,8 @@ reapply:
 		}
 
 		var cfg *substrate.PublicConfig
-		if node.PublicConfig.HasValue {
+		if node.PublicConfig.HasValue && !isEmpty(&node.PublicConfig.AsValue) {
 			cfg = &node.PublicConfig.AsValue
-
 		}
 
 		if err := setPublicConfig(ctx, cl, cfg); err != nil {
@@ -81,7 +86,7 @@ reapply:
 
 				log.Info().Msgf("got a public config update: %+v", event.PublicConfig)
 				var cfg *substrate.PublicConfig
-				if !event.IsEmpty() {
+				if !isEmpty(&event.PublicConfig) {
 					cfg = &event.PublicConfig
 				}
 				if err := setPublicConfig(ctx, cl, cfg); err != nil {

--- a/cmds/modules/noded/public.go
+++ b/cmds/modules/noded/public.go
@@ -17,7 +17,11 @@ func setPublicConfig(ctx context.Context, cl zbus.Client, cfg *substrate.PublicC
 	log.Info().Msg("setting node public config")
 	netMgr := stubs.NewNetworkerStub(cl)
 
-	pub, err := pkg.PublicConfigFrom(cfg)
+	if cfg == nil {
+		return netMgr.UnsetPublicConfig(ctx)
+	}
+
+	pub, err := pkg.PublicConfigFrom(*cfg)
 	if err != nil {
 		return errors.Wrap(err, "failed to create public config from setup")
 	}
@@ -62,7 +66,7 @@ reapply:
 		}
 
 		if err := setPublicConfig(ctx, cl, cfg); err != nil {
-			return errors.Wrap(err, "failed to ")
+			return errors.Wrap(err, "failed to set public config (reapply)")
 		}
 
 		for {

--- a/pkg/events.go
+++ b/pkg/events.go
@@ -30,6 +30,12 @@ type PublicConfigEvent struct {
 	PublicConfig substrate.PublicConfig
 }
 
+func (e *PublicConfigEvent) IsEmpty() bool {
+	// checks the values of the public config
+	pc := &e.PublicConfig
+	return pc.IPv4 == "" && pc.IPv6 == ""
+}
+
 // ContractCancelledEvent a contract has been cancelled, The type specify if this is just notification
 // of the reconnection, or actual event has been received.
 type ContractCancelledEvent struct {

--- a/pkg/events.go
+++ b/pkg/events.go
@@ -30,12 +30,6 @@ type PublicConfigEvent struct {
 	PublicConfig substrate.PublicConfig
 }
 
-func (e *PublicConfigEvent) IsEmpty() bool {
-	// checks the values of the public config
-	pc := &e.PublicConfig
-	return pc.IPv4 == "" && pc.IPv6 == ""
-}
-
 // ContractCancelledEvent a contract has been cancelled, The type specify if this is just notification
 // of the reconnection, or actual event has been received.
 type ContractCancelledEvent struct {

--- a/pkg/network.go
+++ b/pkg/network.go
@@ -190,6 +190,8 @@ type Networker interface {
 
 	// Set node public namespace config.
 	SetPublicConfig(cfg PublicConfig) error
+
+	// UnsetPublicConfig removes public config from node
 	UnsetPublicConfig() error
 
 	// Get node public namespace config
@@ -254,16 +256,10 @@ type PublicConfig struct {
 }
 
 func (p *PublicConfig) IsEmpty() bool {
-	return p.IPv4.Nil() || p.IPv6.Nil()
+	return p.IPv4.Nil() && p.IPv6.Nil()
 }
 
-func PublicConfigFrom(cfg *substrate.PublicConfig) (pub *PublicConfig, err error) {
-	// nil config is valid config to do unset
-	if cfg == nil {
-		return nil, nil
-	}
-
-	pub = new(PublicConfig)
+func PublicConfigFrom(cfg substrate.PublicConfig) (pub PublicConfig, err error) {
 	pub.Type = MacVlanIface
 	pub.IPv4, err = gridtypes.ParseIPNet(cfg.IPv4)
 	if err != nil {

--- a/pkg/network.go
+++ b/pkg/network.go
@@ -188,8 +188,9 @@ type Networker interface {
 
 	// Public Config
 
-	// Set node public namespace config
+	// Set node public namespace config.
 	SetPublicConfig(cfg PublicConfig) error
+	UnsetPublicConfig() error
 
 	// Get node public namespace config
 	GetPublicConfig() (PublicConfig, error)
@@ -252,7 +253,17 @@ type PublicConfig struct {
 	Domain string `json:"domain"`
 }
 
-func PublicConfigFrom(cfg substrate.PublicConfig) (pub PublicConfig, err error) {
+func (p *PublicConfig) IsEmpty() bool {
+	return p.IPv4.Nil() || p.IPv6.Nil()
+}
+
+func PublicConfigFrom(cfg *substrate.PublicConfig) (pub *PublicConfig, err error) {
+	// nil config is valid config to do unset
+	if cfg == nil {
+		return nil, nil
+	}
+
+	pub = new(PublicConfig)
 	pub.Type = MacVlanIface
 	pub.IPv4, err = gridtypes.ParseIPNet(cfg.IPv4)
 	if err != nil {

--- a/pkg/network/namespace/namespace.go
+++ b/pkg/network/namespace/namespace.go
@@ -188,7 +188,13 @@ func Exists(name string) bool {
 // GetByName return a namespace by its name
 func GetByName(name string) (ns.NetNS, error) {
 	nsPath := filepath.Join(netNSPath, name)
-	return ns.GetNS(nsPath)
+	n, err := ns.GetNS(nsPath)
+	var ne ns.NSPathNotExistErr
+	if errors.As(err, &ne) {
+		return nil, os.ErrNotExist
+	}
+
+	return n, err
 }
 
 // List returns a list of all the names of the network namespaces

--- a/pkg/network/namespace/namespace_test.go
+++ b/pkg/network/namespace/namespace_test.go
@@ -35,6 +35,11 @@ func TestCreateNetNS(t *testing.T) {
 	assert.False(t, strings.Contains(string(out), name))
 }
 
+func TestGetNotExist(t *testing.T) {
+	_, err := GetByName("notexist")
+	assert.True(t, os.IsNotExist(err))
+}
+
 func TestNamespaceIsolation(t *testing.T) {
 	ifaces, err := netlink.LinkList()
 	require.NoError(t, err)

--- a/pkg/network/networker.go
+++ b/pkg/network/networker.go
@@ -894,6 +894,10 @@ func (n *networker) Namespace(id zos.NetID) string {
 	return fmt.Sprintf("n-%s", id)
 }
 
+func (n *networker) UnsetPublicConfig() error {
+	panic("unimplemented")
+}
+
 // Set node public namespace config
 func (n *networker) SetPublicConfig(cfg pkg.PublicConfig) error {
 	if cfg.Equal(pkg.PublicConfig{}) {

--- a/pkg/network/networker.go
+++ b/pkg/network/networker.go
@@ -895,7 +895,9 @@ func (n *networker) Namespace(id zos.NetID) string {
 }
 
 func (n *networker) UnsetPublicConfig() error {
-	panic("unimplemented")
+	id := n.identity.NodeID(context.Background())
+	_, err := public.EnsurePublicSetup(id, nil)
+	return err
 }
 
 // Set node public namespace config

--- a/pkg/network/public/persist.go
+++ b/pkg/network/public/persist.go
@@ -59,6 +59,10 @@ func LoadPublicConfig() (*pkg.PublicConfig, error) {
 	return &cfg, nil
 }
 
+func DeletePublicConfig() error {
+	return os.RemoveAll(getPersistencePath(publicConfigFile))
+}
+
 // SavePublicConfig stores public config in a file
 func SavePublicConfig(cfg pkg.PublicConfig) error {
 	file, err := os.Create(getPersistencePath(publicConfigFile))

--- a/pkg/network/public/public.go
+++ b/pkg/network/public/public.go
@@ -355,7 +355,7 @@ func EnsurePublicSetup(nodeID pkg.Identifier, inf *pkg.PublicConfig) (*netlink.B
 		// we need to check if there is already a public config
 		// if yes! we need to make sure to delete it and also restart
 		// the node because that's the only way to properly unset public config
-		DeletePublicConfig()
+		_ = DeletePublicConfig()
 		if HasPublicSetup() {
 			// full node reboot is needed unfortunately
 			// to many things depends on the public namespace

--- a/pkg/stubs/network_stub.go
+++ b/pkg/stubs/network_stub.go
@@ -2,11 +2,10 @@ package stubs
 
 import (
 	"context"
-	"net"
-
 	zbus "github.com/threefoldtech/zbus"
 	pkg "github.com/threefoldtech/zos/pkg"
 	zos "github.com/threefoldtech/zos/pkg/gridtypes/zos"
+	"net"
 )
 
 type NetworkerStub struct {
@@ -467,7 +466,7 @@ func (s *NetworkerStub) RemoveTap(ctx context.Context, arg0 string) (ret0 error)
 	return
 }
 
-func (s *NetworkerStub) SetPublicConfig(ctx context.Context, arg0 interface{}) (ret0 error) {
+func (s *NetworkerStub) SetPublicConfig(ctx context.Context, arg0 pkg.PublicConfig) (ret0 error) {
 	args := []interface{}{arg0}
 	result, err := s.client.RequestContext(ctx, s.module, s.object, "SetPublicConfig", args...)
 	if err != nil {
@@ -574,6 +573,21 @@ func (s *NetworkerStub) TapExists(ctx context.Context, arg0 string) (ret0 bool, 
 	loader := zbus.Loader{
 		&ret0,
 	}
+	if err := result.Unmarshal(&loader); err != nil {
+		panic(err)
+	}
+	return
+}
+
+func (s *NetworkerStub) UnsetPublicConfig(ctx context.Context) (ret0 error) {
+	args := []interface{}{}
+	result, err := s.client.RequestContext(ctx, s.module, s.object, "UnsetPublicConfig", args...)
+	if err != nil {
+		panic(err)
+	}
+	result.PanicOnError()
+	ret0 = result.CallError()
+	loader := zbus.Loader{}
 	if err := result.Unmarshal(&loader); err != nil {
 		panic(err)
 	}

--- a/pkg/stubs/network_stub.go
+++ b/pkg/stubs/network_stub.go
@@ -2,10 +2,11 @@ package stubs
 
 import (
 	"context"
+	"net"
+
 	zbus "github.com/threefoldtech/zbus"
 	pkg "github.com/threefoldtech/zos/pkg"
 	zos "github.com/threefoldtech/zos/pkg/gridtypes/zos"
-	"net"
 )
 
 type NetworkerStub struct {
@@ -466,7 +467,7 @@ func (s *NetworkerStub) RemoveTap(ctx context.Context, arg0 string) (ret0 error)
 	return
 }
 
-func (s *NetworkerStub) SetPublicConfig(ctx context.Context, arg0 pkg.PublicConfig) (ret0 error) {
+func (s *NetworkerStub) SetPublicConfig(ctx context.Context, arg0 interface{}) (ret0 error) {
 	args := []interface{}{arg0}
 	result, err := s.client.RequestContext(ctx, s.module, s.object, "SetPublicConfig", args...)
 	if err != nil {

--- a/pkg/zinit/commands.go
+++ b/pkg/zinit/commands.go
@@ -150,6 +150,10 @@ func (c *Client) Status(service string) (result ServiceStatus, err error) {
 	return
 }
 
+func (c *Client) Reboot() error {
+	return c.cmd("shutdown", nil)
+}
+
 // Exists checks whether a service is monitored or not
 func (c *Client) Exists(service string) (bool, error) {
 	var status ServiceStatus


### PR DESCRIPTION
This handles when  a farmer sets public config to empty values. A proper implementation on the chain is needed to actually unset the public config (set it to None), which is not possible at the moment. Hence we instead handle (also) when the values are unset (empty strings) for ipv4 and ipv6.

When Unsetting the public namespace. the system can not recover cleanly because there are many different parts that rely on the public namespace. (yggrasil, traefik gateway, and users networks). Some of them (like wireguard ports) can't be moved to host namespace hence a full reboot of the node is needed.

for that specific reason the unsetting of public config was not supported but seems it's a use case that we need to handle

Related to #1767 