### PR TITLE
Only add ipv6 gw if public ipv6 is required

### DIFF
--- a/pkg/gridtypes/zos/ipv4.go
+++ b/pkg/gridtypes/zos/ipv4.go
@@ -82,3 +82,11 @@ type PublicIPResult struct {
 	// also provide
 	Gateway net.IP `json:"gateway"`
 }
+
+func (p *PublicIPResult) HasIPv4() bool {
+	return p.IP.IP.To4() != nil
+}
+
+func (p *PublicIPResult) HasIPv6() bool {
+	return p.IPv6.IP.To16() != nil
+}

--- a/pkg/primitives/vm/utils.go
+++ b/pkg/primitives/vm/utils.go
@@ -51,7 +51,8 @@ func (p *Manager) newYggNetworkInterface(ctx context.Context, wl *gridtypes.Work
 				Gateway: iface.Gateway.IP,
 			},
 		},
-		Public: false,
+		PublicIPv4: false,
+		PublicIPv6: false,
 	}
 
 	return out, nil
@@ -112,7 +113,8 @@ func (p *Manager) newPrivNetworkInterface(ctx context.Context, dl gridtypes.Depl
 		},
 		IP4DefaultGateway: net.IP(gw4),
 		IP6DefaultGateway: gw6,
-		Public:            false,
+		PublicIPv4:        false,
+		PublicIPv6:        false,
 	}
 
 	return out, nil
@@ -156,13 +158,15 @@ func (p *Manager) newPubNetworkInterface(ctx context.Context, deployment gridtyp
 		}
 		gw = config.Gateway
 	}
+
 	return pkg.VMIface{
 		Tap:               pubIface,
 		MAC:               mac.String(), // mac so we always get the same IPv6 from slaac
 		IPs:               ips,
 		IP4DefaultGateway: gw,
 		// for now we get ipv6 from slaac, so leave ipv6 stuffs this empty
-		Public: true,
+		PublicIPv4: config.HasIPv4(),
+		PublicIPv6: config.HasIPv6(),
 	}, nil
 }
 

--- a/pkg/vm.go
+++ b/pkg/vm.go
@@ -33,8 +33,10 @@ type VMIface struct {
 	IP4DefaultGateway net.IP
 	// IP6DefaultGateway address for ipv6
 	IP6DefaultGateway net.IP
-	// Private or public network
-	Public bool
+	// PublicIPv4 holds a public IPv4
+	PublicIPv4 bool
+	// PublicIPv4 holds a public Ipv6
+	PublicIPv6 bool
 }
 
 // VMNetworkInfo structure

--- a/pkg/vm/manager.go
+++ b/pkg/vm/manager.go
@@ -162,9 +162,11 @@ func (m *Module) makeNetwork(vm *pkg.VM, cfg *cloudinit.Configuration) ([]Interf
 	v4Routes := make(map[string]string)
 	v6Routes := make(map[string]string)
 
-	hasPub := false
+	hasPubIpv4 := false
+	hasPubIpv6 := false
 	for _, ifcfg := range vm.Network.Ifaces {
-		hasPub = ifcfg.Public || hasPub
+		hasPubIpv4 = ifcfg.PublicIPv4 || hasPubIpv4
+		hasPubIpv6 = ifcfg.PublicIPv6 || hasPubIpv6
 	}
 
 	nics := make([]Interface, 0, len(vm.Network.Ifaces))
@@ -186,11 +188,17 @@ func (m *Module) makeNetwork(vm *pkg.VM, cfg *cloudinit.Configuration) ([]Interf
 			cinet.Addresses = append(cinet.Addresses, ip.String())
 		}
 
-		if ifcfg.Public == hasPub {
+		// this to force usage of gateways only from public
+		// interface. so if hasPub is true, use gateways only
+		// from the public interface. but if hasPub is false
+		// we use gateways for each interface.
+		if ifcfg.PublicIPv4 == hasPubIpv4 {
 			if ifcfg.IP4DefaultGateway != nil {
 				cinet.Gateway4 = ifcfg.IP4DefaultGateway.String()
 			}
+		}
 
+		if ifcfg.PublicIPv6 == hasPubIpv6 {
 			if ifcfg.IP6DefaultGateway != nil {
 				cinet.Gateway6 = ifcfg.IP6DefaultGateway.String()
 			}


### PR DESCRIPTION
- Ipv6 are assigned via slaac
- The vmd has noway then to know if a public ipv6 is assigned to the VM or not. Hence there is noway to know if a default gw6 is to be used or not
- The fix basically checks the result of the public ip workloads hence it can tell if
  - we have publicipv4
  - we have pubblicipv6

Hence the vmd can then choose what gateways to use for which ip class.
- If there is a public ipv4 assigned, then use the gw from the interface that holds the public ipv4 otherwise, use the gw from the private interface
- for ipv6 it's basically the same hence there will be no default gw6 (if public ipv6) is configured. Hence the vm will get gw6 from slaac. 
