### PR TITLE
using tpm to store node identity seed

### DIFF
--- a/cmds/identityd/main.go
+++ b/cmds/identityd/main.go
@@ -6,7 +6,6 @@ import (
 	"math/rand"
 	"os"
 	"os/signal"
-	"path/filepath"
 	"syscall"
 	"time"
 
@@ -33,8 +32,7 @@ const (
 )
 
 const (
-	module   = "identityd"
-	seedName = "seed.txt"
+	module = "identityd"
 )
 
 // Safe makes sure function call not interrupted
@@ -307,9 +305,8 @@ func upgradeLoop(
 }
 
 func getIdentityMgr(root string) (pkg.IdentityManager, error) {
-	seedPath := filepath.Join(root, seedName)
 
-	manager, err := identity.NewManager(seedPath)
+	manager, err := identity.NewManager(root)
 	if err != nil {
 		return nil, err
 	}

--- a/go.sum
+++ b/go.sum
@@ -341,6 +341,7 @@ github.com/d2g/dhcp4client v1.0.0/go.mod h1:j0hNfjhrt2SxUOw55nL0ATM/z4Yt3t2Kd1mW
 github.com/d2g/dhcp4server v0.0.0-20181031114812-7d4a0a7f59a5/go.mod h1:Eo87+Kg/IX2hfWJfwxMzLyuSZyxSoAug2nGa1G2QAi8=
 github.com/d2g/hardwareaddr v0.0.0-20190221164911-e7d9fbe030e4/go.mod h1:bMl4RjIciD2oAxI7DmWRx6gbeqrkoLqv3MV0vzNad+I=
 github.com/dave/jennifer v1.2.0/go.mod h1:fIb+770HOpJ2fmN9EPPKOqm1vMGhB+TwXKMZhrIygKg=
+github.com/dave/jennifer v1.3.0 h1:p3tl41zjjCZTNBytMwrUuiAnherNUZktlhPTKoF/sEk=
 github.com/dave/jennifer v1.3.0/go.mod h1:fIb+770HOpJ2fmN9EPPKOqm1vMGhB+TwXKMZhrIygKg=
 github.com/davecgh/go-spew v0.0.0-20171005155431-ecdeabc65495/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=

--- a/pkg/identity.go
+++ b/pkg/identity.go
@@ -20,6 +20,9 @@ func (s StrIdentifier) Identity() string {
 
 // IdentityManager interface.
 type IdentityManager interface {
+	// Store returns the key store kind
+	StoreKind() string
+
 	// NodeID returns the node id (public key)
 	NodeID() StrIdentifier
 

--- a/pkg/identity/builder.go
+++ b/pkg/identity/builder.go
@@ -37,6 +37,13 @@ func NewStore(root string) (store.Store, error) {
 		return tpm, nil
 	}
 
+	if ok, err := tpm.Exists(); err == nil && ok {
+		// so there is a key on disk, but tpm already has a stored key
+		// then we still just return no need for migration to avoid
+		// overriding the key in tpm
+		return tpm, nil
+	}
+
 	// if we failed to get the key from store
 	// may be better generate a new one?
 	// todo: need discussion

--- a/pkg/identity/builder.go
+++ b/pkg/identity/builder.go
@@ -1,0 +1,62 @@
+package identity
+
+import (
+	"fmt"
+	"path/filepath"
+
+	"github.com/rs/zerolog/log"
+	"github.com/threefoldtech/zos/pkg/identity/store"
+)
+
+const (
+	seedName = "seed.txt"
+)
+
+// NewStore tries to build the best key store available
+// for this ndoe.
+// On a machine with no tpm support, that would be a file
+// store.
+// If TPM is supported, TPM will be used.
+// There is a special case if tpm is supported, but a file seed
+// exits, this file key will be migrated to the TPM store then
+// deleted.
+func NewStore(root string) (store.Store, error) {
+	file := store.NewFileStore(filepath.Join(root, seedName))
+	if !store.IsTPMEnabled() {
+		return file, nil
+	}
+
+	// tpm is supported, but do we have a key
+	tpm := store.NewTPM()
+	exists, err := file.Exists()
+	if err != nil {
+		return nil, fmt.Errorf("failed to check for seed file: %s", err)
+	}
+
+	if !exists {
+		return tpm, nil
+	}
+
+	// if we failed to get the key from store
+	// may be better generate a new one?
+	// todo: need discussion
+
+	key, err := file.Get()
+	if err != nil {
+		return nil, fmt.Errorf("failed to load key from file: %w", err)
+	}
+
+	// migration of key
+	if err := tpm.Set(key); err != nil {
+		// we failed to do migration but we have a valid key.
+		// we shouldn't then fail instead use the file store
+		log.Error().Err(err).Msg("failed to migrate key to tpm store")
+		return file, nil
+	}
+
+	if err := file.Annihilate(); err != nil {
+		log.Error().Err(err).Msg("failed to clear up key file")
+	}
+
+	return tpm, nil
+}

--- a/pkg/identity/builder.go
+++ b/pkg/identity/builder.go
@@ -19,8 +19,8 @@ const (
 // If TPM is supported, TPM will be used.
 // There is a special case if tpm is supported, but a file seed
 // exits, this file key will be migrated to the TPM store then
-// deleted.
-func NewStore(root string) (store.Store, error) {
+// deleted (only if delete is set to true)
+func NewStore(root string, delete bool) (store.Store, error) {
 	file := store.NewFileStore(filepath.Join(root, seedName))
 	if !store.IsTPMEnabled() {
 		return file, nil
@@ -61,8 +61,10 @@ func NewStore(root string) (store.Store, error) {
 		return file, nil
 	}
 
-	if err := file.Annihilate(); err != nil {
-		log.Error().Err(err).Msg("failed to clear up key file")
+	if delete {
+		if err := file.Annihilate(); err != nil {
+			log.Error().Err(err).Msg("failed to clear up key file")
+		}
 	}
 
 	return tpm, nil

--- a/pkg/identity/identityd.go
+++ b/pkg/identity/identityd.go
@@ -25,8 +25,12 @@ type identityManager struct {
 // NewManager creates an identity daemon from seed
 // The daemon will auto generate a new seed if the path does
 // not exist
-func NewManager(path string) (pkg.IdentityManager, error) {
-	st := store.NewFileStore(path)
+func NewManager(root string) (pkg.IdentityManager, error) {
+	st, err := NewStore(root)
+	if err != nil {
+		return nil, errors.Wrap(err, "failed to create key store")
+	}
+	log.Info().Str("kind", st.Kind()).Msg("key store loaded")
 	key, err := st.Get()
 	var pair KeyPair
 	if errors.Is(err, store.ErrKeyDoesNotExist) {

--- a/pkg/identity/identityd.go
+++ b/pkg/identity/identityd.go
@@ -14,9 +14,10 @@ import (
 )
 
 type identityManager struct {
-	key KeyPair
-	sub substrate.Manager
-	env environment.Environment
+	kind string
+	key  KeyPair
+	sub  substrate.Manager
+	env  environment.Environment
 
 	farm string
 	node uint32
@@ -25,8 +26,12 @@ type identityManager struct {
 // NewManager creates an identity daemon from seed
 // The daemon will auto generate a new seed if the path does
 // not exist
-func NewManager(root string) (pkg.IdentityManager, error) {
-	st, err := NewStore(root)
+// debug flag is used to change the behavior slightly when zos is running in debug
+// mode. Right now only the key store uses this flag. In case of debug migrated keys
+// to tpm are not deleted from disks. This allow switching back and forth between tpm
+// and non-tpm key stores.
+func NewManager(root string, debug bool) (pkg.IdentityManager, error) {
+	st, err := NewStore(root, !debug)
 	if err != nil {
 		return nil, errors.Wrap(err, "failed to create key store")
 	}
@@ -61,10 +66,16 @@ func NewManager(root string) (pkg.IdentityManager, error) {
 	}
 
 	return &identityManager{
-		key: pair,
-		sub: sub,
-		env: env,
+		kind: st.Kind(),
+		key:  pair,
+		sub:  sub,
+		env:  env,
 	}, nil
+}
+
+// StoreKind returns store kind
+func (d *identityManager) StoreKind() string {
+	return d.kind
 }
 
 // NodeID returns the node identity

--- a/pkg/identity/keys.go
+++ b/pkg/identity/keys.go
@@ -1,12 +1,8 @@
 package identity
 
 import (
-	"encoding/json"
-	"fmt"
-
 	"github.com/jbenet/go-base58"
 	"github.com/threefoldtech/zos/pkg/versioned"
-	"github.com/tyler-smith/go-bip39"
 
 	"golang.org/x/crypto/ed25519"
 )
@@ -30,6 +26,13 @@ type KeyPair struct {
 	PublicKey  ed25519.PublicKey
 }
 
+func KeyPairFromKey(sk ed25519.PrivateKey) KeyPair {
+	return KeyPair{
+		PrivateKey: sk,
+		PublicKey:  sk.Public().(ed25519.PublicKey),
+	}
+}
+
 // Identity implements the Identifier interface
 func (k KeyPair) Identity() string {
 	return base58.Encode(k.PublicKey)
@@ -41,6 +44,7 @@ func GenerateKeyPair() (k KeyPair, err error) {
 	if err != nil {
 		return k, err
 	}
+
 	k = KeyPair{
 		PrivateKey: privateKey,
 		PublicKey:  publicKey,
@@ -53,73 +57,4 @@ func (k *KeyPair) Save(path string) error {
 	seed := k.PrivateKey.Seed()
 
 	return versioned.WriteFile(path, SeedVersion1, seed, 0400)
-}
-
-// LoadSeed from path
-func LoadSeed(path string) ([]byte, error) {
-	version, seed, err := versioned.ReadFile(path)
-	if versioned.IsNotVersioned(err) {
-		// this is a compatibility code for seed files
-		// in case it does not have any version information
-		if err := versioned.WriteFile(path, SeedVersionLatest, seed, 0400); err != nil {
-			return nil, err
-		}
-		version = SeedVersion1
-	} else if err != nil {
-		return nil, err
-	}
-
-	if version.NE(SeedVersion1) && version.NE(SeedVersion11) {
-		return nil, fmt.Errorf("unknown seed version")
-	}
-
-	if version.EQ(SeedVersion1) {
-		return seed, nil
-	}
-	// it means we read json data instead of the secret
-	type Seed110Struct struct {
-		Mnemonics string `json:"mnemonic"`
-	}
-	var seed110 Seed110Struct
-	if err = json.Unmarshal(seed, &seed110); err != nil {
-		return nil, err
-	}
-	return bip39.EntropyFromMnemonic(seed110.Mnemonics)
-}
-
-// LoadKeyPair reads a seed from a file located at path and re-create a
-// KeyPair using the seed
-func LoadKeyPair(path string) (k KeyPair, err error) {
-	return loadKeyPair(path)
-}
-
-// LoadLegacyKeyPair load keypair without deprecated message for converted
-func LoadLegacyKeyPair(path string) (k KeyPair, err error) {
-	return loadKeyPair(path)
-}
-
-func loadKeyPair(path string) (k KeyPair, err error) {
-	seed, err := LoadSeed(path)
-	if err != nil {
-		return k, err
-	}
-
-	return FromSeed(seed)
-}
-
-// FromSeed creates a new key pair from seed
-func FromSeed(seed []byte) (pair KeyPair, err error) {
-	if len(seed) != ed25519.SeedSize {
-		return pair, fmt.Errorf("seed has the wrong size %d and should be %d", len(seed), ed25519.SeedSize)
-	}
-
-	privateKey := ed25519.NewKeyFromSeed(seed)
-	publicKey := make([]byte, ed25519.PublicKeySize)
-	copy(publicKey, privateKey[32:])
-	pair = KeyPair{
-		PrivateKey: privateKey,
-		PublicKey:  publicKey,
-	}
-
-	return pair, nil
 }

--- a/pkg/identity/keys_test.go
+++ b/pkg/identity/keys_test.go
@@ -1,12 +1,8 @@
 package identity
 
 import (
-	"io/ioutil"
 	"net/url"
-	"os"
 	"testing"
-
-	"encoding/base64"
 
 	"golang.org/x/crypto/ed25519"
 
@@ -21,27 +17,6 @@ func TestGenerateKey(t *testing.T) {
 	assert.NotNil(t, keypair.PublicKey)
 }
 
-func TestSerialize(t *testing.T) {
-	keypair, err := GenerateKeyPair()
-	require.NoError(t, err)
-
-	f, err := ioutil.TempFile("", "")
-	require.NoError(t, err)
-	defer func() {
-		_ = f.Close()
-		_ = os.Remove(f.Name())
-	}()
-
-	err = keypair.Save(f.Name())
-	require.NoError(t, err)
-
-	keypair2, err := LoadKeyPair(f.Name())
-	require.NoError(t, err)
-
-	assert.Equal(t, keypair.PrivateKey, keypair2.PrivateKey)
-	assert.Equal(t, keypair.PublicKey, keypair2.PublicKey)
-}
-
 func TestIdentity(t *testing.T) {
 	sk := ed25519.NewKeyFromSeed([]byte("helloworldhelloworldhelloworld12"))
 	keypair := KeyPair{
@@ -51,40 +26,4 @@ func TestIdentity(t *testing.T) {
 	id := keypair.Identity()
 	assert.Equal(t, "FkUfMueBVSK6V1DCHVAtzzaqPqCPVzGguDzCQxq7Ep85", id)
 	assert.Equal(t, "FkUfMueBVSK6V1DCHVAtzzaqPqCPVzGguDzCQxq7Ep85", url.PathEscape(id), "identity should be url friendly")
-}
-
-func TestLoadSeed110(t *testing.T) {
-	seedfilecontent := `"1.1.0"{"mnemonic":"crop orient animal script safe inquiry neglect tumble maple board degree you intact busy birth west crack cabin lizard embark seed adjust around talk"}`
-	f, err := ioutil.TempFile("", "")
-	require.NoError(t, err)
-	defer func() {
-		_ = f.Close()
-		_ = os.Remove(f.Name())
-	}()
-	_, err = f.WriteString(seedfilecontent)
-	require.NoError(t, err)
-	s, err := LoadSeed(f.Name())
-	require.NoError(t, err)
-	assert.Equal(t, len(s), ed25519.SeedSize)
-
-}
-
-func TestLoadSeed100(t *testing.T) {
-
-	seedfilebase64 := `IjEuMC4wIkiwBpAxl8Xpc4fgQ4Wq3Is5ssEkObXDJANf7KoOw153` // matches `"1.0.0"H°1ÅésàCªÜ9²Á$9µÃ$_ìªÃ^w`
-	seedfilebytes, err := base64.StdEncoding.DecodeString(seedfilebase64)
-	require.NoError(t, err)
-
-	f, err := ioutil.TempFile("", "")
-	require.NoError(t, err)
-	defer func() {
-		_ = f.Close()
-		_ = os.Remove(f.Name())
-	}()
-	_, err = f.Write(seedfilebytes)
-	require.NoError(t, err)
-	s, err := LoadSeed(f.Name())
-	require.NoError(t, err)
-	assert.Equal(t, len(s), ed25519.SeedSize)
-
 }

--- a/pkg/identity/store/file.go
+++ b/pkg/identity/store/file.go
@@ -29,8 +29,12 @@ type FileStore struct {
 
 var _ Store = (*FileStore)(nil)
 
-func NewFileStore(path string) FileStore {
-	return FileStore{path}
+func NewFileStore(path string) *FileStore {
+	return &FileStore{path}
+}
+
+func (f *FileStore) Kind() string {
+	return "file-store"
 }
 
 func (f *FileStore) Set(key ed25519.PrivateKey) error {

--- a/pkg/identity/store/file.go
+++ b/pkg/identity/store/file.go
@@ -1,0 +1,92 @@
+package store
+
+import (
+	"crypto/ed25519"
+	"encoding/json"
+	"os"
+
+	"github.com/pkg/errors"
+	"github.com/threefoldtech/zos/pkg/versioned"
+	"github.com/tyler-smith/go-bip39"
+)
+
+// Version History:
+//   1.0.0: seed binary directly encoded
+//   1.1.0: json with key mnemonic and threebot id
+
+var (
+	// SeedVersion1 (binary seed)
+	SeedVersion1 = versioned.MustParse("1.0.0")
+	// SeedVersion11 (json mnemonic)
+	SeedVersion11 = versioned.MustParse("1.1.0")
+	// SeedVersionLatest link to latest seed version
+	SeedVersionLatest = SeedVersion11
+)
+
+type FileStore struct {
+	path string
+}
+
+var _ Store = (*FileStore)(nil)
+
+func NewFileStore(path string) FileStore {
+	return FileStore{path}
+}
+
+func (f *FileStore) Set(key ed25519.PrivateKey) error {
+	seed := key.Seed()
+	return versioned.WriteFile(f.path, SeedVersion1, seed, 0400)
+}
+
+func (f *FileStore) Annihilate() error {
+	return os.Remove(f.path)
+}
+
+func (f *FileStore) Get() (ed25519.PrivateKey, error) {
+	version, data, err := versioned.ReadFile(f.path)
+	if versioned.IsNotVersioned(err) {
+		// this is a compatibility code for seed files
+		// in case it does not have any version information
+		if err := versioned.WriteFile(f.path, SeedVersionLatest, data, 0400); err != nil {
+			return nil, err
+		}
+		version = SeedVersion1
+	} else if os.IsNotExist(err) {
+		return nil, ErrKeyDoesNotExist
+	} else if err != nil {
+		return nil, err
+	}
+
+	if version.NE(SeedVersion1) && version.NE(SeedVersion11) {
+		return nil, errors.Wrap(ErrInvalidKey, "unknown seed version")
+	}
+
+	if version.EQ(SeedVersion1) {
+		return keyFromSeed(data)
+	}
+	// it means we read json data instead of the secret
+	type Seed110Struct struct {
+		Mnemonics string `json:"mnemonic"`
+	}
+	var seed110 Seed110Struct
+	if err = json.Unmarshal(data, &seed110); err != nil {
+		return nil, errors.Wrapf(ErrInvalidKey, "failed to decode seed: %s", err)
+	}
+
+	seed, err := bip39.EntropyFromMnemonic(seed110.Mnemonics)
+	if err != nil {
+		return nil, errors.Wrapf(ErrInvalidKey, "failed to decode mnemonics: %s", err)
+	}
+
+	return keyFromSeed(seed)
+}
+
+func (f *FileStore) Exists() (bool, error) {
+	if _, err := os.Stat(f.path); os.IsNotExist(err) {
+		return false, nil
+	} else if err != nil {
+		return false, errors.Wrap(err, "failed to check seed file")
+	}
+
+	return true, nil
+}

--- a/pkg/identity/store/keys_test.go
+++ b/pkg/identity/store/keys_test.go
@@ -1,0 +1,77 @@
+package store
+
+import (
+	"crypto/rand"
+	"encoding/base64"
+	"io/ioutil"
+	"os"
+	"testing"
+
+	"golang.org/x/crypto/ed25519"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestSerialize(t *testing.T) {
+	_, sk, err := ed25519.GenerateKey(rand.Reader)
+	assert.NoError(t, err)
+
+	f, err := ioutil.TempFile("", "")
+	require.NoError(t, err)
+	defer func() {
+		_ = f.Close()
+		_ = os.Remove(f.Name())
+	}()
+
+	store := NewFileStore(f.Name())
+	err = store.Set(sk)
+	assert.NoError(t, err)
+
+	loaded, err := store.Get()
+	assert.NoError(t, err)
+
+	assert.Equal(t, sk, loaded)
+}
+
+func TestLoadSeed110(t *testing.T) {
+	seedfilecontent := `"1.1.0"{"mnemonic":"crop orient animal script safe inquiry neglect tumble maple board degree you intact busy birth west crack cabin lizard embark seed adjust around talk"}`
+	f, err := ioutil.TempFile("", "")
+	require.NoError(t, err)
+	defer func() {
+		_ = f.Close()
+		_ = os.Remove(f.Name())
+	}()
+	_, err = f.WriteString(seedfilecontent)
+	require.NoError(t, err)
+	f.Close()
+
+	store := NewFileStore(f.Name())
+	sk, err := store.Get()
+	require.NoError(t, err)
+	assert.NotNil(t, sk)
+	assert.Equal(t, len(sk), ed25519.PrivateKeySize)
+}
+
+func TestLoadSeed100(t *testing.T) {
+
+	seedfilebase64 := `IjEuMC4wIkiwBpAxl8Xpc4fgQ4Wq3Is5ssEkObXDJANf7KoOw153` // matches `"1.0.0"H°1ÅésàCªÜ9²Á$9µÃ$_ìªÃ^w`
+	seedfilebytes, err := base64.StdEncoding.DecodeString(seedfilebase64)
+	require.NoError(t, err)
+
+	f, err := ioutil.TempFile("", "")
+	require.NoError(t, err)
+	defer func() {
+		_ = f.Close()
+		_ = os.Remove(f.Name())
+	}()
+	_, err = f.Write(seedfilebytes)
+	require.NoError(t, err)
+	f.Close()
+
+	store := NewFileStore(f.Name())
+	sk, err := store.Get()
+	require.NoError(t, err)
+	assert.NotNil(t, sk)
+	assert.Equal(t, len(sk), ed25519.PrivateKeySize)
+}

--- a/pkg/identity/store/store.go
+++ b/pkg/identity/store/store.go
@@ -1,0 +1,37 @@
+/*
+Key store implements different methods of storing the node identity seed on disk
+*/
+package store
+
+import (
+	"crypto/ed25519"
+	"fmt"
+
+	"github.com/pkg/errors"
+)
+
+var (
+	ErrKeyDoesNotExist = fmt.Errorf("key does not exist")
+	ErrInvalidKey      = fmt.Errorf("invalid key data")
+)
+
+type Store interface {
+	// Get returns the key from the store
+	Get() (ed25519.PrivateKey, error)
+	// Updates, or overrides the current key
+	Set(key ed25519.PrivateKey) error
+	// Check if key there is a key stored in the
+	// store
+	Exists() (bool, error)
+	// Destroys the key
+	Annihilate() error
+}
+
+// keyFromSeed creates a new key pair from seed
+func keyFromSeed(seed []byte) (key ed25519.PrivateKey, err error) {
+	if len(seed) != ed25519.SeedSize {
+		return nil, errors.Wrapf(ErrInvalidKey, "seed has the wrong size %d and should be %d", len(seed), ed25519.SeedSize)
+	}
+
+	return ed25519.NewKeyFromSeed(seed), nil
+}

--- a/pkg/identity/store/store.go
+++ b/pkg/identity/store/store.go
@@ -25,6 +25,8 @@ type Store interface {
 	Exists() (bool, error)
 	// Destroys the key
 	Annihilate() error
+	// Kind returns store kind
+	Kind() string
 }
 
 // keyFromSeed creates a new key pair from seed

--- a/pkg/identity/store/tpm.go
+++ b/pkg/identity/store/tpm.go
@@ -1,0 +1,28 @@
+package store
+
+import "crypto/ed25519"
+
+type TPMStore struct{}
+
+var _ Store = (*TPMStore)(nil)
+
+// Get returns the key from the store
+func (t *TPMStore) Get() (ed25519.PrivateKey, error) {
+	panic("unimplemented")
+}
+
+// Updates, or overrides the current key
+func (t *TPMStore) Set(key ed25519.PrivateKey) error {
+	panic("unimplemented")
+}
+
+// Check if key there is a key stored in the
+// store
+func (t *TPMStore) Exists() (bool, error) {
+	panic("unimplemented")
+}
+
+// Destroys the key
+func (t *TPMStore) Annihilate() error {
+	panic("unimplemented")
+}

--- a/pkg/identity/store/tpm/utils.go
+++ b/pkg/identity/store/tpm/utils.go
@@ -1,0 +1,68 @@
+package tpm
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"os/exec"
+
+	"github.com/pkg/errors"
+	"gopkg.in/yaml.v2"
+)
+
+func tpm(ctx context.Context, name string, out interface{}, arg ...string) error {
+	name = fmt.Sprintf("tpm2_%s", name)
+
+	cmd := exec.CommandContext(ctx, name, arg...)
+
+	output, err := cmd.Output()
+	if err, ok := err.(*exec.ExitError); ok && err != nil {
+		return errors.Wrapf(err, "error while running command: (%s)", string(err.Stderr))
+	} else if err != nil {
+		return errors.Wrap(err, "failed to run tpm")
+	}
+
+	if out == nil {
+		return nil
+	}
+
+	decoder := yaml.NewDecoder(bytes.NewBuffer(output))
+
+	return decoder.Decode(out)
+}
+
+// IsTPMSupported checks if TPM is accessible on this system
+func IsTPMSupported(ctx context.Context) bool {
+	pcrs, err := PCRs(ctx)
+	if err != nil {
+		return false
+	}
+
+	return len(pcrs) > 0
+}
+
+// PersistedHandlers return a list of persisted handlers on the system
+func PersistedHandlers(ctx context.Context) (handlers []string, err error) {
+	err = tpm(ctx, "getcap", &handlers, "handles-persistent")
+	return
+}
+
+// PCRs returns the available PCRs numbers as map of [hash-algorithm][]int
+func PCRs(ctx context.Context) (map[string][]int, error) {
+	var data struct {
+		Top []map[string][]int `yaml:"selected-pcrs"`
+	}
+
+	if err := tpm(ctx, "getcap", &data, "pcrs"); err != nil {
+		return nil, err
+	}
+
+	pcrs := make(map[string][]int)
+	for _, m := range data.Top {
+		for k, l := range m {
+			pcrs[k] = l
+		}
+	}
+
+	return pcrs, nil
+}

--- a/pkg/identity/store/tpm/utils_test.go
+++ b/pkg/identity/store/tpm/utils_test.go
@@ -1,0 +1,23 @@
+package tpm
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestPersistedHandlers(t *testing.T) {
+	t.Skip("manual test needs specific setup")
+	handlers, err := PersistedHandlers(context.Background())
+	assert.NoError(t, err)
+	fmt.Println(handlers)
+}
+
+func TestPCRs(t *testing.T) {
+	//t.Skip("manual test needs specific setup")
+	pcrs, err := PCRs(context.Background())
+	assert.NoError(t, err)
+	fmt.Println(pcrs)
+}

--- a/pkg/identity/store/tpm/utils_test.go
+++ b/pkg/identity/store/tpm/utils_test.go
@@ -16,8 +16,34 @@ func TestPersistedHandlers(t *testing.T) {
 }
 
 func TestPCRs(t *testing.T) {
-	//t.Skip("manual test needs specific setup")
+	t.Skip("manual test needs specific setup")
 	pcrs, err := PCRs(context.Background())
 	assert.NoError(t, err)
 	fmt.Println(pcrs)
+}
+
+func TestPCRSelector(t *testing.T) {
+	selector := PCRSelector{
+		SHA1: {1, 2, 3},
+	}
+
+	assert.Equal(t, "sha1:1,2,3", selector.String())
+
+	selector = PCRSelector{
+		SHA1:   {1, 2, 3},
+		SHA256: {3, 4},
+	}
+
+	assert.Equal(t, "sha1:1,2,3+sha256:3,4", selector.String())
+}
+
+func TestPCRPolicy(t *testing.T) {
+	t.Skip("manual test")
+	selector := PCRSelector{
+		SHA1: {0, 1, 2},
+	}
+
+	hash, err := PCRPolicy(context.Background(), selector)
+	assert.NoError(t, err)
+	assert.Equal(t, HexString("f3473b1bc51f0c9179f4c6f377b5b7d20bde98793e1a052c7bc3b736b821d1fe"), hash)
 }

--- a/pkg/identity/store/tpm/utils_test.go
+++ b/pkg/identity/store/tpm/utils_test.go
@@ -43,7 +43,7 @@ func TestPCRPolicy(t *testing.T) {
 		SHA1: {0, 1, 2},
 	}
 
-	hash, err := PCRPolicy(context.Background(), selector)
+	hash, err := CreatePCRPolicy(context.Background(), selector)
 	assert.NoError(t, err)
 	assert.Equal(t, HexString("f3473b1bc51f0c9179f4c6f377b5b7d20bde98793e1a052c7bc3b736b821d1fe"), hash)
 }

--- a/pkg/network/nr/net_resource_test.go
+++ b/pkg/network/nr/net_resource_test.go
@@ -19,6 +19,10 @@ type testIdentityManager struct {
 
 var _ pkg.IdentityManager = (*testIdentityManager)(nil)
 
+func (t *testIdentityManager) StoreKind() string {
+	return "test"
+}
+
 // NodeID returns the node id (public key)
 func (t *testIdentityManager) NodeID() pkg.StrIdentifier {
 	return pkg.StrIdentifier(t.id)

--- a/pkg/network/yggdrasil/yygdrasil_test.go
+++ b/pkg/network/yggdrasil/yygdrasil_test.go
@@ -1,19 +1,18 @@
 package yggdrasil
 
 import (
+	"crypto/ed25519"
 	"net"
 	"testing"
 
 	"github.com/stretchr/testify/require"
-	"github.com/threefoldtech/zos/pkg/identity"
 	"gotest.tools/assert"
 )
 
 func TestAddresses(t *testing.T) {
-	kp, err := identity.FromSeed([]byte("00000000000000000000000000000000"))
-	require.NoError(t, err)
+	sk := ed25519.NewKeyFromSeed([]byte("00000000000000000000000000000000"))
 
-	cfg := GenerateConfig(kp.PrivateKey)
+	cfg := GenerateConfig(sk)
 	s := NewYggServer(&cfg)
 
 	ip, err := s.Address()

--- a/pkg/stubs/identity_stub.go
+++ b/pkg/stubs/identity_stub.go
@@ -208,6 +208,22 @@ func (s *IdentityManagerStub) Sign(ctx context.Context, arg0 []uint8) (ret0 []ui
 	return
 }
 
+func (s *IdentityManagerStub) StoreKind(ctx context.Context) (ret0 string) {
+	args := []interface{}{}
+	result, err := s.client.RequestContext(ctx, s.module, s.object, "StoreKind", args...)
+	if err != nil {
+		panic(err)
+	}
+	result.PanicOnError()
+	loader := zbus.Loader{
+		&ret0,
+	}
+	if err := result.Unmarshal(&loader); err != nil {
+		panic(err)
+	}
+	return
+}
+
 func (s *IdentityManagerStub) Verify(ctx context.Context, arg0 []uint8, arg1 []uint8) (ret0 error) {
 	args := []interface{}{arg0, arg1}
 	result, err := s.client.RequestContext(ctx, s.module, s.object, "Verify", args...)

--- a/qemu/vm.sh
+++ b/qemu/vm.sh
@@ -9,6 +9,7 @@ bridge=zos0
 graphics="-nographic -nodefaults"
 smp=1
 mem=3
+tpm=0
 
 usage() {
    cat <<EOF
@@ -22,14 +23,14 @@ Usage: vm -n $name [ -r ] [ -d ]
    -b: bridge for network (default zos)
    -g: open GUI
    -m: memory in Gigabytes
+   -t: tpm support (requires swtpm)
    -h: help
-
 EOF
    exit 0
 }
 
 
-while getopts "c:n:i:rdb:gs:m:" opt; do
+while getopts "c:n:i:rdtb:gs:m:" opt; do
    case $opt in
    i )  image=$OPTARG ;;
    r )  reset=1 ;;
@@ -40,6 +41,7 @@ while getopts "c:n:i:rdb:gs:m:" opt; do
    g )  graphics="" ;;
    s )  smp=$OPTARG ;;
    m )  mem=$OPTARG ;;
+   t )  tpm=1 ;;
    h )  usage ; exit 0 ;;
    \?)  usage ; exit 1 ;;
    esac
@@ -73,6 +75,32 @@ if ps -eaf | grep -v grep | grep "$uuid" > /dev/null; then
     exit 1
 fi
 
+tpmargs=""
+if [[ $tpm -eq "1" ]]; then
+   if ! command -v swtpm &> /dev/null; then
+      echo "tpm option require `swtpm` please install first"
+      exit 1
+   fi
+   pkill swtpm
+   tpm_dir="$vmdir/tpm"
+   tpm_socket="$vmdir/swtpm.sock"
+   mkdir -p $tpm_dir
+   rm $tpm_socket &> /dev/null || true
+   runs int he backgroun
+   swtpm \
+      socket --tpm2 \
+      --tpmstate dir=$tpm_dir \
+      --ctrl type=unixio,path=$vmdir/swtpm.sock \
+      --log level=20 &> tpm.logs &
+
+   while [ ! -S "$tpm_socket" ]; do
+      echo "waiting for tpm"
+      sleep 1s
+   done
+   sleep 1s
+   tpmargs="-chardev socket,id=chrtpm,path=${tpm_socket} -tpmdev emulator,id=tpm0,chardev=chrtpm -device tpm-tis,tpmdev=tpm0"
+fi
+
 echo "boot $image"
 
 qemu-system-x86_64 -kernel $image \
@@ -88,7 +116,6 @@ qemu-system-x86_64 -kernel $image \
     -drive file=$vmdir/vdc.qcow2,if=virtio -drive file=$vmdir/vdd.qcow2,if=virtio \
     -drive file=$vmdir/vde.qcow2,if=virtio \
     -serial null -serial mon:stdio \
-    -chardev socket,id=chrtpm,path=/tmp/swtpm-sock \
-    -tpmdev emulator,id=tpm0,chardev=chrtpm \
-    -device tpm-tis,tpmdev=tpm0 \
-    ${graphics}
+    ${graphics} \
+    ${tpmargs} \
+    ;

--- a/qemu/vm.sh
+++ b/qemu/vm.sh
@@ -88,4 +88,7 @@ qemu-system-x86_64 -kernel $image \
     -drive file=$vmdir/vdc.qcow2,if=virtio -drive file=$vmdir/vdd.qcow2,if=virtio \
     -drive file=$vmdir/vde.qcow2,if=virtio \
     -serial null -serial mon:stdio \
+    -chardev socket,id=chrtpm,path=/tmp/mytpm1/swtpm-sock \
+    -tpmdev emulator,id=tpm0,chardev=chrtpm \
+    -device tpm-tis,tpmdev=tpm0 \
     ${graphics}

--- a/qemu/vm.sh
+++ b/qemu/vm.sh
@@ -88,7 +88,7 @@ qemu-system-x86_64 -kernel $image \
     -drive file=$vmdir/vdc.qcow2,if=virtio -drive file=$vmdir/vdd.qcow2,if=virtio \
     -drive file=$vmdir/vde.qcow2,if=virtio \
     -serial null -serial mon:stdio \
-    -chardev socket,id=chrtpm,path=/tmp/mytpm1/swtpm-sock \
+    -chardev socket,id=chrtpm,path=/tmp/swtpm-sock \
     -tpmdev emulator,id=tpm0,chardev=chrtpm \
     -device tpm-tis,tpmdev=tpm0 \
     ${graphics}

--- a/qemu/vm.sh
+++ b/qemu/vm.sh
@@ -86,7 +86,7 @@ if [[ $tpm -eq "1" ]]; then
    tpm_socket="$vmdir/swtpm.sock"
    mkdir -p $tpm_dir
    rm $tpm_socket &> /dev/null || true
-   runs int he backgroun
+   # runs in the backgroun
    swtpm \
       socket --tpm2 \
       --tpmstate dir=$tpm_dir \


### PR DESCRIPTION
Depends on #1787 

This will does the following:
- For nodes that has tpm, use tpm to store node seed
- Nodes without tpm, will continue use a file on disk
- Nodes that already has a key file, will move that key to tpm and delete the key if the node has tpm

This PR uses the tpm2 utils. The branch and build and install tpm is not merged yet. 

> There are changes related to the update to make sure identityd restarts after installing the latest tpm2 binaries