### PR TITLE
qsfs: deprovision: don't fail if it's already marked...

### DIFF
--- a/pkg/container/container.go
+++ b/pkg/container/container.go
@@ -551,7 +551,6 @@ func (c *Module) SignalDelete(ns string, id pkg.ContainerID) error {
 	container, err := client.LoadContainer(ctx, string(id))
 	if err != nil {
 		if errdefs.IsNotFound(err) {
-			log.Warn().Str("id", string(id)).Msg("attempt to delete a non-existing container")
 			return nil
 		}
 		return err

--- a/pkg/container/container.go
+++ b/pkg/container/container.go
@@ -550,8 +550,13 @@ func (c *Module) SignalDelete(ns string, id pkg.ContainerID) error {
 	// log.Debug().Str("id", string(id)).Msg("fetching container")
 	container, err := client.LoadContainer(ctx, string(id))
 	if err != nil {
+		if errdefs.IsNotFound(err) {
+			log.Warn().Str("id", string(id)).Msg("attempt to delete a non-existing container")
+			return nil
+		}
 		return err
 	}
+
 	// mark this container as perminant down. so the watcher
 	// does not try to restart it again
 	c.failures.Set(string(id), permanent, cache.DefaultExpiration)

--- a/pkg/container/container.go
+++ b/pkg/container/container.go
@@ -549,10 +549,9 @@ func (c *Module) SignalDelete(ns string, id pkg.ContainerID) error {
 
 	// log.Debug().Str("id", string(id)).Msg("fetching container")
 	container, err := client.LoadContainer(ctx, string(id))
-	if err != nil {
-		if errdefs.IsNotFound(err) {
-			return nil
-		}
+	if errdefs.IsNotFound(err) {
+		return nil
+	} else if err != nil {
 		return err
 	}
 

--- a/pkg/qsfsd/qsfs.go
+++ b/pkg/qsfsd/qsfs.go
@@ -267,7 +267,6 @@ func (q *QSFS) SignalDelete(wlID string) error {
 	marked, err := q.isMarkedForDeletion(ctx, wlID)
 
 	if marked {
-		log.Warn().Str("workload", wlID).Msg("already marked for deletion")
 		return nil
 	}
 	if err != nil {

--- a/pkg/qsfsd/qsfs.go
+++ b/pkg/qsfsd/qsfs.go
@@ -267,7 +267,8 @@ func (q *QSFS) SignalDelete(wlID string) error {
 	marked, err := q.isMarkedForDeletion(ctx, wlID)
 
 	if marked {
-		return errors.New("already marked for deletion")
+		log.Warn().Str("workload", wlID).Msg("already marked for deletion")
+		return nil
 	}
 	if err != nil {
 		return errors.Wrap(err, "failed to check deletion mark")


### PR DESCRIPTION
also don't fail if the container does not exist too.

Related:

* #1788 