### PR TITLE
Avoid missing events

### DIFF
--- a/cmds/modules/noded/main.go
+++ b/cmds/modules/noded/main.go
@@ -31,6 +31,7 @@ import (
 const (
 	module          = "node"
 	registrarModule = "registrar"
+	eventsBlock     = "/tmp/events.chain"
 )
 
 // Module is entry point for module
@@ -210,7 +211,8 @@ func action(cli *cli.Context) error {
 	if err != nil {
 		return err
 	}
-	events := events.New(sub, node)
+
+	events := events.New(sub, node, eventsBlock)
 
 	system, err := monitord.NewSystemMonitor(node, 2*time.Second)
 	if err != nil {

--- a/cmds/modules/noded/public.go
+++ b/cmds/modules/noded/public.go
@@ -71,12 +71,6 @@ reapply:
 		for {
 			select {
 			case event := <-events:
-				if event.Kind == pkg.EventSubscribed {
-					// the events has re-subscribed, so possible
-					// loss of events.
-					// then we-reapply
-					continue reapply
-				}
 
 				log.Info().Msgf("got a public config update: %+v", event.PublicConfig)
 				var cfg *substrate.PublicConfig

--- a/cmds/modules/provisiond/events.go
+++ b/cmds/modules/provisiond/events.go
@@ -8,7 +8,6 @@ import (
 	"github.com/rs/zerolog/log"
 	"github.com/threefoldtech/substrate-client"
 	"github.com/threefoldtech/zbus"
-	"github.com/threefoldtech/zos/pkg"
 	"github.com/threefoldtech/zos/pkg/provision"
 	"github.com/threefoldtech/zos/pkg/stubs"
 )
@@ -123,18 +122,6 @@ func (r *ContractEventHandler) Run(ctx context.Context) error {
 				}
 			}()
 		case event := <-cancellation:
-			if event.Kind == pkg.EventSubscribed {
-				// we run this in a go routine because we don't
-				// want synchronization of contracts on the chain (that can take some time)
-				// to block
-				go func() {
-					if err := r.sync(ctx); err != nil {
-						log.Error().Err(err).Msg("failed to synchronize contracts with the chain")
-					}
-				}()
-				continue
-			}
-
 			log.Debug().Msgf("received a cancel contract event %+v", event)
 
 			// otherwise we know what contract to be deleted

--- a/pkg/events.go
+++ b/pkg/events.go
@@ -10,30 +10,15 @@ import (
 
 //go:generate zbusc -module node -version 0.0.1 -name events -package stubs github.com/threefoldtech/zos/pkg+Events stubs/events_stub.go
 
-// EventKind describes event kind
-type EventKind int
-
-const (
-	// EventSubscribed event is always sent when a new connection to tfchain is done
-	// this will let the receiver know that we just reconnected to the network hence
-	// possible events loss has occurred. Hence the receiver need to make sure
-	// it's in sync with the network
-	EventSubscribed EventKind = iota
-	// EventReceived mean a new event has been received, and need to be handled
-	EventReceived
-)
-
 // PublicConfigEvent pubic config event received. The type specify if this is just notification
 // of the reconnection, or actual event has been received.
 type PublicConfigEvent struct {
-	Kind         EventKind
 	PublicConfig substrate.OptionPublicConfig
 }
 
 // ContractCancelledEvent a contract has been cancelled, The type specify if this is just notification
 // of the reconnection, or actual event has been received.
 type ContractCancelledEvent struct {
-	Kind     EventKind
 	Contract uint64
 	TwinId   uint32
 }
@@ -42,7 +27,6 @@ type ContractCancelledEvent struct {
 // If Kind is EventSubscribed it means event stream has been reconnected and might be events loss. It's up to the
 // handler of this event type to make sure contracts are synched with the grid.
 type ContractLockedEvent struct {
-	Kind     EventKind
 	Contract uint64
 	TwinId   uint32
 	Lock     bool

--- a/pkg/events/events.go
+++ b/pkg/events/events.go
@@ -2,10 +2,13 @@ package events
 
 import (
 	"context"
+	"encoding/binary"
 	"fmt"
+	"os"
 	"sync"
 	"time"
 
+	gsrpc "github.com/centrifuge/go-substrate-rpc-client/v4"
 	"github.com/centrifuge/go-substrate-rpc-client/v4/types"
 	"github.com/pkg/errors"
 	"github.com/rs/zerolog/log"
@@ -13,12 +16,11 @@ import (
 	"github.com/threefoldtech/zos/pkg"
 )
 
-var (
-	errStreamDisconnected = fmt.Errorf("stream disconnected")
-)
+type Events struct {
+	sub   substrate.Manager
+	state string
+	last  types.BlockNumber
 
-type Manager struct {
-	mgr            substrate.Manager
 	node           uint32
 	pubCfg         chan pkg.PublicConfigEvent
 	contractCancel chan pkg.ContractCancelledEvent
@@ -27,9 +29,14 @@ type Manager struct {
 	o sync.Once
 }
 
-func New(mgr substrate.Manager, node uint32) pkg.Events {
-	return &Manager{
-		mgr:            mgr,
+var (
+	_ pkg.Events = (*Events)(nil)
+)
+
+func New(sub substrate.Manager, node uint32, state string) *Events {
+	return &Events{
+		sub:            sub,
+		state:          state,
 		node:           node,
 		pubCfg:         make(chan pkg.PublicConfigEvent),
 		contractCancel: make(chan pkg.ContractCancelledEvent),
@@ -37,126 +44,180 @@ func New(mgr substrate.Manager, node uint32) pkg.Events {
 	}
 }
 
-func (m *Manager) start(ctx context.Context) {
-	log.Info().Msg("start listening to chain events")
-	for {
-		if err := m.listen(ctx); err != nil {
-			log.Error().Err(err).Msg("listening to events failed, retry in 10 seconds")
-			<-time.After(10 * time.Second)
+func (e *Events) setLatest(num types.BlockNumber) error {
+	e.last = num
+	var d [4]byte
+	binary.BigEndian.PutUint32(d[:], uint32(num))
+	if err := os.WriteFile(e.state, d[:], 0644); err != nil {
+		return errors.Wrap(err, "failed to commit last block state")
+	}
+	return nil
+}
+
+func (e *Events) getLatest(cl *gsrpc.SubstrateAPI) (types.BlockNumber, error) {
+	// getLatest need to
+	if e.last != 0 {
+		return e.last, nil
+	}
+
+	// last is unknown, use last key file
+	data, err := os.ReadFile(e.state)
+	if err == nil {
+		// get latest from the chain
+		return types.BlockNumber(binary.BigEndian.Uint32(data)), nil
+	}
+
+	block, err := cl.RPC.Chain.GetBlockLatest()
+	if err != nil {
+		return 0, errors.Wrap(err, "failed to get last block")
+	}
+	// set latest to previous block because
+	return block.Block.Header.Number - 1, nil
+
+}
+
+func (e *Events) eventsTo(cl *gsrpc.SubstrateAPI, meta *types.Metadata, block types.Header) error {
+	//
+	last, err := e.getLatest(cl)
+	if err != nil {
+		return errors.Wrap(err, "failed to get latest processed block")
+	}
+
+	key, err := types.CreateStorageKey(meta, "System", "Events", nil)
+	if err != nil {
+		return err
+	}
+
+	start := last + 1
+	end := block.Number
+
+	// NOTE: calling QueryStorage with start/end hashes does not work
+	// and always return error 'RPC call is unsafe to be called externally'
+	for i := start; i <= end; i++ {
+		hash, err := cl.RPC.Chain.GetBlockHash(uint64(i))
+		if err != nil {
+			return errors.Wrapf(err, "failed to get block hash '%d'", start)
+		}
+
+		changes, err := cl.RPC.State.QueryStorageAt([]types.StorageKey{key}, hash)
+		if err != nil {
+			return err
+		}
+
+		e.process(changes, meta)
+	}
+
+	return nil
+}
+
+func (e *Events) process(changes []types.StorageChangeSet, meta *types.Metadata) {
+	for _, set := range changes {
+		fmt.Printf("%x\n", set.Block)
+		for _, change := range set.Changes {
+			if !change.HasStorageData {
+				continue
+			}
+
+			var events substrate.EventRecords
+			if err := types.EventRecordsRaw(change.StorageData).DecodeEventRecords(meta, &events); err != nil {
+				log.Error().Err(err).Msg("failed to decode events from tfchain")
+				continue
+			}
+
+			for _, event := range events.TfgridModule_NodePublicConfigStored {
+				if event.Node != types.U32(e.node) {
+					continue
+				}
+				log.Info().Msgf("got a public config update: %+v", event.Config)
+				e.pubCfg <- pkg.PublicConfigEvent{
+					PublicConfig: event.Config,
+				}
+			}
+
+			for _, event := range events.SmartContractModule_NodeContractCanceled {
+				if event.Node != types.U32(e.node) {
+					continue
+				}
+				log.Info().Uint64("contract", uint64(event.ContractID)).Msg("got contract cancel update")
+				e.contractCancel <- pkg.ContractCancelledEvent{
+					Contract: uint64(event.ContractID),
+					TwinId:   uint32(event.Twin),
+				}
+			}
+
+			for _, event := range events.SmartContractModule_ContractGracePeriodStarted {
+				if event.NodeID != types.U32(e.node) {
+					continue
+				}
+				log.Info().Uint64("contract", uint64(event.ContractID)).Msg("got contract grace period started")
+				e.contractLocked <- pkg.ContractLockedEvent{
+					Contract: uint64(event.ContractID),
+					TwinId:   uint32(event.TwinID),
+					Lock:     true,
+				}
+			}
+
+			for _, event := range events.SmartContractModule_ContractGracePeriodEnded {
+				if event.NodeID != types.U32(e.node) {
+					continue
+				}
+				log.Info().Uint64("contract", uint64(event.ContractID)).Msg("got contract grace period ended")
+				e.contractLocked <- pkg.ContractLockedEvent{
+					Contract: uint64(event.ContractID),
+					TwinId:   uint32(event.TwinID),
+					Lock:     false,
+				}
+			}
 		}
 	}
 }
 
-func (m *Manager) events(ctx context.Context) error {
-	subClient, meta, err := m.mgr.Raw()
+func (e *Events) subscribe(ctx context.Context) error {
+	cl, meta, err := e.sub.Raw()
 	if err != nil {
-		return errors.Wrap(err, "failed to get client to substrate")
+		return errors.Wrap(err, "failed to connect to chain")
 	}
 
-	defer subClient.Client.Close()
-
-	m.pubCfg <- pkg.PublicConfigEvent{Kind: pkg.EventSubscribed}
-	m.contractCancel <- pkg.ContractCancelledEvent{Kind: pkg.EventSubscribed}
-
-	// Subscribe to system events via storage
-	key, err := types.CreateStorageKey(meta, "System", "Events", nil)
+	defer cl.Client.Close()
+	sub, err := cl.RPC.Chain.SubscribeNewHeads()
 	if err != nil {
-		return errors.Wrap(err, "failed to get storage key for events")
+		return errors.Wrap(err, "failed to subscribe to new blocks")
 	}
 
-	reg, err := subClient.RPC.State.SubscribeStorageRaw([]types.StorageKey{key})
-	if err != nil {
-		return errors.Wrap(err, "failed to subscribe to events")
-	}
+	defer sub.Unsubscribe()
 
 	for {
 		select {
-		case event := <-reg.Chan():
-			//m.sub.GetBlock(block types.Hash)
-			for _, change := range event.Changes {
-				if !change.HasStorageData {
-					continue
-				}
-
-				var events substrate.EventRecords
-				if err := types.EventRecordsRaw(change.StorageData).DecodeEventRecords(meta, &events); err != nil {
-					log.Error().Err(err).Msg("failed to decode events from tfchain")
-					continue
-				}
-
-				for _, e := range events.TfgridModule_NodePublicConfigStored {
-					if e.Node != types.U32(m.node) {
-						continue
-					}
-					log.Info().Msgf("got a public config update: %+v", e.Config)
-					m.pubCfg <- pkg.PublicConfigEvent{
-						Kind:         pkg.EventReceived,
-						PublicConfig: e.Config,
-					}
-				}
-
-				for _, e := range events.SmartContractModule_NodeContractCanceled {
-					if e.Node != types.U32(m.node) {
-						continue
-					}
-					log.Info().Uint64("contract", uint64(e.ContractID)).Msg("got contract cancel update")
-					m.contractCancel <- pkg.ContractCancelledEvent{
-						Kind:     pkg.EventReceived,
-						Contract: uint64(e.ContractID),
-						TwinId:   uint32(e.Twin),
-					}
-				}
-
-				for _, e := range events.SmartContractModule_ContractGracePeriodStarted {
-					if e.NodeID != types.U32(m.node) {
-						continue
-					}
-					log.Info().Uint64("contract", uint64(e.ContractID)).Msg("got contract grace period started")
-					m.contractLocked <- pkg.ContractLockedEvent{
-						Kind:     pkg.EventReceived,
-						Contract: uint64(e.ContractID),
-						TwinId:   uint32(e.TwinID),
-						Lock:     true,
-					}
-				}
-
-				for _, e := range events.SmartContractModule_ContractGracePeriodEnded {
-					if e.NodeID != types.U32(m.node) {
-						continue
-					}
-					log.Info().Uint64("contract", uint64(e.ContractID)).Msg("got contract grace period ended")
-					m.contractLocked <- pkg.ContractLockedEvent{
-						Kind:     pkg.EventReceived,
-						Contract: uint64(e.ContractID),
-						TwinId:   uint32(e.TwinID),
-						Lock:     false,
-					}
-				}
-			}
-		case err := <-reg.Err():
-			// need a reconnect
-			return errors.Wrapf(errStreamDisconnected, "subscription to events stopped (%s), reconnecting", err)
 		case <-ctx.Done():
-			return ctx.Err()
-		}
-	}
-}
-
-// Start subscribing and producing events
-func (m *Manager) listen(ctx context.Context) error {
-	for {
-		err := m.events(ctx)
-		if errors.Is(err, context.Canceled) {
 			return nil
-		} else if errors.Is(err, errStreamDisconnected) {
-			continue
-		} else {
+		case err := <-sub.Err():
 			return err
+		case block := <-sub.Chan():
+			err := e.eventsTo(cl, meta, block)
+			if err != nil {
+				log.Error().Err(err).Msg("failed to process chain events")
+				continue
+			}
+
+			if err := e.setLatest(block.Number); err != nil {
+				return errors.Wrap(err, "failed to commit last block number")
+			}
 		}
 	}
 }
 
-func (m *Manager) PublicConfigEvent(ctx context.Context) <-chan pkg.PublicConfigEvent {
+func (e *Events) start(ctx context.Context) {
+	for {
+		err := e.subscribe(ctx)
+		if err != nil {
+			<-time.After(10 * time.Second)
+			continue
+		}
+		return
+	}
+}
+
+func (m *Events) PublicConfigEvent(ctx context.Context) <-chan pkg.PublicConfigEvent {
 	m.o.Do(func() {
 		go m.start(ctx)
 	})
@@ -164,7 +225,7 @@ func (m *Manager) PublicConfigEvent(ctx context.Context) <-chan pkg.PublicConfig
 	return m.pubCfg
 }
 
-func (m *Manager) ContractCancelledEvent(ctx context.Context) <-chan pkg.ContractCancelledEvent {
+func (m *Events) ContractCancelledEvent(ctx context.Context) <-chan pkg.ContractCancelledEvent {
 	m.o.Do(func() {
 		go m.start(ctx)
 	})
@@ -172,7 +233,7 @@ func (m *Manager) ContractCancelledEvent(ctx context.Context) <-chan pkg.Contrac
 	return m.contractCancel
 }
 
-func (m *Manager) ContractLockedEvent(ctx context.Context) <-chan pkg.ContractLockedEvent {
+func (m *Events) ContractLockedEvent(ctx context.Context) <-chan pkg.ContractLockedEvent {
 	m.o.Do(func() {
 		go m.start(ctx)
 	})

--- a/pkg/events/events.go
+++ b/pkg/events/events.go
@@ -3,7 +3,6 @@ package events
 import (
 	"context"
 	"encoding/binary"
-	"fmt"
 	"os"
 	"sync"
 	"time"
@@ -112,7 +111,6 @@ func (e *Events) eventsTo(cl *gsrpc.SubstrateAPI, meta *types.Metadata, block ty
 
 func (e *Events) process(changes []types.StorageChangeSet, meta *types.Metadata) {
 	for _, set := range changes {
-		fmt.Printf("%x\n", set.Block)
 		for _, change := range set.Changes {
 			if !change.HasStorageData {
 				continue


### PR DESCRIPTION
The code improves chain events processing by making sure all blocks are processed. This is accomplished by 
- Wait for new blocks 
- Once a  block is created, the block height is checked against the last processed block. 
- All blocks from last processed block to current height is processed.
- Last processed block is stored in a temp file.
- On boot the system always uses the current block number as last processed block  

> Services that processes events still can be down when an event is received hence it doesn't also get a chance to handle the event. The recommended solution is that a service on start need to start listening to events then synchronize with the chain