### PR TITLE
test: use `T.TempDir` to create temporary test directory

### DIFF
--- a/pkg/flist/cleaner_test.go
+++ b/pkg/flist/cleaner_test.go
@@ -15,11 +15,8 @@ import (
 
 func TestCacheCleaner(t *testing.T) {
 
-	cache, err := ioutil.TempDir("", "clean-cache-*")
+	cache := t.TempDir()
 
-	defer os.RemoveAll(cache)
-
-	require.NoError(t, err)
 	flister := flistModule{
 		cache: cache,
 	}
@@ -54,7 +51,7 @@ func TestCacheCleaner(t *testing.T) {
 		require.NoError(t, err)
 	}
 
-	err = flister.cleanCache(now, 50*24*time.Hour) // this should delete 50 files!
+	err := flister.cleanCache(now, 50*24*time.Hour) // this should delete 50 files!
 	require.NoError(t, err)
 
 	files, err := ioutil.ReadDir(cache)

--- a/pkg/flist/flist_test.go
+++ b/pkg/flist/flist_test.go
@@ -3,7 +3,6 @@ package flist
 import (
 	"bytes"
 	"context"
-	"io/ioutil"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -143,17 +142,12 @@ func TestMountUnmount(t *testing.T) {
 	cmder := &testCommander{T: t}
 	strg := &StorageMock{}
 
-	root, err := ioutil.TempDir("", "flist_root")
-	require.NoError(t, err)
-
-	defer os.RemoveAll(root)
+	root := t.TempDir()
 
 	sys := &testSystem{}
 	flister := newFlister(root, strg, cmder, sys)
 
-	backend, err := ioutil.TempDir("", "flist_backend")
-	require.NoError(t, err)
-	defer os.RemoveAll(backend)
+	backend := t.TempDir()
 
 	strg.On("VolumeLookup", mock.Anything, mock.Anything).Return(backend, nil)
 
@@ -180,17 +174,10 @@ func TestMountUnmountRO(t *testing.T) {
 	cmder := &testCommander{T: t}
 	strg := &StorageMock{}
 
-	root, err := ioutil.TempDir("", "flist_root")
-	require.NoError(t, err)
-
-	defer os.RemoveAll(root)
+	root := t.TempDir()
 
 	sys := &testSystem{}
 	flister := newFlister(root, strg, cmder, sys)
-
-	backend, err := ioutil.TempDir("", "flist_backend")
-	require.NoError(t, err)
-	defer os.RemoveAll(backend)
 
 	name := "test"
 
@@ -216,18 +203,13 @@ func TestIsolation(t *testing.T) {
 	cmder := &testCommander{T: t}
 	strg := &StorageMock{}
 
-	root, err := ioutil.TempDir("", "flist_root")
-	require.NoError(err)
-
-	defer os.RemoveAll(root)
+	root := t.TempDir()
 
 	sys := &testSystem{}
 
 	flister := newFlister(root, strg, cmder, sys)
 
-	backend, err := ioutil.TempDir("", "flist_backend")
-	require.NoError(err)
-	defer os.RemoveAll(backend)
+	backend := t.TempDir()
 	strg.On("VolumeLookup", mock.Anything, mock.Anything).Return(backend, nil)
 
 	strg.On("VolumeCreate", mock.Anything, mock.Anything, mock.Anything, uint64(256*mib)).
@@ -258,9 +240,7 @@ func TestDownloadFlist(t *testing.T) {
 	cmder := &testCommander{T: t}
 	strg := &StorageMock{}
 
-	root, err := ioutil.TempDir("", "flist_root")
-	require.NoError(err)
-	defer os.RemoveAll(root)
+	root := t.TempDir()
 
 	sys := &testSystem{}
 

--- a/pkg/network/ndmz/ndmz_test.go
+++ b/pkg/network/ndmz/ndmz_test.go
@@ -2,9 +2,7 @@ package ndmz
 
 import (
 	"fmt"
-	"io/ioutil"
 	"net"
-	"os"
 	"sync"
 	"testing"
 
@@ -39,11 +37,7 @@ func TestIpv6(t *testing.T) {
 }
 
 func TestIPv4Allocate(t *testing.T) {
-	ipamPath, err := ioutil.TempDir("", "")
-	require.NoError(t, err)
-	t.Cleanup(func() {
-		_ = os.RemoveAll(ipamPath)
-	})
+	ipamPath := t.TempDir()
 
 	addr, err := allocateIPv4("network1", ipamPath)
 	require.NoError(t, err)
@@ -59,11 +53,7 @@ func TestIPv4Allocate(t *testing.T) {
 }
 
 func TestIPv4AllocateConcurent(t *testing.T) {
-	ipamPath, err := ioutil.TempDir("", "")
-	require.NoError(t, err)
-	t.Cleanup(func() {
-		_ = os.RemoveAll(ipamPath)
-	})
+	ipamPath := t.TempDir()
 
 	wg := sync.WaitGroup{}
 	wg.Add(10)

--- a/pkg/network/portm/backend/fs_test.go
+++ b/pkg/network/portm/backend/fs_test.go
@@ -1,8 +1,6 @@
 package backend
 
 import (
-	"io/ioutil"
-	"os"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -10,12 +8,7 @@ import (
 )
 
 func TestReserve(t *testing.T) {
-	dir, err := ioutil.TempDir("", "")
-	require.NoError(t, err)
-
-	defer func() {
-		os.RemoveAll(dir)
-	}()
+	dir := t.TempDir()
 
 	ns1 := "ns"
 	ns2 := "ns2"

--- a/pkg/network/portm/backend/lock_test.go
+++ b/pkg/network/portm/backend/lock_test.go
@@ -1,7 +1,6 @@
 package backend
 
 import (
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"testing"
@@ -10,9 +9,7 @@ import (
 )
 
 func TestLockOperations(t *testing.T) {
-	dir, err := ioutil.TempDir("", "")
-	require.NoError(t, err)
-	defer os.RemoveAll(dir)
+	dir := t.TempDir()
 
 	// create a dummy file to lock
 	path := filepath.Join(dir, "x")
@@ -32,9 +29,7 @@ func TestLockOperations(t *testing.T) {
 }
 
 func TestLockFolderPath(t *testing.T) {
-	dir, err := ioutil.TempDir("", "")
-	require.NoError(t, err)
-	defer os.RemoveAll(dir)
+	dir := t.TempDir()
 
 	// use the folder to lock
 	m, err := NewFileLock(dir)

--- a/pkg/provision/storage.fs/storage_test.go
+++ b/pkg/provision/storage.fs/storage_test.go
@@ -4,7 +4,6 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"testing"
@@ -38,9 +37,7 @@ func init() {
 
 func TestStorageAdd(t *testing.T) {
 	require := require.New(t)
-	root, err := ioutil.TempDir("", "storage-")
-	require.NoError(err)
-	defer os.RemoveAll(root)
+	root := t.TempDir()
 
 	store, err := NewFSStore(root)
 	require.NoError(err)
@@ -69,9 +66,7 @@ func TestStorageAdd(t *testing.T) {
 
 func TestStorageAddSharable(t *testing.T) {
 	require := require.New(t)
-	root, err := ioutil.TempDir("", "storage-")
-	require.NoError(err)
-	defer os.RemoveAll(root)
+	root := t.TempDir()
 
 	store, err := NewFSStore(root)
 	require.NoError(err)
@@ -110,9 +105,7 @@ func TestStorageAddSharable(t *testing.T) {
 
 func TestStorageAddConflictingSharable(t *testing.T) {
 	require := require.New(t)
-	root, err := ioutil.TempDir("", "storage-")
-	require.NoError(err)
-	defer os.RemoveAll(root)
+	root := t.TempDir()
 
 	store, err := NewFSStore(root)
 	require.NoError(err)
@@ -164,9 +157,7 @@ func TestStorageAddConflictingSharable(t *testing.T) {
 
 func TestStorageSetSharable(t *testing.T) {
 	require := require.New(t)
-	root, err := ioutil.TempDir("", "storage-")
-	require.NoError(err)
-	defer os.RemoveAll(root)
+	root := t.TempDir()
 
 	store, err := NewFSStore(root)
 	require.NoError(err)
@@ -261,9 +252,7 @@ func TestStorageSetSharable(t *testing.T) {
 
 func TestStorageSet(t *testing.T) {
 	require := require.New(t)
-	root, err := ioutil.TempDir("", "storage-")
-	require.NoError(err)
-	defer os.RemoveAll(root)
+	root := t.TempDir()
 
 	store, err := NewFSStore(root)
 	require.NoError(err)
@@ -298,9 +287,7 @@ func TestStorageSet(t *testing.T) {
 
 func TestStorageGet(t *testing.T) {
 	require := require.New(t)
-	root, err := ioutil.TempDir("", "storage-")
-	require.NoError(err)
-	defer os.RemoveAll(root)
+	root := t.TempDir()
 
 	store, err := NewFSStore(root)
 	require.NoError(err)
@@ -332,9 +319,7 @@ func TestStorageGet(t *testing.T) {
 
 func TestStorageByTwin(t *testing.T) {
 	require := require.New(t)
-	root, err := ioutil.TempDir("", "storage-")
-	require.NoError(err)
-	defer os.RemoveAll(root)
+	root := t.TempDir()
 
 	store, err := NewFSStore(root)
 	require.NoError(err)

--- a/pkg/upgrade/upgrade_test.go
+++ b/pkg/upgrade/upgrade_test.go
@@ -1,7 +1,6 @@
 package upgrade
 
 import (
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"testing"
@@ -24,10 +23,7 @@ func TestUpgraderDownload(t *testing.T) {
 
 	store, err := up.getFlist(flist)
 	require.NoError(err)
-	tmp, err := ioutil.TempDir("", "download-*")
-
-	require.NoError(err)
-	defer os.RemoveAll(tmp)
+	tmp := t.TempDir()
 
 	err = up.copyRecursive(store, tmp)
 	require.NoError(err)


### PR DESCRIPTION
A testing cleanup. 

This pull request replaces `ioutil.TempDir` with `t.TempDir`. We can use the `T.TempDir` function from the `testing` package to create temporary directory. The directory created by `T.TempDir` is automatically removed when the test and all its subtests complete. 

Reference: https://pkg.go.dev/testing#T.TempDir

```go
func TestFoo(t *testing.T) {
	// before
	tmpDir, err := ioutil.TempDir("", "")
	if err != nil {
		panic(err)
	}
	defer os.RemoveAll(tmpDir)

	// now
	tmpDir := t.TempDir()
}
```