### PR TITLE
Modify the format validation of fqdn gateway backend

### DIFF
--- a/pkg/gateway/gateway.go
+++ b/pkg/gateway/gateway.go
@@ -571,8 +571,12 @@ func (g *gatewayModule) setupRouting(wlID string, fqdn string, backends []string
 			if err != nil {
 				return errors.Wrap(err, "couldn't parse backend host")
 			}
-			if u.Scheme != "https" {
-				return errors.New("enabling tls passthrough requires backends to have https scheme")
+			if u.Scheme != "" {
+				return errors.New("enabling tls passthrough requires backends to have no scheme")
+			}
+
+			if u.Port() == "" {
+				return errors.New("enabling tls passthrough requires backends to have a port")
 			}
 			servers[idx] = Server{
 				Address: u.Host,

--- a/pkg/gateway/gateway.go
+++ b/pkg/gateway/gateway.go
@@ -20,6 +20,7 @@ import (
 	"github.com/threefoldtech/zos/pkg"
 	"github.com/threefoldtech/zos/pkg/environment"
 	"github.com/threefoldtech/zos/pkg/gridtypes"
+	"github.com/threefoldtech/zos/pkg/gridtypes/zos"
 	"github.com/threefoldtech/zos/pkg/stubs"
 	"github.com/threefoldtech/zos/pkg/zinit"
 	"gopkg.in/yaml.v2"
@@ -566,17 +567,13 @@ func (g *gatewayModule) setupRouting(wlID string, fqdn string, backends []string
 	servers := make([]Server, len(backends))
 	for idx, backend := range backends {
 		if TLSPassthrough {
+			if err := zos.Backend(backend).Valid(true); err != nil {
+				return errors.Wrap(err, "couldn't validate backend host")
+			}
 			u, err := url.Parse(backend)
 			log.Debug().Str("hostname", u.Host).Str("backend", backend).Msg("tls passthrough")
 			if err != nil {
 				return errors.Wrap(err, "couldn't parse backend host")
-			}
-			if u.Scheme != "" {
-				return errors.New("enabling tls passthrough requires backends to have no scheme")
-			}
-
-			if u.Port() == "" {
-				return errors.New("enabling tls passthrough requires backends to have a port")
 			}
 			servers[idx] = Server{
 				Address: u.Host,

--- a/pkg/gridtypes/zos/gw_fqdn.go
+++ b/pkg/gridtypes/zos/gw_fqdn.go
@@ -30,10 +30,8 @@ func (b Backend) Valid(tls bool) error {
 		if u.Port() == "" {
 			return fmt.Errorf("missing port in backend address")
 		}
-	} else {
-		if u.Scheme != "http" {
-			return fmt.Errorf("scheme expected to be http")
-		}
+	} else if u.Scheme != "http" {
+		return fmt.Errorf("scheme expected to be http")
 	}
 
 	ip := net.ParseIP(u.Hostname())

--- a/pkg/gridtypes/zos/gw_fqdn.go
+++ b/pkg/gridtypes/zos/gw_fqdn.go
@@ -17,14 +17,20 @@ var (
 
 type Backend string
 
-// check if valid http://x.x.x.x:port or [::]:port
+// check if valid http://ip:port, http://ip or ip:port
 func (b Backend) Valid() error {
 	u, err := url.Parse(string(b))
 	if err != nil {
 		return errors.Wrap(err, "failed to parse backend")
 	}
-	if u.Scheme != "http" && u.Scheme != "https" {
-		return fmt.Errorf("invalid scheme expected http, or https")
+	if u.Scheme != "" {
+		if u.Scheme != "http" {
+			return fmt.Errorf("invalid scheme expected either http, or empty")
+		}
+	} else {
+		if u.Port() == "" {
+			return fmt.Errorf("backend missing either scheme or port")
+		}
 	}
 
 	ip := net.ParseIP(u.Hostname())

--- a/pkg/gridtypes/zos/gw_name.go
+++ b/pkg/gridtypes/zos/gw_name.go
@@ -28,7 +28,7 @@ func (g GatewayNameProxy) Valid(getter gridtypes.WorkloadGetter) error {
 		return fmt.Errorf("backends list can not be empty")
 	}
 	for _, backend := range g.Backends {
-		if err := backend.Valid(); err != nil {
+		if err := backend.Valid(g.TLSPassthrough); err != nil {
 			return errors.Wrapf(err, "failed to validate backend '%s'", backend)
 		}
 	}


### PR DESCRIPTION
These changes Ensure that the backend should be one of:
- URL, which must have a scheme as `HTTP` (in case we configuring HTTP service, atm this happens when tls_passthrough is false)
- Address, which must have a port included (in case we configuring TCP service, atm this happens when tls_passthrough is true)
 
 What's changed:
- Remove the validation that requires the scheme to be `HTTPS` when `tls_passthrough` is true.
- Return an error if the scheme is not empty and `tls_passthrough` is true
- Returns an error if the port wasn't provided  and `tls_passthrough` is true

Related Issue:
https://github.com/threefoldtech/zos/issues/1794
https://github.com/threefoldtech/zos/issues/1842
 