### PR TITLE
Don't re-add the reserved capacity to used memory

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -42,7 +42,7 @@ require (
 	github.com/shirou/gopsutil v3.21.11+incompatible
 	github.com/stretchr/testify v1.7.0
 	github.com/threefoldtech/0-fs v1.3.1-0.20201203163303-d963de9adea7
-	github.com/threefoldtech/rmb-sdk-go v0.0.0-20230208121945-1920816a9268
+	github.com/threefoldtech/rmb-sdk-go v0.0.0-20230214123537-4833a4e157e6
 	github.com/threefoldtech/substrate-client v0.1.2
 	github.com/threefoldtech/zbus v1.0.1
 	github.com/tyler-smith/go-bip39 v1.1.0
@@ -82,6 +82,7 @@ require (
 	github.com/gofrs/flock v0.8.1 // indirect
 	github.com/gogo/googleapis v1.4.1 // indirect
 	github.com/gogo/protobuf v1.3.2 // indirect
+	github.com/golang-jwt/jwt v3.2.2+incompatible // indirect
 	github.com/golang/groupcache v0.0.0-20210331224755-41bb18bfe9da // indirect
 	github.com/golang/protobuf v1.5.2 // indirect
 	github.com/golang/snappy v0.0.4 // indirect

--- a/go.sum
+++ b/go.sum
@@ -289,6 +289,8 @@ github.com/gogo/protobuf v1.2.1/go.mod h1:hp+jE20tsWTFYpLwKvXlhS1hjn+gTNwPg2I6zV
 github.com/gogo/protobuf v1.3.1/go.mod h1:SlYgWuQ5SjCEi6WLHjHCa1yvBfUnHcTbrrZtXPKa29o=
 github.com/gogo/protobuf v1.3.2 h1:Ov1cvc58UF3b5XjBnZv7+opcTcQFZebYjWzi34vdm4Q=
 github.com/gogo/protobuf v1.3.2/go.mod h1:P1XiOD3dCwIKUDQYPy72D8LYyHL2YPYrpS2s69NZV8Q=
+github.com/golang-jwt/jwt v3.2.2+incompatible h1:IfV12K8xAKAnZqdXVzCZ+TOjboZ2keLg81eXfW3O+oY=
+github.com/golang-jwt/jwt v3.2.2+incompatible/go.mod h1:8pz2t5EyA70fFQQSrl6XZXzqecmYZeUEB8OUGHkxJ+I=
 github.com/golang-jwt/jwt/v4 v4.3.0/go.mod h1:/xlHOz8bRuivTWchD4jCa+NbatV+wEUSzwAxVc6locg=
 github.com/golang/freetype v0.0.0-20170609003504-e2365dfdc4a0/go.mod h1:E/TSTwGwJL78qG/PmXZO1EjYhfJinVAhrmmHX6Z8B9k=
 github.com/golang/geo v0.0.0-20190916061304-5b978397cfec/go.mod h1:QZ0nwyI2jOfgRAoBvP+ab5aRr7c9x7lhGEJrKvBwjWI=
@@ -744,6 +746,8 @@ github.com/threefoldtech/go-substrate-rpc-client/v4 v4.0.6-0.20230102154731-7c63
 github.com/threefoldtech/go-substrate-rpc-client/v4 v4.0.6-0.20230102154731-7c633b7d3c71/go.mod h1:5g1oM4Zu3BOaLpsKQ+O8PAv2kNuq+kPcA1VzFbsSqxE=
 github.com/threefoldtech/rmb-sdk-go v0.0.0-20230208121945-1920816a9268 h1:HL0WRgjKn18az5pDDD9XEFkeMTBB1lWJGBF+5Cb8LLg=
 github.com/threefoldtech/rmb-sdk-go v0.0.0-20230208121945-1920816a9268/go.mod h1:ddt04wNV0lkrfijSa1x2nbEoyBO41WO0B0BFLIeP6Mg=
+github.com/threefoldtech/rmb-sdk-go v0.0.0-20230214123537-4833a4e157e6 h1:TCWsrRzpnqSUvwtDLyM/b3FiSh8LBiBL7/uByAbSKu8=
+github.com/threefoldtech/rmb-sdk-go v0.0.0-20230214123537-4833a4e157e6/go.mod h1:ddt04wNV0lkrfijSa1x2nbEoyBO41WO0B0BFLIeP6Mg=
 github.com/threefoldtech/substrate-client v0.1.2 h1:9Xl13AYaspViKSjII18NgJWdA/9c0aLKuaWR38RpP7I=
 github.com/threefoldtech/substrate-client v0.1.2/go.mod h1:ys/GJLeLmNX8E36UFMeR0yZC5Lo4PufYtfwsVX8H/AM=
 github.com/threefoldtech/zbus v1.0.1 h1:3KaEpyOiDYAw+lrAyoQUGIvY9BcjVRXlQ1beBRqhRNk=

--- a/pkg/primitives/statistics.go
+++ b/pkg/primitives/statistics.go
@@ -90,17 +90,20 @@ func (s *Statistics) getUsableMemoryBytes() (gridtypes.Capacity, gridtypes.Unit,
 		return cap, 0, err
 	}
 
+	log.Debug().Msgf("active capacity on the node: %+v", cap)
 	m, err := mem.VirtualMemory()
 	if err != nil {
 		return cap, 0, err
 	}
 
 	theoreticalUsed := cap.MRU
-	actualUsed := (m.Total - m.Available) + uint64(s.reserved.MRU)
-
+	log.Debug().Uint64("used", uint64(theoreticalUsed)).Msg("theoretical used")
+	actualUsed := m.Total - m.Available
+	log.Debug().Uint64("used", uint64(actualUsed)).Msg("actual used")
 	used := gridtypes.Max(theoreticalUsed, gridtypes.Unit(actualUsed))
 
 	usable := gridtypes.Unit(m.Total) - used
+	log.Debug().Uint64("usable", uint64(usable)).Msg("usable by new")
 	return cap, usable, nil
 }
 

--- a/pkg/primitives/statistics.go
+++ b/pkg/primitives/statistics.go
@@ -90,20 +90,16 @@ func (s *Statistics) getUsableMemoryBytes() (gridtypes.Capacity, gridtypes.Unit,
 		return cap, 0, err
 	}
 
-	log.Debug().Msgf("active capacity on the node: %+v", cap)
 	m, err := mem.VirtualMemory()
 	if err != nil {
 		return cap, 0, err
 	}
 
 	theoreticalUsed := cap.MRU
-	log.Debug().Uint64("used", uint64(theoreticalUsed)).Msg("theoretical used")
 	actualUsed := m.Total - m.Available
-	log.Debug().Uint64("used", uint64(actualUsed)).Msg("actual used")
 	used := gridtypes.Max(theoreticalUsed, gridtypes.Unit(actualUsed))
 
 	usable := gridtypes.Unit(m.Total) - used
-	log.Debug().Uint64("usable", uint64(usable)).Msg("usable by new")
 	return cap, usable, nil
 }
 


### PR DESCRIPTION
We use to add the reserved system capacity the actual used capacity. this causes double usage of the reserved because software that is already running has been already added. 

Hence we only add reserved to the user workloads capacity. then take the maximum of both. 