### PR TITLE
return pools capacity

### DIFF
--- a/client/node.go
+++ b/client/node.go
@@ -186,6 +186,13 @@ func (n *NodeClient) Counters(ctx context.Context) (total gridtypes.Capacity, us
 	return result.Total, result.Used, result.System, nil
 }
 
+// Pools returns statistics of separate pools
+func (n *NodeClient) Pools(ctx context.Context) (pools []pkg.PoolMetrics, err error) {
+	const cmd = "zos.storage.pools"
+	err = n.bus.Call(ctx, n.nodeTwin, cmd, nil, &pools)
+	return
+}
+
 // NetworkListWGPorts return a list of all "taken" ports on the node. A new deployment
 // should be careful to use a free port for its network setup.
 func (n *NodeClient) NetworkListWGPorts(ctx context.Context) ([]uint16, error) {

--- a/cmds/modules/provisiond/main.go
+++ b/cmds/modules/provisiond/main.go
@@ -395,6 +395,8 @@ func action(cli *cli.Context) error {
 		return errors.Wrap(err, "failed to create statistics api")
 	}
 
+	setupStorageRmb(zosRouter, cl)
+
 	_ = mbus.NewDeploymentMessageBus(zosRouter, engine)
 
 	log.Info().Msg("running rmb handler")
@@ -426,4 +428,12 @@ func getNodeReserved(cl zbus.Client, available gridtypes.Capacity) (counter grid
 	)
 
 	return
+}
+
+func setupStorageRmb(router rmb.Router, cl zbus.Client) {
+	storage := router.Subroute("storage")
+	storage.WithHandler("pools", func(ctx context.Context, payload []byte) (interface{}, error) {
+		stub := stubs.NewStorageModuleStub(cl)
+		return stub.Metrics(ctx)
+	})
 }

--- a/docs/manual/api.md
+++ b/docs/manual/api.md
@@ -65,6 +65,23 @@ Capacity {
 
 > Note that, `used` capacity equal the full workload reserved capacity PLUS the system reserved capacity
 so `used = user_used + system`, while `system` is only the amount of resourced reserved by `zos` itself
+
+# Storage
+## List separate pools with capacity
+| command |body| return|
+|---|---|---|
+| `zos.storage.pools` | - |`[]Pool`|
+
+List all node pools with their types, size and used space
+where
+```json
+Pool {
+    "name": "pool-id",
+    "type": "(ssd|hdd)",
+    "size": <size in bytes>,
+    "used": <used in bytes>
+}
+```
 # Network
 ## List Wireguard Ports
 | command |body| return|

--- a/go.mod
+++ b/go.mod
@@ -70,6 +70,7 @@ require (
 	github.com/coreos/go-iptables v0.6.0 // indirect
 	github.com/cosmos/go-bip39 v1.0.0 // indirect
 	github.com/cpuguy83/go-md2man/v2 v2.0.0 // indirect
+	github.com/dave/jennifer v1.3.0 // indirect
 	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/decred/dcrd/crypto/blake256 v1.0.0 // indirect
 	github.com/decred/dcrd/dcrec/secp256k1/v3 v3.0.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -182,6 +182,7 @@ github.com/d2g/dhcp4client v1.0.0/go.mod h1:j0hNfjhrt2SxUOw55nL0ATM/z4Yt3t2Kd1mW
 github.com/d2g/dhcp4server v0.0.0-20181031114812-7d4a0a7f59a5/go.mod h1:Eo87+Kg/IX2hfWJfwxMzLyuSZyxSoAug2nGa1G2QAi8=
 github.com/d2g/hardwareaddr v0.0.0-20190221164911-e7d9fbe030e4/go.mod h1:bMl4RjIciD2oAxI7DmWRx6gbeqrkoLqv3MV0vzNad+I=
 github.com/dave/jennifer v1.2.0/go.mod h1:fIb+770HOpJ2fmN9EPPKOqm1vMGhB+TwXKMZhrIygKg=
+github.com/dave/jennifer v1.3.0 h1:p3tl41zjjCZTNBytMwrUuiAnherNUZktlhPTKoF/sEk=
 github.com/dave/jennifer v1.3.0/go.mod h1:fIb+770HOpJ2fmN9EPPKOqm1vMGhB+TwXKMZhrIygKg=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=

--- a/pkg/gridtypes/workload.go
+++ b/pkg/gridtypes/workload.go
@@ -194,6 +194,10 @@ func (w *Workload) Challenge(i io.Writer) error {
 		return err
 	}
 
+	if _, err := fmt.Fprintf(i, "%s", w.Name); err != nil {
+		return err
+	}
+
 	if _, err := fmt.Fprintf(i, "%s", w.Type.String()); err != nil {
 		return err
 	}

--- a/pkg/primitives/zdb/zdb.go
+++ b/pkg/primitives/zdb/zdb.go
@@ -172,20 +172,13 @@ func (p *Manager) zdbProvisionImpl(ctx context.Context, wl *gridtypes.WorkloadWi
 			}, nil
 		}
 
-		// we did not find the namespace, but is this container
-		// a possible candidate to hold the new namespace?
-		reserved, err := index.Reserved()
-		if err != nil {
-			return zos.ZDBResult{}, errors.Wrap(err, "failed to check total reserved size")
-		}
-
 		device, err := storage.DeviceLookup(ctx, container.Name)
 		if err != nil {
 			log.Error().Err(err).Str("container", string(id)).Msg("failed to inspect zdb device")
 			continue
 		}
 
-		if reserved+uint64(config.Size) <= uint64(device.Usage.Size) {
+		if uint64(device.Usage.Used)+uint64(config.Size) <= uint64(device.Usage.Size) {
 			candidates = append(candidates, container)
 		}
 	}

--- a/pkg/storage.go
+++ b/pkg/storage.go
@@ -153,6 +153,16 @@ type StorageModule interface {
 
 	// DeviceLookup inspects a previously allocated device
 	DeviceLookup(name string) (Device, error)
+
+	// Capacity
+	Metrics() ([]PoolMetrics, error)
+}
+
+type PoolMetrics struct {
+	Name string         `json:"name"`
+	Type DeviceType     `json:"type"`
+	Size gridtypes.Unit `json:"size"`
+	Used gridtypes.Unit `json:"used"`
 }
 
 // VDisk info returned by a call to inspect

--- a/pkg/storage/filesystem/btrfs.go
+++ b/pkg/storage/filesystem/btrfs.go
@@ -367,7 +367,8 @@ func (v *btrfsVolume) Usage() (usage Usage, err error) {
 	if used == 0 {
 		// in case no limit is set on the subvolume, we assume
 		// it's size is the size of the files on that volumes
-		used, err = FilesUsage(v.Path())
+		// or a special case when the volume is a zdb volume
+		used, err = volumeUsage(v.Path())
 		if err != nil {
 			return usage, errors.Wrap(err, "failed to get subvolume usage")
 		}

--- a/pkg/stubs/storage_stub.go
+++ b/pkg/stubs/storage_stub.go
@@ -258,6 +258,23 @@ func (s *StorageModuleStub) DiskWrite(ctx context.Context, arg0 string, arg1 str
 	return
 }
 
+func (s *StorageModuleStub) Metrics(ctx context.Context) (ret0 []pkg.PoolMetrics, ret1 error) {
+	args := []interface{}{}
+	result, err := s.client.RequestContext(ctx, s.module, s.object, "Metrics", args...)
+	if err != nil {
+		panic(err)
+	}
+	result.PanicOnError()
+	ret1 = result.CallError()
+	loader := zbus.Loader{
+		&ret0,
+	}
+	if err := result.Unmarshal(&loader); err != nil {
+		panic(err)
+	}
+	return
+}
+
 func (s *StorageModuleStub) Monitor(ctx context.Context) (<-chan pkg.PoolsStats, error) {
 	ch := make(chan pkg.PoolsStats, 1)
 	recv, err := s.client.Stream(ctx, s.module, s.object, "Monitor")

--- a/pkg/upgrade/hub_test.go
+++ b/pkg/upgrade/hub_test.go
@@ -42,7 +42,7 @@ func TestInfo(t *testing.T) {
 }
 
 func TestInfoGet(t *testing.T) {
-	const flist = "tf-zos/zos:0.1.0-rc1.flist"
+	const flist = "tf-zos/zos:development-3:latest.flist"
 
 	var hub HubClient
 	info, err := hub.Info(flist)

--- a/pkg/upgrade/hub_test.go
+++ b/pkg/upgrade/hub_test.go
@@ -42,7 +42,7 @@ func TestInfo(t *testing.T) {
 }
 
 func TestInfoGet(t *testing.T) {
-	const flist = "tf-zos/zos:development-3:latest.flist"
+	const flist = "thabet/redis.flist"
 
 	var hub HubClient
 	info, err := hub.Info(flist)


### PR DESCRIPTION
Add an external api over rmb to return the node pools, and their total size and used capacity for each pool. the idea is to make it easier to do capacity planning knowing the available space per pool