### PR TITLE
Implement a clean close or rrd database

### DIFF
--- a/cmds/modules/provisiond/reporter.go
+++ b/cmds/modules/provisiond/reporter.go
@@ -43,6 +43,15 @@ func reportBuilder() interface{} {
 	return &Report{}
 }
 
+func ReportChecks(metricsPath string) error {
+	rrd, err := rrd.NewRRDBolt(metricsPath, 5*time.Minute, 24*time.Hour)
+	if err != nil {
+		return errors.Wrap(err, "failed to create metrics database")
+	}
+
+	return rrd.Close()
+}
+
 // NewReporter creates a new capacity reporter
 func NewReporter(metricsPath string, cl zbus.Client, root string) (*Reporter, error) {
 	idMgr := stubs.NewIdentityManagerStub(cl)
@@ -282,6 +291,11 @@ func (r *Reporter) getLastReportTime() (int64, bool, error) {
 		return 0, false, errors.Wrap(err, "failed to get timestamp of last report")
 	}
 	return int64(stored), ok, nil
+}
+
+func (r *Reporter) Close() {
+	_ = r.rrd.Close()
+	_ = r.queue.Close()
 }
 
 // Run runs the reporter

--- a/pkg/rrd/rrd.go
+++ b/pkg/rrd/rrd.go
@@ -23,6 +23,9 @@ type RRD interface {
 	// Last returns the last reported value for a metric given the metric
 	// name
 	Last(key string) (value float64, ok bool, err error)
+
+	// Close the db
+	Close() error
 }
 
 type Printer interface {
@@ -84,6 +87,10 @@ func newRRDBolt(path string, window time.Duration, retention time.Duration) (*rr
 		window:    uint64(window / time.Second),
 		retention: uint64(retention / time.Second),
 	}, nil
+}
+
+func (r *rrdBolt) Close() error {
+	return r.db.Close()
 }
 
 func (r *rrdBolt) printBucket(bucket *bolt.Bucket, out io.Writer) error {


### PR DESCRIPTION
Also fix corrupt db files by deleting the corrupt db the detection is done indirectly by running an integrity check in a separate process because the corrupt db causes a SIGBUS