### PR TITLE
Gateway private network

### DIFF
--- a/bins/packages/nnc/nnc.sh
+++ b/bins/packages/nnc/nnc.sh
@@ -1,0 +1,33 @@
+NNC_VERSION="1.0.0-rc2"
+NNC_CHECKSUM="7fbadaae30c19b79e6348bf1bd1d29fc"
+NNC_LINK="https://github.com/threefoldtech/nnc/releases/download/v${NNC_VERSION}/nnc"
+
+download_nnc() {
+    echo "download nnc"
+    download_file ${NNC_LINK} ${NNC_CHECKSUM} nnc-peer
+}
+
+prepare_nnc() {
+    echo "[+] prepare nnc"
+    github_name "nnc-${NNC_VERSION}"
+}
+
+install_nnc() {
+    echo "[+] install nnc"
+
+    mkdir -p "${ROOTDIR}/bin"
+
+    cp ${DISTDIR}/nnc-peer ${ROOTDIR}/bin/nnc
+    chmod +x ${ROOTDIR}/bin/*
+    strip ${ROOTDIR}/bin/*
+}
+
+build_nnc() {
+    pushd "${DISTDIR}"
+
+    download_nnc
+    popd
+
+    prepare_nnc
+    install_nnc
+}

--- a/docs/architecture/decisions/0004-gateway-over-wireguard.md
+++ b/docs/architecture/decisions/0004-gateway-over-wireguard.md
@@ -1,0 +1,24 @@
+# 1. Record architecture decisions
+
+Date: 2023-03-14
+
+## Status
+
+Accepted
+
+## Context
+
+Support gateway over user private wireguard. This means private workloads can be exposed (over the gateway) without using
+yggdrasil.
+
+Users can accomplish this by adding the gateway node to their network (can also act as an access-point) then while configuring
+the gateway they need to set the network name.
+
+## Decision
+
+- User can provide a private ip to the target (backend) now for gateway workloads
+- User has to include the gateway node into his network
+- Gateway workload has to include network name where the ip lives
+- Backward compatible with old configuration. backend still can be over yggdrail
+
+## Consequences

--- a/pkg/gateway.go
+++ b/pkg/gateway.go
@@ -1,5 +1,7 @@
 package pkg
 
+import "github.com/threefoldtech/zos/pkg/gridtypes/zos"
+
 //go:generate mkdir -p stubs
 
 //go:generate zbusc -module gateway -version 0.0.1 -name manager -package stubs github.com/threefoldtech/zos/pkg+Gateway stubs/gateway_stub.go
@@ -22,8 +24,8 @@ func (m *GatewayMetrics) Nu(service string) (result uint64) {
 }
 
 type Gateway interface {
-	SetNamedProxy(wlID string, prefix string, backends []string, TLSPassthrough bool, twinID uint32) (string, error)
-	SetFQDNProxy(wlID string, fqdn string, backends []string, TLSPassthrough bool) error
+	SetNamedProxy(wlID string, config zos.GatewayNameProxy) (string, error)
+	SetFQDNProxy(wlID string, config zos.GatewayFQDNProxy) error
 	DeleteNamedProxy(wlID string) error
 	Metrics() (GatewayMetrics, error)
 }

--- a/pkg/gateway/gateway.go
+++ b/pkg/gateway/gateway.go
@@ -37,6 +37,10 @@ const (
 	httpCertResolver = "resolver"
 	dnsCertResolver  = "dnsresolver"
 	validationPeriod = 1 * time.Hour
+
+	configDir = "proxy"
+	metaDir   = "traefik"
+	zinitDir  = "zinit"
 )
 
 var (
@@ -48,6 +52,7 @@ var (
 )
 
 type gatewayModule struct {
+	root     string
 	cl       zbus.Client
 	resolver *net.Resolver
 	sub      substrate.Manager
@@ -55,7 +60,7 @@ type gatewayModule struct {
 	reservedDomains map[string]string
 	domainLock      sync.RWMutex
 
-	proxyConfigPath  string
+	//proxyConfigPath  string
 	staticConfigPath string
 	binPath          string
 	certScriptPath   string
@@ -164,18 +169,14 @@ func loadDomains(ctx context.Context, dir string) (map[string]string, error) {
 }
 func New(ctx context.Context, cl zbus.Client, root string) (pkg.Gateway, error) {
 	// where should service-restart/node-reboot recovery be handled?
+	for _, dir := range []string{configDir, metaDir, zinitDir} {
+		dir = filepath.Join(root, dir)
+		if err := os.MkdirAll(dir, 0644); err != nil {
+			return nil, errors.Wrapf(err, "failed to create directory '%s'", dir)
+		}
+	}
+
 	configPath := filepath.Join(root, "proxy")
-	err := os.MkdirAll(configPath, 0644)
-	if err != nil {
-		return nil, errors.Wrap(err, "couldn't make gateway config dir")
-	}
-
-	traefikMetadata := filepath.Join(root, "traefik")
-	err = os.MkdirAll(traefikMetadata, 0644)
-	if err != nil {
-		return nil, errors.Wrap(err, "couldn't make traefik metadata directory")
-	}
-
 	bin, err := ensureTraefikBin(ctx, cl)
 	if err != nil {
 		return nil, errors.Wrap(err, "failed to ensure traefik binary")
@@ -218,7 +219,7 @@ func New(ctx context.Context, cl zbus.Client, root string) (pkg.Gateway, error) 
 		cl:               cl,
 		resolver:         r,
 		sub:              sub,
-		proxyConfigPath:  configPath,
+		root:             root,
 		staticConfigPath: staticCfgPath,
 		certScriptPath:   certScriptPath,
 		binPath:          bin,
@@ -463,7 +464,7 @@ func (g *gatewayModule) startTraefik(z *zinit.Client) error {
 }
 
 func (g *gatewayModule) configPath(name string) string {
-	return filepath.Join(g.proxyConfigPath, fmt.Sprintf("%s.yaml", name))
+	return filepath.Join(g.root, configDir, fmt.Sprintf("%s.yaml", name))
 }
 
 func (g *gatewayModule) validateNameContract(name string, twinID uint32) error {
@@ -499,6 +500,10 @@ func (g *gatewayModule) SetNamedProxy(wlID string, config zos.GatewayNameProxy) 
 	ctx, cancel := context.WithTimeout(context.Background(), 1*time.Minute)
 	defer cancel()
 
+	if len(config.Backends) != 1 {
+		return "", fmt.Errorf("only one backend is supported got '%d'", len(config.Backends))
+	}
+
 	twinID, _, _, err := gridtypes.WorkloadID(wlID).Parts()
 	if err != nil {
 		return "", errors.Wrap(err, "invalid workload id")
@@ -525,16 +530,20 @@ func (g *gatewayModule) SetNamedProxy(wlID string, config zos.GatewayNameProxy) 
 		},
 	}
 
-	if err := g.setupRouting(wlID, fqdn, config.Backends, gatewayTLSConfig, config.TLSPassthrough); err != nil {
+	if err := g.setupRouting(ctx, wlID, fqdn, gatewayTLSConfig, config.GatewayBase); err != nil {
 		return "", err
-	} else {
-		return fqdn, nil
 	}
+
+	return fqdn, nil
 }
 
 func (g *gatewayModule) SetFQDNProxy(wlID string, config zos.GatewayFQDNProxy) error {
 	ctx, cancel := context.WithTimeout(context.Background(), 1*time.Minute)
 	defer cancel()
+
+	if len(config.Backends) != 1 {
+		return fmt.Errorf("only one backend is supported got '%d'", len(config.Backends))
+	}
 
 	cfg, err := g.ensureGateway(ctx, false)
 	if err != nil {
@@ -555,15 +564,60 @@ func (g *gatewayModule) SetFQDNProxy(wlID string, config zos.GatewayFQDNProxy) e
 			},
 		},
 	}
-	return g.setupRouting(wlID, config.FQDN, config.Backends, gatewayTLSConfig, config.TLSPassthrough)
+
+	return g.setupRouting(ctx, wlID, config.FQDN, gatewayTLSConfig, config.GatewayBase)
 }
-func (g *gatewayModule) setupRouting(wlID string, fqdn string, backends []zos.Backend, tlsConfig TlsConfig, TLSPassthrough bool) error {
+
+func (g *gatewayModule) setupRouting(ctx context.Context, wlID string, fqdn string, tlsConfig TlsConfig, config zos.GatewayBase) error {
+	backend := config.Backends[0]
+
+	if err := zos.Backend(backend).Valid(config.TLSPassthrough); err != nil {
+		return errors.Wrapf(err, "failed to validate backend '%s'", backend)
+	}
+
 	if _, ok := g.getReservedDomain(fqdn); ok {
 		return errors.New("domain already registered")
 	}
 
+	if config.Network == nil {
+		// not going over user private network
+		return g.setupRoutingGeneric(wlID, fqdn, tlsConfig, config)
+	}
+
+	// otherwise we need to configure a nnc process
+	// to forward the user traffic.
+
+	// first validate that network exist and get the network namespace
+	twinID, _, _, err := gridtypes.WorkloadID(wlID).Parts()
+	if err != nil {
+		return errors.Wrap(err, "invalid workload id")
+	}
+	// if network is set, means this ip need to be reached from inside the user NR
+	net := stubs.NewNetworkerStub(g.cl)
+	netID := zos.NetworkID(twinID, *config.Network)
+	if _, err := net.GetNet(ctx, netID); err != nil {
+		return errors.Wrap(err, "failed to get user network")
+	}
+	ns := net.Namespace(ctx, netID)
+	backend, err = g.nncEnsure(wlID, ns, config.Backends[0])
+	if err != nil {
+		return errors.Wrap(err, "failed to ensure local gateway")
+	}
+
+	if !config.TLSPassthrough {
+		// if tls passthrough is disabled traefik expecting backend
+		// to be in the format http://<ip>:port
+		backend = zos.Backend(fmt.Sprintf("http://%s", backend))
+	}
+
+	config.Backends = []zos.Backend{backend}
+	return g.setupRoutingGeneric(wlID, fqdn, tlsConfig, config)
+}
+
+func (g *gatewayModule) setupRoutingGeneric(wlID string, fqdn string, tlsConfig TlsConfig, config zos.GatewayBase) error {
+	backend := config.Backends[0]
 	var rule string
-	if TLSPassthrough {
+	if config.TLSPassthrough {
 		rule = fmt.Sprintf("HostSNI(`%s`)", fqdn)
 		tlsConfig = TlsConfig{
 			Passthrough: "true",
@@ -571,17 +625,14 @@ func (g *gatewayModule) setupRouting(wlID string, fqdn string, backends []zos.Ba
 	} else {
 		rule = fmt.Sprintf("Host(`%s`)", fqdn)
 	}
-	servers := make([]Server, len(backends))
-	for idx, backend := range backends {
-		if err := zos.Backend(backend).Valid(TLSPassthrough); err != nil {
-			return errors.Wrapf(err, "failed to validate backend '%s'", backend)
-		}
-		if TLSPassthrough {
-			servers[idx] = Server{Address: string(backend)}
-		} else {
-			servers[idx] = Server{Url: string(backend)}
-		}
+
+	var server Server
+	if config.TLSPassthrough {
+		server = Server{Address: string(backend)}
+	} else {
+		server = Server{Url: string(backend)}
 	}
+
 	route := fmt.Sprintf("%s-route", wlID)
 	proxyConfig := ProxyConfig{}
 
@@ -596,12 +647,12 @@ func (g *gatewayModule) setupRouting(wlID string, fqdn string, backends []zos.Ba
 		Services: map[string]Service{
 			wlID: {
 				LoadBalancer: LoadBalancer{
-					Servers: servers,
+					Servers: []Server{server},
 				},
 			},
 		},
 	}
-	if TLSPassthrough {
+	if config.TLSPassthrough {
 		proxyConfig.TCP = routingconfig
 	} else {
 		proxyConfig.Http = routingconfig
@@ -619,6 +670,8 @@ func (g *gatewayModule) setupRouting(wlID string, fqdn string, backends []zos.Ba
 }
 
 func (g *gatewayModule) DeleteNamedProxy(wlID string) error {
+	g.destroyNNC(wlID)
+
 	path := g.configPath(wlID)
 	_, domain, err := domainFromConfig(path)
 	if os.IsNotExist(err) {

--- a/pkg/gateway/gateway.go
+++ b/pkg/gateway/gateway.go
@@ -3,6 +3,7 @@ package gateway
 import (
 	"context"
 	"fmt"
+	"io"
 	"net"
 	"os"
 	"path/filepath"
@@ -16,6 +17,7 @@ import (
 	"github.com/threefoldtech/substrate-client"
 	"github.com/threefoldtech/zbus"
 	"github.com/threefoldtech/zos/pkg"
+	"github.com/threefoldtech/zos/pkg/cache"
 	"github.com/threefoldtech/zos/pkg/environment"
 	"github.com/threefoldtech/zos/pkg/gridtypes"
 	"github.com/threefoldtech/zos/pkg/gridtypes/zos"
@@ -31,8 +33,8 @@ var (
 
 const (
 	traefikService = "traefik"
-	// letsencrypt email need to customizable by he farmer.
-	letsencryptEmail = "letsencrypt@threefold.tech"
+	// letsEncryptEmail email need to customizable by he farmer.
+	letsEncryptEmail = "letsencrypt@threefold.tech"
 	// certResolver must match the one defined in static config
 	httpCertResolver = "resolver"
 	dnsCertResolver  = "dnsresolver"
@@ -52,7 +54,7 @@ var (
 )
 
 type gatewayModule struct {
-	root     string
+	volatile string
 	cl       zbus.Client
 	resolver *net.Resolver
 	sub      substrate.Manager
@@ -167,16 +169,84 @@ func loadDomains(ctx context.Context, dir string) (map[string]string, error) {
 	}
 	return domains, nil
 }
+
+// migration moves config that was on persisted storage
+// to volatile storage.
+// gateway should NOT persist config because on node reboot
+// the gw config files are re-created anyway.
+func migrateFiles(root, volatile string) error {
+	// need to move any files from root/proxy to volatile/proxy
+	source := filepath.Join(root, configDir)
+	dest := filepath.Join(volatile, configDir)
+	entries, err := os.ReadDir(source)
+	if os.IsNotExist(err) {
+		return nil
+	} else if err != nil {
+		return err
+	}
+
+	move := func(source, dest string) error {
+		src, err := os.Open(source)
+		if err != nil {
+			return err
+		}
+		defer src.Close()
+		dst, err := os.Create(dest)
+		if err != nil {
+			return err
+		}
+		defer dst.Close()
+		_, err = io.Copy(dst, src)
+		return err
+	}
+
+	for _, entry := range entries {
+		if entry.IsDir() {
+			continue
+		}
+
+		old := filepath.Join(source, entry.Name())
+		new := filepath.Join(dest, entry.Name())
+		if err := move(old, new); err != nil {
+			log.Error().Err(err).Str("name", entry.Name()).Msg("failed to migrate gw config")
+			continue
+		}
+		if err := os.Remove(old); err != nil {
+			log.Error().Err(err).Str("name", entry.Name()).Msg("failed to remove old gw config")
+		}
+	}
+
+	return nil
+}
+
 func New(ctx context.Context, cl zbus.Client, root string) (pkg.Gateway, error) {
 	// where should service-restart/node-reboot recovery be handled?
-	for _, dir := range []string{configDir, metaDir, zinitDir} {
+	volatile, err := cache.VolatileDir("gateway", 10*cache.Megabyte)
+	if err != nil && !os.IsExist(err) {
+		return nil, fmt.Errorf("failed to create gateway cache directory: %w", err)
+	}
+
+	// create persisted directories
+	for _, dir := range []string{metaDir} {
 		dir = filepath.Join(root, dir)
 		if err := os.MkdirAll(dir, 0644); err != nil {
 			return nil, errors.Wrapf(err, "failed to create directory '%s'", dir)
 		}
 	}
 
-	configPath := filepath.Join(root, "proxy")
+	// create volatile directories
+	for _, dir := range []string{configDir, zinitDir} {
+		dir = filepath.Join(volatile, dir)
+		if err := os.MkdirAll(dir, 0644); err != nil {
+			return nil, errors.Wrapf(err, "failed to create directory '%s'", dir)
+		}
+	}
+
+	// (migration goes here)
+	if err := migrateFiles(root, volatile); err != nil {
+		log.Error().Err(err).Msg("failed doing gateway config migration")
+	}
+
 	bin, err := ensureTraefikBin(ctx, cl)
 	if err != nil {
 		return nil, errors.Wrap(err, "failed to ensure traefik binary")
@@ -193,11 +263,13 @@ func New(ctx context.Context, cl zbus.Client, root string) (pkg.Gateway, error) 
 		return nil, errors.Wrap(err, "failed to create cert script")
 	}
 	staticCfgPath := filepath.Join(root, "traefik.yaml")
-	updated, err := staticConfig(staticCfgPath, root, letsencryptEmail)
+	updated, err := staticConfig(staticCfgPath, root, volatile, letsEncryptEmail)
 	if err != nil {
 		return nil, errors.Wrap(err, "failed to create static config")
 	}
-	r := &net.Resolver{
+
+	// we create the resolver to avoid the cache
+	resolver := &net.Resolver{
 		PreferGo: true,
 		Dial: func(ctx context.Context, network, address string) (net.Conn, error) {
 			d := net.Dialer{
@@ -206,7 +278,8 @@ func New(ctx context.Context, cl zbus.Client, root string) (pkg.Gateway, error) 
 			return d.DialContext(ctx, network, "8.8.8.8:53")
 		},
 	}
-	domains, err := loadDomains(ctx, configPath)
+
+	domains, err := loadDomains(ctx, filepath.Join(volatile, configDir))
 	if err != nil {
 		return nil, errors.Wrap(err, "failed to load old domains")
 	}
@@ -217,9 +290,9 @@ func New(ctx context.Context, cl zbus.Client, root string) (pkg.Gateway, error) 
 
 	gw := &gatewayModule{
 		cl:               cl,
-		resolver:         r,
+		resolver:         resolver,
 		sub:              sub,
-		root:             root,
+		volatile:         volatile,
 		staticConfigPath: staticCfgPath,
 		certScriptPath:   certScriptPath,
 		binPath:          bin,
@@ -238,15 +311,11 @@ func New(ctx context.Context, cl zbus.Client, root string) (pkg.Gateway, error) 
 }
 
 func (g *gatewayModule) getReservedDomain(domain string) (string, bool) {
-	g.domainLock.RLock()
-	defer g.domainLock.RUnlock()
 	v, ok := g.reservedDomains[domain]
 	return v, ok
 }
 
 func (g *gatewayModule) setReservedDomain(domain string, wlID string) {
-	g.domainLock.Lock()
-	defer g.domainLock.Unlock()
 	log.Debug().
 		Str("domain", domain).
 		Str("wlID", wlID).
@@ -255,8 +324,6 @@ func (g *gatewayModule) setReservedDomain(domain string, wlID string) {
 }
 
 func (g *gatewayModule) deleteReservedDomain(domain string) {
-	g.domainLock.Lock()
-	defer g.domainLock.Unlock()
 	log.Debug().
 		Str("domain", domain).
 		Msg("deleting domain")
@@ -264,8 +331,9 @@ func (g *gatewayModule) deleteReservedDomain(domain string) {
 }
 
 func (g *gatewayModule) copyReservedDomain() map[string]string {
-	g.domainLock.RLock()
-	defer g.domainLock.RUnlock()
+	g.domainLock.Lock()
+	defer g.domainLock.Unlock()
+
 	res := make(map[string]string, len(g.reservedDomains))
 	for k, v := range g.reservedDomains {
 		res[k] = v
@@ -291,6 +359,7 @@ func (g *gatewayModule) validateNameContracts() error {
 		return nil
 	}
 	reservedDomains := g.copyReservedDomain()
+
 	for domain, id := range reservedDomains {
 		wlID := gridtypes.WorkloadID(id)
 		twinID, _, _, err := wlID.Parts()
@@ -464,7 +533,7 @@ func (g *gatewayModule) startTraefik(z *zinit.Client) error {
 }
 
 func (g *gatewayModule) configPath(name string) string {
-	return filepath.Join(g.root, configDir, fmt.Sprintf("%s.yaml", name))
+	return filepath.Join(g.volatile, configDir, fmt.Sprintf("%s.yaml", name))
 }
 
 func (g *gatewayModule) validateNameContract(name string, twinID uint32) error {
@@ -569,6 +638,9 @@ func (g *gatewayModule) SetFQDNProxy(wlID string, config zos.GatewayFQDNProxy) e
 }
 
 func (g *gatewayModule) setupRouting(ctx context.Context, wlID string, fqdn string, tlsConfig TlsConfig, config zos.GatewayBase) error {
+	g.domainLock.Lock()
+	defer g.domainLock.Unlock()
+
 	backend := config.Backends[0]
 
 	if err := zos.Backend(backend).Valid(config.TLSPassthrough); err != nil {

--- a/pkg/gateway/gateway.go
+++ b/pkg/gateway/gateway.go
@@ -62,7 +62,6 @@ type gatewayModule struct {
 	reservedDomains map[string]string
 	domainLock      sync.RWMutex
 
-	//proxyConfigPath  string
 	staticConfigPath string
 	binPath          string
 	certScriptPath   string

--- a/pkg/gateway/nnc.go
+++ b/pkg/gateway/nnc.go
@@ -63,19 +63,6 @@ func (n *NNC) port() (uint16, error) {
 	return uint16(value), nil
 }
 
-func (n *NNC) target() (string, error) {
-	return n.arg("--target")
-}
-
-func (n *NNC) namespace() (string, error) {
-	path, err := n.arg("--namespace")
-	if err != nil {
-		return "", err
-	}
-
-	return filepath.Base(path), nil
-}
-
 func (g *gatewayModule) nncZinitPath(name string) string {
 	return filepath.Join(g.volatile, zinitDir, fmt.Sprintf("%s.yaml", name))
 }
@@ -87,7 +74,9 @@ func (g *gatewayModule) nncList() (map[uint16]NNC, error) {
 		return nil, err
 	}
 	nncs := make(map[uint16]NNC)
-	for name, _ := range services {
+	// note: should we just instead list the config
+	// from the known config directory?
+	for name := range services {
 		if !strings.HasPrefix(name, nncServicePrefix) {
 			continue
 		}

--- a/pkg/gateway/nnc.go
+++ b/pkg/gateway/nnc.go
@@ -1,0 +1,241 @@
+package gateway
+
+import (
+	"fmt"
+	"math"
+	"math/rand"
+	"net"
+	"os"
+	"path/filepath"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/google/shlex"
+	"github.com/pkg/errors"
+	"github.com/threefoldtech/zos/pkg/gridtypes"
+	"github.com/threefoldtech/zos/pkg/gridtypes/zos"
+	"github.com/threefoldtech/zos/pkg/zinit"
+	"gopkg.in/yaml.v2"
+)
+
+const (
+	nncServicePrefix = "nnc-"
+	nncStartPort     = 2000
+)
+
+type NNC struct {
+	ID   gridtypes.WorkloadID
+	Exec string
+}
+
+func (n *NNC) arg(key string) (string, error) {
+	parts, err := shlex.Split(n.Exec)
+	if err != nil {
+		return "", err
+	}
+
+	for i, part := range parts {
+		if part == key {
+			return parts[i+1], nil
+		}
+	}
+
+	return "", fmt.Errorf("not found")
+}
+
+func (n *NNC) port() (uint16, error) {
+	listen, err := n.arg("--listen")
+	if err != nil {
+		return 0, err
+	}
+
+	_, port, err := net.SplitHostPort(listen)
+	if err != nil {
+		return 0, err
+	}
+
+	value, err := strconv.Atoi(port)
+	if err != nil {
+		return 0, err
+	}
+
+	return uint16(value), nil
+}
+
+func (n *NNC) target() (string, error) {
+	return n.arg("--target")
+}
+
+func (n *NNC) namespace() (string, error) {
+	path, err := n.arg("--namespace")
+	if err != nil {
+		return "", err
+	}
+
+	return filepath.Base(path), nil
+}
+
+func (g *gatewayModule) nncZinitPath(name string) string {
+	return filepath.Join(g.root, zinitDir, fmt.Sprintf("%s.yaml", name))
+}
+
+func (g *gatewayModule) listNNC() (map[uint16]NNC, error) {
+	cl := zinit.Default()
+	services, err := cl.List()
+	if err != nil {
+		return nil, err
+	}
+	nncs := make(map[uint16]NNC)
+	for name, _ := range services {
+		if !strings.HasPrefix(name, nncServicePrefix) {
+			continue
+		}
+		id := strings.TrimPrefix(name, nncServicePrefix)
+
+		cfg, err := cl.Get(name)
+		if err != nil {
+			return nil, err
+		}
+
+		nnc := NNC{
+			ID:   gridtypes.WorkloadID(id),
+			Exec: cfg.Exec,
+		}
+
+		port, err := nnc.port()
+		if err != nil {
+			return nil, err
+		}
+
+		nncs[port] = nnc
+	}
+
+	return nncs, nil
+}
+
+func (g *gatewayModule) nncGet(name string) (NNC, error) {
+	cl := zinit.Default()
+	cfg, err := cl.Get(name)
+	if err != nil {
+		return NNC{}, err
+	}
+
+	return NNC{
+		ID:   gridtypes.WorkloadID(strings.TrimPrefix(name, nncServicePrefix)),
+		Exec: cfg.Exec,
+	}, nil
+
+}
+
+func (g *gatewayModule) nncName(id string) string {
+	return fmt.Sprintf("%s%s", nncServicePrefix, id)
+}
+
+func (g *gatewayModule) nncFreePort() (uint16, error) {
+	// TODO: this need to call while holding some lock
+	// to avoid double allocation of the same port
+	current, err := g.listNNC()
+	if err != nil {
+		return 0, err
+	}
+
+	for {
+		port := uint16(rand.Intn(math.MaxUint16-nncStartPort) + nncStartPort)
+		if _, ok := current[port]; !ok {
+			return port, nil
+		}
+	}
+}
+
+func (g *gatewayModule) nncCreateService(name string, service zinit.InitService) error {
+	path := g.nncZinitPath(name)
+	data, err := yaml.Marshal(service)
+	if err != nil {
+		return err
+	}
+
+	if err := os.WriteFile(path, data, 0644); err != nil {
+		return errors.Wrap(err, "failed to create nnc service file")
+	}
+
+	// link under zinit /etc/zinit
+
+	if err := os.Symlink(path, filepath.Join("/etc/zinit", fmt.Sprintf("%s.yaml", name))); err != nil {
+		return errors.Wrap(err, "failed to create nnc service symlink")
+	}
+
+	return nil
+}
+
+func (g *gatewayModule) nncEnsure(wlID, namespace string, backend zos.Backend) (zos.Backend, error) {
+	name := g.nncName(wlID)
+
+	// reuse or find a new free IP
+	var free uint16
+	nnc, err := g.nncGet(name)
+	if err == nil {
+		// a service with the same name already exists
+		// verify the backend?
+		free, err = nnc.port()
+		// we always destroy the service if
+		// a one already exists with the same name
+		// to allow updating the gw code.
+		g.destroyNNC(wlID)
+	} else if errors.Is(err, zinit.ErrUnknownService) {
+		// if does not exist, just find a free port
+		free, err = g.nncFreePort()
+	} else if err != nil {
+		return "", err
+	}
+
+	// this checks the error returned by the
+	// free port allocation
+	if err != nil {
+		return "", err
+	}
+
+	target, err := backend.AsAddress()
+	if err != nil {
+		return "", err
+	}
+
+	be := zos.Backend(fmt.Sprintf("127.0.0.1:%d", free))
+
+	cmd := []string{
+		"ip", "netns", "exec", "public",
+		"nnc",
+		"--listen", string(be),
+		"--namespace", filepath.Join("/var/run/netns/", namespace),
+		"--target", target,
+	}
+
+	service := zinit.InitService{
+		Exec: strings.Join(cmd, " "),
+	}
+
+	if err = g.nncCreateService(name, service); err != nil {
+		return "", err
+	}
+
+	defer func() {
+		if err != nil {
+			g.destroyNNC(wlID)
+		}
+	}()
+
+	if err = zinit.Default().Monitor(name); err != nil {
+		return "", errors.Wrap(err, "failed to start nnc service")
+	}
+
+	return be, nil
+}
+
+func (g *gatewayModule) destroyNNC(wlID string) {
+	name := g.nncName(wlID)
+	path := g.nncZinitPath(name)
+
+	cl := zinit.Default()
+	_ = cl.Destroy(10*time.Second, name)
+	_ = os.Remove(path)
+}

--- a/pkg/gateway/nnc.go
+++ b/pkg/gateway/nnc.go
@@ -24,6 +24,7 @@ const (
 	nncStartPort     = 2000
 )
 
+// NNC holds (and extracts) information from nnc command
 type NNC struct {
 	ID   gridtypes.WorkloadID
 	Exec string
@@ -44,6 +45,7 @@ func (n *NNC) arg(key string) (string, error) {
 	return "", fmt.Errorf("not found")
 }
 
+// port return port number this nnc instance is listening on
 func (n *NNC) port() (uint16, error) {
 	listen, err := n.arg("--listen")
 	if err != nil {
@@ -63,10 +65,13 @@ func (n *NNC) port() (uint16, error) {
 	return uint16(value), nil
 }
 
+// nncZinitPath return path to the nnc zinit config file given the name
 func (g *gatewayModule) nncZinitPath(name string) string {
 	return filepath.Join(g.volatile, zinitDir, fmt.Sprintf("%s.yaml", name))
 }
 
+// nncList lists all running instances of nnc. the map key is
+// the instance configured listening port
 func (g *gatewayModule) nncList() (map[uint16]NNC, error) {
 	cl := zinit.Default()
 	services, err := cl.List()
@@ -103,6 +108,7 @@ func (g *gatewayModule) nncList() (map[uint16]NNC, error) {
 	return nncs, nil
 }
 
+// nncGet return NNC instance by name
 func (g *gatewayModule) nncGet(name string) (NNC, error) {
 	cl := zinit.Default()
 	cfg, err := cl.Get(name)
@@ -157,6 +163,8 @@ func (g *gatewayModule) nncCreateService(name string, service zinit.InitService)
 	return nil
 }
 
+// nncEnsure creates (or reuse) an nnc instance given the workload ID. the destination namespace and backend
+// it return the backend that need to be configured in traefik.
 func (g *gatewayModule) nncEnsure(wlID, namespace string, backend zos.Backend) (zos.Backend, error) {
 	name := g.nncName(wlID)
 
@@ -220,6 +228,7 @@ func (g *gatewayModule) nncEnsure(wlID, namespace string, backend zos.Backend) (
 	return be, nil
 }
 
+// destroyNNC stops and clean up nnc instances
 func (g *gatewayModule) destroyNNC(wlID string) {
 	name := g.nncName(wlID)
 	path := g.nncZinitPath(name)

--- a/pkg/gateway/nnc.go
+++ b/pkg/gateway/nnc.go
@@ -77,10 +77,10 @@ func (n *NNC) namespace() (string, error) {
 }
 
 func (g *gatewayModule) nncZinitPath(name string) string {
-	return filepath.Join(g.root, zinitDir, fmt.Sprintf("%s.yaml", name))
+	return filepath.Join(g.volatile, zinitDir, fmt.Sprintf("%s.yaml", name))
 }
 
-func (g *gatewayModule) listNNC() (map[uint16]NNC, error) {
+func (g *gatewayModule) nncList() (map[uint16]NNC, error) {
 	cl := zinit.Default()
 	services, err := cl.List()
 	if err != nil {
@@ -135,7 +135,7 @@ func (g *gatewayModule) nncName(id string) string {
 func (g *gatewayModule) nncFreePort() (uint16, error) {
 	// TODO: this need to call while holding some lock
 	// to avoid double allocation of the same port
-	current, err := g.listNNC()
+	current, err := g.nncList()
 	if err != nil {
 		return 0, err
 	}

--- a/pkg/gateway/static.go
+++ b/pkg/gateway/static.go
@@ -19,8 +19,8 @@ var dConfig string
 var certScript string
 
 // staticConfig write static config to file
-func staticConfig(p, root, email string) (bool, error) {
-	config := fmt.Sprintf(config, root, email)
+func staticConfig(p, root, volatile, email string) (bool, error) {
+	config := fmt.Sprintf(config, root, email, volatile)
 
 	var update bool
 	if oldConfig, err := os.ReadFile(p); os.IsNotExist(err) {

--- a/pkg/gateway/static/config.yaml
+++ b/pkg/gateway/static/config.yaml
@@ -16,7 +16,7 @@ metrics:
     entryPoint: metrics
 providers:
   file:
-    directory: "%[1]s/proxy"
+    directory: "%[3]s/proxy"
     watch: true
 certificatesResolvers:
   resolver:

--- a/pkg/gridtypes/zos/gw.go
+++ b/pkg/gridtypes/zos/gw.go
@@ -1,0 +1,103 @@
+package zos
+
+import (
+	"fmt"
+	"io"
+	"math"
+	"net"
+	"net/url"
+	"strconv"
+
+	"github.com/pkg/errors"
+	"github.com/threefoldtech/zos/pkg/gridtypes"
+)
+
+type Backend string
+
+// Parse accepts http://ip:port, http://ip or ip:port
+// checks if backend string is a valid string based on the tlsPassthrough parameter
+// ip:port is only valid in case of tlsPassthrough is true
+// http://ip:port or http://ip is valid in case of tlsPassthrough is false
+func (b Backend) Valid(tlsPassthrough bool) error {
+	var hostName string
+	if tlsPassthrough {
+		host, port, err := net.SplitHostPort(string(b))
+		if err != nil {
+			return fmt.Errorf("failed to parse backend %s with error: %w", b, err)
+		}
+
+		parsedPort, err := strconv.ParseUint(port, 10, 64)
+		if err != nil {
+			return fmt.Errorf("invalid port in backend: %s", port)
+		}
+
+		if parsedPort > math.MaxUint16 {
+			return fmt.Errorf("port '%s' must be <= 65535", port)
+		}
+
+		hostName = host
+	} else {
+		u, err := url.Parse(string(b))
+		if err != nil {
+			return fmt.Errorf("failed to parse backend with error: %w", err)
+		}
+
+		if u.Scheme != "http" {
+			return fmt.Errorf("scheme expected to be http")
+		}
+		hostName = u.Hostname()
+	}
+
+	ip := net.ParseIP(hostName)
+	if len(ip) == 0 || ip.IsLoopback() {
+		return fmt.Errorf("invalid ip address in backend: %s", hostName)
+	}
+	return nil
+}
+
+// GatewayBase definition. this will proxy name.<zos.domain> to backends
+type GatewayBase struct {
+	// Passthrough whether to pass tls traffic or not
+	TLSPassthrough bool `json:"tls_passthrough"`
+
+	// Backends are list of backend ips (only one is supported atm)
+	Backends []Backend `json:"backends"`
+
+	// Network name to join [optional].
+	// If set the backend IP can be a private ip in that network.
+	// the network then must be
+	// the same rules for tls-passthrough applies.
+	Network *gridtypes.Name `json:"network,omitempty"`
+}
+
+func (g GatewayBase) Valid(getter gridtypes.WorkloadGetter) error {
+	if len(g.Backends) == 0 {
+		return fmt.Errorf("backends list can not be empty")
+	}
+
+	if len(g.Backends) != 1 {
+		return fmt.Errorf("only one backend is supported")
+	}
+
+	for _, backend := range g.Backends {
+		if err := backend.Valid(g.TLSPassthrough); err != nil {
+			return errors.Wrapf(err, "failed to validate backend '%s'", backend)
+		}
+	}
+
+	return nil
+}
+
+func (g GatewayBase) Challenge(w io.Writer) error {
+	if _, err := fmt.Fprintf(w, "%t", g.TLSPassthrough); err != nil {
+		return err
+	}
+
+	for _, backend := range g.Backends {
+		if _, err := fmt.Fprintf(w, "%s", string(backend)); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}

--- a/pkg/gridtypes/zos/gw_fqdn.go
+++ b/pkg/gridtypes/zos/gw_fqdn.go
@@ -3,13 +3,8 @@ package zos
 import (
 	"fmt"
 	"io"
-	"math"
-	"net"
-	"net/url"
 	"regexp"
-	"strconv"
 
-	"github.com/pkg/errors"
 	"github.com/threefoldtech/zos/pkg/gridtypes"
 )
 
@@ -17,59 +12,12 @@ var (
 	gwNameRegex = regexp.MustCompile(`^[a-zA-Z0-9-.]+$`)
 )
 
-type Backend string
-
-// Parse accepts http://ip:port, http://ip or ip:port
-// checks if backend string is a valid string based on the tlsPassthrough parameter
-// ip:port is only valid in case of tlsPassthrough is true
-// http://ip:port or http://ip is valid in case of tlsPassthrough is false
-func (b Backend) Valid(tlsPassthrough bool) error {
-	var hostName string
-	if tlsPassthrough {
-		host, port, err := net.SplitHostPort(string(b))
-		if err != nil {
-			return fmt.Errorf("failed to parse backend %s with error: %w", b, err)
-		}
-
-		parsedPort, err := strconv.ParseUint(port, 10, 64)
-		if err != nil {
-			return fmt.Errorf("invalid port in backend: %s", port)
-		}
-
-		if parsedPort > math.MaxUint16 {
-			return fmt.Errorf("port '%s' must be <= 65535", port)
-		}
-
-		hostName = host
-	} else {
-		u, err := url.Parse(string(b))
-		if err != nil {
-			return fmt.Errorf("failed to parse backend with error: %w", err)
-		}
-
-		if u.Scheme != "http" {
-			return fmt.Errorf("scheme expected to be http")
-		}
-		hostName = u.Hostname()
-	}
-
-	ip := net.ParseIP(hostName)
-	if len(ip) == 0 || ip.IsLoopback() {
-		return fmt.Errorf("invalid ip address in backend: %s", hostName)
-	}
-	return nil
-}
-
 // GatewayFQDNProxy definition. this will proxy name.<zos.domain> to backends
 type GatewayFQDNProxy struct {
+	GatewayBase
+
 	// FQDN the fully qualified domain name to use (cannot be present with Name)
 	FQDN string `json:"fqdn"`
-
-	// Passthroug whether to pass tls traffic or not
-	TLSPassthrough bool `json:"tls_passthrough"`
-
-	// Backends are list of backend ips
-	Backends []Backend `json:"backends"`
 }
 
 func (g GatewayFQDNProxy) Valid(getter gridtypes.WorkloadGetter) error {
@@ -79,16 +27,8 @@ func (g GatewayFQDNProxy) Valid(getter gridtypes.WorkloadGetter) error {
 	if g.FQDN[len(g.FQDN)-1] == '.' {
 		return fmt.Errorf("fqdn can't end with a dot")
 	}
-	if len(g.Backends) == 0 {
-		return fmt.Errorf("backends list can not be empty")
-	}
-	for _, backend := range g.Backends {
-		if err := backend.Valid(g.TLSPassthrough); err != nil {
-			return errors.Wrapf(err, "failed to validate backend '%s'", backend)
-		}
-	}
 
-	return nil
+	return g.GatewayBase.Valid(getter)
 }
 
 func (g GatewayFQDNProxy) Challenge(w io.Writer) error {
@@ -96,17 +36,7 @@ func (g GatewayFQDNProxy) Challenge(w io.Writer) error {
 		return err
 	}
 
-	if _, err := fmt.Fprintf(w, "%t", g.TLSPassthrough); err != nil {
-		return err
-	}
-
-	for _, backend := range g.Backends {
-		if _, err := fmt.Fprintf(w, "%s", string(backend)); err != nil {
-			return err
-		}
-	}
-
-	return nil
+	return g.GatewayBase.Challenge(w)
 }
 
 func (g GatewayFQDNProxy) Capacity() (gridtypes.Capacity, error) {
@@ -117,6 +47,5 @@ func (g GatewayFQDNProxy) Capacity() (gridtypes.Capacity, error) {
 }
 
 // GatewayProxyResult results
-type GatewayProxyResult struct {
-	FQDN string `json:"fqdn"`
+type GatewayFQDNResult struct {
 }

--- a/pkg/gridtypes/zos/gw_test.go
+++ b/pkg/gridtypes/zos/gw_test.go
@@ -68,6 +68,52 @@ func TestValidBackend(t *testing.T) {
 	})
 }
 
+func TestAsAddress(t *testing.T) {
+
+	cases := []struct {
+		Backend Backend
+		Address string
+		Err     bool
+	}{
+		{
+			Backend: Backend("http://10.20.30.40"),
+			Address: "10.20.30.40:80",
+		},
+		{
+			Backend: Backend("[2001:db8:3333:4444:CCCC:DDDD:EEEE:FFFF]:200"),
+			Address: "[2001:db8:3333:4444:CCCC:DDDD:EEEE:FFFF]:200",
+		},
+		{
+			Backend: Backend("2001:db8:3333:4444:CCCC:DDDD:EEEE:FFFF:200"),
+			Err:     true,
+		},
+		{
+			Backend: Backend("http://[2001:db8:3333:4444:CCCC:DDDD:EEEE:FFFF]:200"),
+			Address: "[2001:db8:3333:4444:CCCC:DDDD:EEEE:FFFF]:200",
+		},
+		{
+			Backend: Backend("http://10.20.30.40:500"),
+			Address: "10.20.30.40:500",
+		},
+		{
+			Backend: Backend("10.20.30.40:500"),
+			Address: "10.20.30.40:500",
+		},
+	}
+
+	for _, c := range cases {
+		t.Run(string(c.Backend), func(t *testing.T) {
+			addr, err := c.Backend.AsAddress()
+			if c.Err {
+				require.Error(t, err)
+			} else {
+				require.NoError(t, err)
+				require.Equal(t, c.Address, addr)
+			}
+		})
+	}
+}
+
 func TestValidBackendIP6(t *testing.T) {
 	require := require.New(t)
 

--- a/pkg/primitives/gateway/gatewayfqdn.go
+++ b/pkg/primitives/gateway/gatewayfqdn.go
@@ -31,12 +31,9 @@ func (p *FQDNManager) Provision(ctx context.Context, wl *gridtypes.WorkloadWithI
 	if err := json.Unmarshal(wl.Data, &proxy); err != nil {
 		return nil, fmt.Errorf("failed to unmarshal gateway proxy from reservation: %w", err)
 	}
-	backends := make([]string, len(proxy.Backends))
-	for idx, backend := range proxy.Backends {
-		backends[idx] = string(backend)
-	}
+
 	gateway := stubs.NewGatewayStub(p.zbus)
-	err := gateway.SetFQDNProxy(ctx, wl.ID.String(), proxy.FQDN, backends, proxy.TLSPassthrough)
+	err := gateway.SetFQDNProxy(ctx, wl.ID.String(), proxy)
 	if err != nil {
 		return nil, errors.Wrap(err, "failed to setup fqdn proxy")
 	}

--- a/pkg/primitives/gateway/gatewayname.go
+++ b/pkg/primitives/gateway/gatewayname.go
@@ -33,13 +33,9 @@ func (p *NameManager) Provision(ctx context.Context, wl *gridtypes.WorkloadWithI
 	if err := json.Unmarshal(wl.Data, &proxy); err != nil {
 		return nil, fmt.Errorf("failed to unmarshal gateway proxy from reservation: %w", err)
 	}
-	backends := make([]string, len(proxy.Backends))
-	for idx, backend := range proxy.Backends {
-		backends[idx] = string(backend)
-	}
-	twinID, _ := provision.GetDeploymentID(ctx)
+
 	gateway := stubs.NewGatewayStub(p.zbus)
-	fqdn, err := gateway.SetNamedProxy(ctx, wl.ID.String(), proxy.Name, backends, proxy.TLSPassthrough, twinID)
+	fqdn, err := gateway.SetNamedProxy(ctx, wl.ID.String(), proxy)
 	if err != nil {
 		return nil, errors.Wrap(err, "failed to setup name proxy")
 	}

--- a/pkg/stubs/gateway_stub.go
+++ b/pkg/stubs/gateway_stub.go
@@ -8,6 +8,7 @@ import (
 	"context"
 	zbus "github.com/threefoldtech/zbus"
 	pkg "github.com/threefoldtech/zos/pkg"
+	zos "github.com/threefoldtech/zos/pkg/gridtypes/zos"
 )
 
 type GatewayStub struct {
@@ -59,8 +60,8 @@ func (s *GatewayStub) Metrics(ctx context.Context) (ret0 pkg.GatewayMetrics, ret
 	return
 }
 
-func (s *GatewayStub) SetFQDNProxy(ctx context.Context, arg0 string, arg1 string, arg2 []string, arg3 bool) (ret0 error) {
-	args := []interface{}{arg0, arg1, arg2, arg3}
+func (s *GatewayStub) SetFQDNProxy(ctx context.Context, arg0 string, arg1 zos.GatewayFQDNProxy) (ret0 error) {
+	args := []interface{}{arg0, arg1}
 	result, err := s.client.RequestContext(ctx, s.module, s.object, "SetFQDNProxy", args...)
 	if err != nil {
 		panic(err)
@@ -74,8 +75,8 @@ func (s *GatewayStub) SetFQDNProxy(ctx context.Context, arg0 string, arg1 string
 	return
 }
 
-func (s *GatewayStub) SetNamedProxy(ctx context.Context, arg0 string, arg1 string, arg2 []string, arg3 bool, arg4 uint32) (ret0 string, ret1 error) {
-	args := []interface{}{arg0, arg1, arg2, arg3, arg4}
+func (s *GatewayStub) SetNamedProxy(ctx context.Context, arg0 string, arg1 zos.GatewayNameProxy) (ret0 string, ret1 error) {
+	args := []interface{}{arg0, arg1}
 	result, err := s.client.RequestContext(ctx, s.module, s.object, "SetNamedProxy", args...)
 	if err != nil {
 		panic(err)


### PR DESCRIPTION
Fixes #1674

- Add optional `network`. If set the gateway can then proxy traffic to that network. Which means user can gateway traffic to a private workload that lives inside this network.
- Backward compatible with older configurations, user can still use yggdrasil backends although not recommended for reliability  
- Fix few issues in gateway start up. specially after node reboot.