### PR TITLE
use the cloud-container from autobuilder

### DIFF
--- a/pkg/primitives/vm/vm.go
+++ b/pkg/primitives/vm/vm.go
@@ -21,8 +21,7 @@ import (
 )
 
 const (
-	// this probably need a way to update. for now just hard code it
-	cloudContainerFlist = "https://hub.grid.tf/azmy.3bot/cloud-container-20221122.flist"
+	cloudContainerFlist = "https://hub.grid.tf/tf-autobuilder/cloud-container-8730b6f.flist"
 	cloudContainerName  = "cloud-container"
 )
 


### PR DESCRIPTION
Please note the following:

cloud-container has been update to do autobuild. There was a problem that newer versions of gcc did not work on kernel **5.2**. Hence i had to update the kernel to version **6.1.21**.

So while this only one line of changed code it brings a new kernel to all new `containers` running on zos.

[cloud-container](https://github.com/threefoldtech/cloud-container)