### PR TITLE
Udhcp probe

### DIFF
--- a/.github/workflows/bins.yaml
+++ b/.github/workflows/bins.yaml
@@ -120,3 +120,9 @@ jobs:
       package: cloudconsole
     secrets:
       token: ${{ secrets.HUB_JWT }}
+  misc:
+    uses: ./.github/workflows/bin-package.yaml
+    with:
+      package: misc
+    secrets:
+      token: ${{ secrets.HUB_JWT }}

--- a/bins/packages/misc/misc.sh
+++ b/bins/packages/misc/misc.sh
@@ -1,0 +1,23 @@
+MISC_VERSION="1"
+
+prepare_misc() {
+    echo "[+] prepare 0-fs"
+    github_name "misc-${MISC_VERSION}"
+}
+
+install_misc() {
+    echo "[+] install misc"
+
+    mkdir -p "${ROOTDIR}/"
+    cp -av $1/packages/misc/root/* "${ROOTDIR}/"
+}
+
+build_misc() {
+    base=$(pwd)
+    pushd "${DISTDIR}"
+
+    prepare_misc
+    install_misc $base
+
+    popd
+}

--- a/bins/packages/misc/readme.md
+++ b/bins/packages/misc/readme.md
@@ -1,0 +1,18 @@
+# The package
+
+this package include miscellaneous files that don't really fit a certain package
+
+## Files
+
+### `prop.script`
+
+this file is a **HARD LINK** to the file with the same name at `/bootstrap/usr/share/udhcp/` this file exists in two places
+because
+
+- It needs to be part of the 0-initramfs (zos kernel) because it's needed to exist before the node has internet connection
+and the bootstrap directory is what is included during the kernel build
+- But it also need to be in a package because that any node that is booted with an older build of the kernel must also get the same
+file
+
+I am not sure if the hard-link is maintained in a github repo (I assume not) so any changes to the prop.script must be maintained in
+the two copies

--- a/bins/packages/misc/root/usr/share/udhcp/probe.script
+++ b/bins/packages/misc/root/usr/share/udhcp/probe.script
@@ -1,0 +1,32 @@
+#!/bin/sh
+
+# this prope script can work as a udhcpc script
+# that does not configure the interface but instead
+# prints out the result from the bound operation
+# in a json object.
+# this is usually used as
+# udhcpc -qf --now -s <this script> -i inf
+
+stage=$1
+
+# we only handle bound process
+if [ $stage != "bound" ]; then
+    exit 0
+fi
+
+# the idea is that we print out
+# all config received in a json
+# object so others can read that
+# out
+cat <<EOF
+{
+    "subnet": "$subnet",
+    "router": "$router",
+    "ip": "$ip",
+    "siaddr": "$siaddr",
+    "dns": "$dns",
+    "servierid": "$serverid",
+    "broadcast": "$broadcast",
+    "lease": "$lease"
+}
+EOF

--- a/cmds/internet/main.go
+++ b/cmds/internet/main.go
@@ -88,6 +88,8 @@ func configureZOS() error {
 			return err
 		}
 
+		log.Info().Int("count", len(ifaceConfigs)).Msg("found interfaces with internet access")
+		log.Debug().Msgf("found interfaces: %+v", ifaceConfigs)
 		zosChild, err := bootstrap.SelectZOS(ifaceConfigs)
 		if err != nil {
 			log.Error().Err(err).Msg("failed to select a valid interface for zos bridge")

--- a/pkg/gridtypes/zos/zmachine.go
+++ b/pkg/gridtypes/zos/zmachine.go
@@ -271,8 +271,8 @@ func (v ZMachine) Challenge(b io.Writer) error {
 
 // ZMachineResult result returned by VM reservation
 type ZMachineResult struct {
-	ID         string  `json:"id"`
-	IP         string  `json:"ip"`
-	YggIP      string  `json:"ygg_ip"`
+	ID         string `json:"id"`
+	IP         string `json:"ip"`
+	YggIP      string `json:"ygg_ip"`
 	ConsoleURL string `json:"console_url"`
 }

--- a/pkg/network/bootstrap/bootstrap.go
+++ b/pkg/network/bootstrap/bootstrap.go
@@ -25,11 +25,10 @@ import (
 
 // IfaceConfig contains all the IP address and routes of an interface
 type IfaceConfig struct {
-	Name    string
-	Addrs4  []netlink.Addr
-	Addrs6  []netlink.Addr
-	Routes4 []netlink.Route
-	Routes6 []netlink.Route
+	Name      string
+	Addrs4    []netlink.Addr
+	Addrs6    []netlink.Addr
+	DefaultGW net.IP
 }
 
 // Requires tesll the analyser to wait for ip type
@@ -47,6 +46,7 @@ type byIP4 []IfaceConfig
 func (a byIP4) Len() int      { return len(a) }
 func (a byIP4) Swap(i, j int) { a[i], a[j] = a[j], a[i] }
 func (a byIP4) Less(i, j int) bool {
+
 	sort.Sort(byAddr(a[i].Addrs4))
 	sort.Sort(byAddr(a[j].Addrs4))
 	return bytes.Compare(a[i].Addrs4[0].IP, a[j].Addrs4[0].IP) < 0
@@ -170,6 +170,7 @@ func AnalyzeLink(ctx context.Context, requires Requires, link netlink.Link) (cfg
 		}()
 
 		name := link.Attrs().Name
+		cfg.Name = name
 
 		if err := options.Set(name, options.IPv6Disable(false)); err != nil {
 			return errors.Wrapf(err, "failed to enable ip6 on %s", name)
@@ -177,17 +178,22 @@ func AnalyzeLink(ctx context.Context, requires Requires, link netlink.Link) (cfg
 
 		log.Info().Str("interface", name).Msg("start DHCP probe")
 
-		probe := dhcp.NewProbe()
-		if err := probe.Start(name); err != nil {
-			return errors.Wrap(err, "error duging DHCP probe")
-		}
-		defer func() {
-			if err := probe.Stop(); err != nil {
-				log.Error().Err(err).Msg("could not stop DHCP probe properly")
+		if requires&RequiresIPv4 != 0 {
+			// requires IPv4
+			prope, err := dhcp.DHCPPrope(ctx, name)
+			if err != nil {
+				return errors.Wrapf(err, "no ip v4 on interface '%s'", name)
 			}
-		}()
+			ip, err := prope.IPNet()
+			if err != nil {
+				return errors.Wrap(err, "invalid ip address returned by dhcp")
+			}
+			cfg.Addrs4 = append(cfg.Addrs4, netlink.Addr{IPNet: ip})
+			if len(prope.Router) != 0 {
+				cfg.DefaultGW = net.ParseIP(prope.Router).To4()
+			}
+		}
 
-		var addrs4 = newAddrSet()
 		var addrs6 = newAddrSet()
 
 	loop:
@@ -196,13 +202,7 @@ func AnalyzeLink(ctx context.Context, requires Requires, link netlink.Link) (cfg
 			case <-ctx.Done():
 				return ctx.Err()
 			default:
-				addrs, err := netlink.AddrList(link, netlink.FAMILY_V4)
-				if err != nil {
-					return errors.Wrapf(err, "could not read address from interface %s", name)
-				}
-				addrs4.AddSlice(addrs)
-
-				addrs, err = netlink.AddrList(link, netlink.FAMILY_V6)
+				addrs, err := netlink.AddrList(link, netlink.FAMILY_V6)
 				if err != nil {
 					return errors.Wrapf(err, "could not read address from interface %s", name)
 				}
@@ -213,8 +213,7 @@ func AnalyzeLink(ctx context.Context, requires Requires, link netlink.Link) (cfg
 					}
 				}
 
-				if ((requires&RequiresIPv6 == 0) || addrs6.Len() != 0) &&
-					((requires&RequiresIPv4 == 0) || addrs4.Len() != 0) {
+				if (requires&RequiresIPv6 == 0) || addrs6.Len() != 0 {
 					break loop
 				}
 
@@ -222,23 +221,7 @@ func AnalyzeLink(ctx context.Context, requires Requires, link netlink.Link) (cfg
 			}
 		}
 
-		routes4, err := netlink.RouteList(link, netlink.FAMILY_V4)
-		if err != nil {
-			return errors.Wrapf(err, "could not read routes from interface %s", name)
-		}
-		routes6, err := netlink.RouteList(link, netlink.FAMILY_V6)
-		if err != nil {
-			return errors.Wrapf(err, "could not read routes from interface %s", name)
-		}
-
-		cfg = IfaceConfig{
-			Name:    name,
-			Addrs4:  addrs4.ToSlice(),
-			Addrs6:  addrs6.ToSlice(),
-			Routes4: routes4,
-			Routes6: routes6,
-		}
-
+		cfg.Addrs6 = addrs6.ToSlice()
 		return nil
 	})
 
@@ -265,38 +248,21 @@ func analyzeLink(ctx context.Context, wg *sync.WaitGroup, out chan<- analyzeResu
 func SelectZOS(cfgs []IfaceConfig) (string, error) {
 
 	selected4 := cfgs[:0]
-	// selected6 := cfgs[:0]
 	for _, cfg := range cfgs {
-		for _, route := range cfg.Routes4 {
-			if route.Gw != nil && isPrivateIP(route.Gw) {
+		if cfg.DefaultGW != nil && isPrivateIP(cfg.DefaultGW) {
+			selected4 = append(selected4, cfg)
+		}
+	}
+
+	if len(selected4) == 0 {
+		for _, cfg := range cfgs {
+			if cfg.DefaultGW != nil {
 				selected4 = append(selected4, cfg)
 			}
 		}
 
-		// for _, route := range cfg.Routes4 {
-		// 	if route.Gw != nil && isPrivateIP(route.Gw) {
-		// 		selected6 = append(selected6, cfg)
-		// 	}
-		// }
 	}
-
-	if len(selected4) < 1 {
-		for _, cfg := range cfgs {
-			for _, route := range cfg.Routes4 {
-				if route.Gw != nil {
-					selected4 = append(selected4, cfg)
-				}
-			}
-
-			// for _, route := range cfg.Routes6 {
-			// 	if route.Gw != nil {
-			// 		selected6 = append(selected6, cfg)
-			// 	}
-			// }
-		}
-	}
-
-	if len(selected4) < 1 {
+	if len(selected4) == 0 {
 		return "", fmt.Errorf("no route with default gateway found")
 	}
 

--- a/pkg/network/bootstrap/bootstrap.go
+++ b/pkg/network/bootstrap/bootstrap.go
@@ -180,17 +180,17 @@ func AnalyzeLink(ctx context.Context, requires Requires, link netlink.Link) (cfg
 
 		if requires&RequiresIPv4 != 0 {
 			// requires IPv4
-			prope, err := dhcp.Probe(ctx, name)
+			probe, err := dhcp.Probe(ctx, name)
 			if err != nil {
 				return errors.Wrapf(err, "no ip v4 on interface '%s'", name)
 			}
-			ip, err := prope.IPNet()
+			ip, err := probe.IPNet()
 			if err != nil {
 				return errors.Wrap(err, "invalid ip address returned by dhcp")
 			}
 			cfg.Addrs4 = append(cfg.Addrs4, netlink.Addr{IPNet: ip})
-			if len(prope.Router) != 0 {
-				cfg.DefaultGW = net.ParseIP(prope.Router).To4()
+			if len(probe.Router) != 0 {
+				cfg.DefaultGW = net.ParseIP(probe.Router).To4()
 			}
 		}
 

--- a/pkg/network/bootstrap/bootstrap.go
+++ b/pkg/network/bootstrap/bootstrap.go
@@ -180,7 +180,7 @@ func AnalyzeLink(ctx context.Context, requires Requires, link netlink.Link) (cfg
 
 		if requires&RequiresIPv4 != 0 {
 			// requires IPv4
-			prope, err := dhcp.DHCPPrope(ctx, name)
+			prope, err := dhcp.Probe(ctx, name)
 			if err != nil {
 				return errors.Wrapf(err, "no ip v4 on interface '%s'", name)
 			}

--- a/pkg/network/bootstrap/bootstrap_test.go
+++ b/pkg/network/bootstrap/bootstrap_test.go
@@ -70,12 +70,3 @@ func mustParseAddr(s string) netlink.Addr {
 	}
 	return *addr
 }
-
-func mustParseIPNet(addr string) *net.IPNet {
-	ip, ipnet, err := net.ParseCIDR(addr)
-	if err != nil {
-		panic(err)
-	}
-	ipnet.IP = ip
-	return ipnet
-}

--- a/pkg/network/bootstrap/bootstrap_test.go
+++ b/pkg/network/bootstrap/bootstrap_test.go
@@ -20,45 +20,7 @@ var _testIfaceCfgs = []IfaceConfig{
 			mustParseAddr("2001:b:a:0:5645:46ff:fef6:261/64"),
 			mustParseAddr("fe80::5645:46ff:fef6:261/64"),
 		},
-		Routes4: []netlink.Route{
-			{
-				LinkIndex: 2,
-				Dst:       nil,
-				Src:       nil,
-				Gw:        net.ParseIP("172.20.0.1"),
-				Table:     254,
-			},
-			{
-				LinkIndex: 2,
-				Dst:       mustParseIPNet("172.20.0.0/24"),
-				Src:       net.ParseIP("172.20.0.96"),
-				Gw:        net.ParseIP("172.20.0.1"),
-				Table:     254,
-			},
-		},
-		Routes6: []netlink.Route{
-			{
-				LinkIndex: 2,
-				Dst:       mustParseIPNet("2001:b:a::/64"),
-				Src:       nil,
-				Gw:        nil,
-				Table:     254,
-			},
-			{
-				LinkIndex: 2,
-				Dst:       mustParseIPNet("fe80::/64"),
-				Src:       nil,
-				Gw:        nil,
-				Table:     254,
-			},
-			{
-				LinkIndex: 2,
-				Dst:       nil,
-				Src:       nil,
-				Gw:        net.ParseIP("fe80::c084:66ff:fe93:42aa"),
-				Table:     254,
-			},
-		},
+		DefaultGW: net.ParseIP("172.20.0.1"),
 	},
 	{
 		Name: "eth1",
@@ -69,45 +31,7 @@ var _testIfaceCfgs = []IfaceConfig{
 			mustParseAddr("2001:b:a:0:5645:46ff:fef6:262/64"),
 			mustParseAddr("fe80::5645:46ff:fef6:262/64"),
 		},
-		Routes4: []netlink.Route{
-			{
-				LinkIndex: 3,
-				Dst:       nil,
-				Src:       nil,
-				Gw:        net.ParseIP("172.20.0.1"),
-				Table:     254,
-			},
-			{
-				LinkIndex: 3,
-				Dst:       mustParseIPNet("172.20.0.0/24"),
-				Src:       net.ParseIP("172.20.0.97"),
-				Gw:        net.ParseIP("172.20.0.1"),
-				Table:     254,
-			},
-		},
-		Routes6: []netlink.Route{
-			{
-				LinkIndex: 3,
-				Dst:       mustParseIPNet("2001:b:a::/64"),
-				Src:       nil,
-				Gw:        nil,
-				Table:     254,
-			},
-			{
-				LinkIndex: 3,
-				Dst:       mustParseIPNet("fe80::/64"),
-				Src:       nil,
-				Gw:        nil,
-				Table:     254,
-			},
-			{
-				LinkIndex: 3,
-				Dst:       nil,
-				Src:       nil,
-				Gw:        net.ParseIP("fe80::c084:66ff:fe93:42aa"),
-				Table:     254,
-			},
-		},
+		DefaultGW: net.ParseIP("172.20.0.1"),
 	},
 }
 

--- a/pkg/network/dhcp/dhcp.go
+++ b/pkg/network/dhcp/dhcp.go
@@ -13,7 +13,7 @@ import (
 	"github.com/rs/zerolog/log"
 )
 
-type PropeOutput struct {
+type ProbeOutput struct {
 	Subnet        string `json:"subnet"`
 	Router        string `json:"router"`
 	IP            string `json:"ip"`
@@ -24,7 +24,7 @@ type PropeOutput struct {
 	Lease         string `json:"lease"`
 }
 
-func (p *PropeOutput) IPNet() (*net.IPNet, error) {
+func (p *ProbeOutput) IPNet() (*net.IPNet, error) {
 	mask := net.ParseIP(p.Subnet).To4()
 	if mask == nil {
 		return nil, fmt.Errorf("invalid subnet mask (%s)", p.Subnet)
@@ -40,7 +40,7 @@ func (p *PropeOutput) IPNet() (*net.IPNet, error) {
 	}, nil
 }
 
-func DHCPPrope(ctx context.Context, inf string) (output PropeOutput, err error) {
+func Probe(ctx context.Context, inf string) (output ProbeOutput, err error) {
 	// use udhcpc to prope the interface.
 	// this depends on that the interface is UP
 	cmd := exec.CommandContext(ctx, "udhcpc",
@@ -49,7 +49,7 @@ func DHCPPrope(ctx context.Context, inf string) (output PropeOutput, err error) 
 		"-f",       //foreground
 		"-t", "20", //send 20 dhcp queries
 		"-T", "1", // every second
-		"-s", "/usr/share/udhcp/prope.script", // use the prope script
+		"-s", "/usr/share/udhcp/probe.script", // use the prope script
 		"--now", // exit if lease is not obtained
 	)
 

--- a/pkg/network/dhcp/dhcp.go
+++ b/pkg/network/dhcp/dhcp.go
@@ -1,55 +1,75 @@
 package dhcp
 
 import (
+	"bytes"
+	"context"
+	"encoding/json"
 	"fmt"
+	"io"
+	"net"
 	"os/exec"
 
+	"github.com/pkg/errors"
 	"github.com/rs/zerolog/log"
 )
 
-// Probe is used to do some DHCP request on a interface
-type Probe struct {
-	cmd *exec.Cmd
+type PropeOutput struct {
+	Subnet        string `json:"subnet"`
+	Router        string `json:"router"`
+	IP            string `json:"ip"`
+	SourceAddress string `json:"siaddr"`
+	DNS           string `json:"dns"`
+	ServerID      string `json:"serverid"`
+	BroadcastIP   string `json:"broadcast"`
+	Lease         string `json:"lease"`
 }
 
-// NewProbe returns a Probe
-func NewProbe() *Probe {
-	return &Probe{}
+func (p *PropeOutput) IPNet() (*net.IPNet, error) {
+	mask := net.ParseIP(p.Subnet).To4()
+	if mask == nil {
+		return nil, fmt.Errorf("invalid subnet mask (%s)", p.Subnet)
+	}
+	ip := net.ParseIP(p.IP).To4()
+	if ip == nil {
+		return nil, fmt.Errorf("invalid ip  (%s)", p.IP)
+	}
+
+	return &net.IPNet{
+		IP:   ip,
+		Mask: net.IPMask(mask),
+	}, nil
 }
 
-// Start starts the DHCP client process
-func (d *Probe) Start(inf string) error {
-
-	d.cmd = exec.Command("udhcpc",
-		"-f", //foreground
-		"-i", inf,
+func DHCPPrope(ctx context.Context, inf string) (output PropeOutput, err error) {
+	// use udhcpc to prope the interface.
+	// this depends on that the interface is UP
+	cmd := exec.CommandContext(ctx, "udhcpc",
+		"-i", inf, //the interface to prope
+		"-q",       // exist once lease is optained
+		"-f",       //foreground
 		"-t", "20", //send 20 dhcp queries
 		"-T", "1", // every second
-		"-s", "/usr/share/udhcp/simple.script",
-		"-p", fmt.Sprintf("/run/udhcpc.%s.pid", inf),
+		"-s", "/usr/share/udhcp/prope.script", // use the prope script
 		"--now", // exit if lease is not obtained
 	)
 
-	log.Debug().Msgf("start udhcpc for probing: %v", d.cmd.String())
-	if err := d.cmd.Start(); err != nil {
-		return err
+	var stdout bytes.Buffer
+	var stderr bytes.Buffer
+
+	cmd.Stdout = &stdout
+	cmd.Stderr = &stderr
+	if err := cmd.Run(); err != nil {
+		return output, errors.Wrapf(err, "failed to prope interface '%s': %s", inf, stderr.String())
 	}
 
-	return nil
-}
-
-// Stop kills the DHCP client process
-func (d *Probe) Stop() error {
-	if d.cmd.ProcessState != nil && d.cmd.ProcessState.Exited() {
-		return nil
+	log.Debug().Str("output", stdout.String()).Msg("output from dhcp proping")
+	dec := json.NewDecoder(&stdout)
+	if err := dec.Decode(&output); err != nil {
+		buf, _ := io.ReadAll(dec.Buffered())
+		str := stdout.String() + string(buf)
+		return output, errors.Wrapf(err, "failed to decode proper output (%s)", str)
 	}
 
-	if err := d.cmd.Process.Kill(); err != nil {
-		log.Error().Err(err).Msg("could not kill proper")
-		return err
-	}
-
-	_ = d.cmd.Wait()
-
-	return nil
+	log.Debug().Msgf("output: %+v", output)
+	return
 }

--- a/pkg/network/ndmz/dualstack.go
+++ b/pkg/network/ndmz/dualstack.go
@@ -361,7 +361,7 @@ func waitIP4() error {
 	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
 	defer cancel()
 
-	prope, err := dhcp.DHCPPrope(ctx, dmzPub4)
+	prope, err := dhcp.Probe(ctx, dmzPub4)
 
 	if err != nil {
 		return errors.Wrapf(err, "error while proping interface '%s'", dmzPub4)

--- a/pkg/network/ndmz/dualstack.go
+++ b/pkg/network/ndmz/dualstack.go
@@ -358,38 +358,19 @@ func (d *dmzImpl) Interfaces() ([]types.IfaceInfo, error) {
 // waitIP4 waits to receives some IPv4 from DHCP
 // it returns the pid of the dhcp process or an error
 func waitIP4() error {
-	// run DHCP to interface public in ndmz
-	probe := dhcp.NewProbe()
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
 
-	if err := probe.Start(dmzPub4); err != nil {
-		return err
-	}
-	defer func() {
-		_ = probe.Stop()
-	}()
+	prope, err := dhcp.DHCPPrope(ctx, dmzPub4)
 
-	link, err := netlink.LinkByName(dmzPub4)
 	if err != nil {
-		return err
+		return errors.Wrapf(err, "error while proping interface '%s'", dmzPub4)
+	}
+	if len(prope.IP) != 0 && len(prope.Router) != 0 {
+		return nil
 	}
 
-	cTimeout := time.After(time.Second * 30)
-	for {
-		select {
-		case <-cTimeout:
-			return errors.Errorf("public interface in ndmz did not received an IP. make sure DHCP is working")
-		default:
-			hasGW, _, err := ifaceutil.HasDefaultGW(link, netlink.FAMILY_V4)
-			if err != nil {
-				return err
-			}
-			if !hasGW {
-				time.Sleep(time.Second)
-				continue
-			}
-			return nil
-		}
-	}
+	return errors.Errorf("public interface in ndmz did not received an IP. make sure DHCP is working")
 }
 
 func waitIP6() error {


### PR DESCRIPTION
This PR changes the way `probing` for interfaces is done. Instead of starting udhcp and leave it running then check if the interface got an IP. Instead what we do is that we run udhcpc with a different script that just prints the lease information received by udhcpc as a json object. 

Udhcpc then is started with few extra flags that makes it exit the moment is received or times out.

This make it faster and much better to debug what happens if a node did not receive a dhcp lease.

Note: The script appears in 2 locations because:
- Old images that is already booted needs a copy of that script so updated networkd can work normally (since probe code now uses it)
- New images need to include this script as well (0-initrafms) hence script is also included in bootstrap that is already merged to main.