### PR TITLE
Make sure on boot we exclude the current workload from cap

### DIFF
--- a/pkg/provision/interface.go
+++ b/pkg/provision/interface.go
@@ -104,6 +104,10 @@ type StorageCapacity struct {
 	Workloads int
 }
 
+// Used with Storage interface to compute capacity, exclude any deployment
+// and or workload that returns true from the capacity calculation.
+type Exclude = func(dl *gridtypes.Deployment, wl *gridtypes.Workload) bool
+
 // Storage interface
 type Storage interface {
 	// Create a new deployment in storage, it sets the initial transactions
@@ -132,7 +136,7 @@ type Storage interface {
 	// ByTwin return list of deployments for a twin
 	ByTwin(twin uint32) ([]uint64, error)
 	// return total capacity and active deployments
-	Capacity() (StorageCapacity, error)
+	Capacity(exclude ...Exclude) (StorageCapacity, error)
 }
 
 // Janitor interface


### PR DESCRIPTION
Fixes #1960

On boot we have to reprocess all active workloads, but during this time we also need to exclude the "used capacity" of that workload from the theoritical total used capacity on the node otherwise the node might think that there are no enough capcity available