### PR TITLE
Vm flist from files

### DIFF
--- a/docs/manual/zmachine/zmachine.md
+++ b/docs/manual/zmachine/zmachine.md
@@ -9,10 +9,168 @@ scenario, the `Zmachine` is started from an `Flist`.
 > Note, both VM and Container on ZOS are actually served as Virtual Machines. The
 only difference is that if you are running in VM mode, you only need to provide a **raw**
 disk image (image.raw) in your flist.
+
+## Container
+
+A container is meant to host `microservice`. The `microservice` architecture generally
+dictates that each service should be run in it's own container (therefore providing
+a level of isolation), and communicate with other containers it depends on over the
+network.
+
+Similar to docker. In Zos, a container is actually also run in a virtualized environment.
+Similar to containers, some setup is done on behalf of the user. After setup this is done,
+the users `entrypoint` is started.
+
+It should be noted that a container has no control over the kernel
+used to run it, if this is required, a `VM` should be used instead. Furthermore,
+a container should ideally only have 1 process running. A container can be a single
+binary, or a complete filesystem. In general, the first should be preferred, and
+if you need the latter, it might be an indication that you actually want a `VM`.
+
+For containers, the network setup will be created for you. Your init process can
+assume that it will be fully set up (according to the config you provided) by the
+time it is started. Mountpoints will also be setup for you. The environment variables
+passed will be available inside the container.
+
 ## VM
 
-In a VM mode, you run your own operating system (for now only linux is supported)
+In container mode, zos provide a minimal kernel that is used to run a light weight VM
+and then run your app from your flist. If you need control over the kernel you can actually
+still provide it inside the flist as follows:
+
+- /boot/vmlinuz
+- /boot/initrd.img [optional]
+
+**NOTE**: the vmlinuz MUST be an EFI kernel (not compressed) if building your own kernel, or you can use the [extract-vmlinux](https://github.com/torvalds/linux/blob/master/scripts/extract-vmlinux) script to extract the EFI kernel. To test if your kernel is a valid elf kernel run command
+`readelf -n <path/to/vmlinuz>`
+
+Any of those files can be a symlink to another file in the flist.
+
+If ZOS found the `/boot/vmlinuz` file, it will use this with the initrd.img if also exists. otherwise zos will use the built-in minimal kernel and run in `container` mode.
+
+### Building an ubuntu VM flist
+
+This is a guide to help you build a working VM flist.
+
+This guide is for ubuntu `jammy`
+
+prepare rootfs
+
+```bash
+mkdir ubuntu:jammy
+```
+
+bootstrap ubuntu
+
+```bash
+sudo debootstrap jammy ubuntu:jammy  http://archive.ubuntu.com/ubuntu
+```
+
+this will create and download the basic rootfs for ubuntu jammy in the directory `ubuntu:jammy`.
+After its done we can then chroot into this directory to continue installing the necessary packages needed and configure
+few things.
+
+> I am using script called `arch-chroot` which is available by default on arch but you can also install on ubuntu to continue
+the following steps
+
+```bash
+sudo arch-chroot ubuntu:jammy
+```
+
+> This script (similar to the `chroot` command) switch root to that given directory but also takes care of mounting /dev /sys, etc.. for you
+and clean it up on exit.
+
+Next just remove this link and re-create the file with a valid name to be able to continue
+
+```bash
+# make sure to set the path correctly
+export PATH=/usr/local/sbin/:/usr/local/bin/:/usr/sbin/:/usr/bin/:/sbin:/bin
+
+rm /etc/resolv.conf
+echo 'nameserver 1.1.1.1' > /etc/resolv.conf`
+```
+
+Install cloud-init
+
+```bash
+apt-get update
+apt-get cloud-init openssh-server curl
+# to make sure we have clean setup
+cloud-init clean
+```
+
+Also really important that we install a kernel
+
+```bash
+apt-get install linux-modules-extra-5.15.0-25-generic
+```
+
+> I choose this package because it will also install extra modules for us and a generic kernel
+
+Next make sure that virtiofs is part of the initramfs image
+
+```bash
+echo 'fs-virtiofs' >> /etc/initramfs-tools/modules
+update-initramfs -c -k all
+```
+
+clean up cache
+
+```bash
+apt-get clean
+```
+
+Last thing we do inside the container before we actually upload the flist
+is to make sure the kernel is in the correct format
+
+This step does not require that we stay in the chroot so hit `ctr+d` or type `exit`
+
+you should be out of the arch-chroot now
+
+```bash
+curl -O https://raw.githubusercontent.com/torvalds/linux/master/scripts/extract-vmlinux
+chmox +x extract-vmlinux
+
+sudo ./extract-vmlinux ubuntu:jammy/boot/vmlinuz | sudo tee ubuntu:jammy/boot/vmlinuz-5.15.0-25-generic.elf > /dev/null
+# then replace original kernel
+sudo mv ubuntu:jammy/boot/vmlinuz-5.15.0-25-generic.elf ubuntu:jammy/boot/vmlinuz-5.15.0-25-generic
+```
+
+To verify you can do this:
+
+```bash
+ls -l ubuntu:jammy/boot
+```
+
+and it should show something like
+
+```bash
+total 101476
+-rw-r--r-- 1 root root   260489 Mar 30  2022 config-5.15.0-25-generic
+drwxr-xr-x 1 root root       54 Jun 28 15:35 grub
+lrwxrwxrwx 1 root root       28 Jun 28 15:35 initrd.img -> initrd.img-5.15.0-25-generic
+-rw-r--r-- 1 root root 41392462 Jun 28 15:39 initrd.img-5.15.0-25-generic
+lrwxrwxrwx 1 root root       28 Jun 28 15:35 initrd.img.old -> initrd.img-5.15.0-25-generic
+-rw------- 1 root root  6246119 Mar 30  2022 System.map-5.15.0-25-generic
+lrwxrwxrwx 1 root root       25 Jun 28 15:35 vmlinuz -> vmlinuz-5.15.0-25-generic
+-rw-r--r-- 1 root root 55988436 Jun 28 15:50 vmlinuz-5.15.0-25-generic
+lrwxrwxrwx 1 root root       25 Jun 28 15:35 vmlinuz.old -> vmlinuz-5.15.0-25-generic
+```
+
+Now package the tar for upload
+
+```bash
+sudo rm -rf ubuntu:jammy/dev/*
+sudo tar -czf ubuntu-jammy.tar.gz -C ubuntu:jammy .
+```
+
+Upload to the hub, and use it to create a Zmachine
+
+## VM Image [deprecated]
+
+In a VM image mode, you run your own operating system (for now only linux is supported)
 The image provided must be
+
 - EFI bootable
 - Cloud-init enabled.
 
@@ -25,6 +183,11 @@ volume.
 The image used to the boot the VM must has cloud-init enabled on boot. Cloud-init
 receive its config over the NoCloud source. This takes care of setting up networking, hostname
 , root authorized_keys.
+
+> This method of building a full VM from a raw image is not recommended and will get phased out in
+the future. It's better to use either the container method to run containerized Apps. Another option
+is to run your own kernel from an flist (explained below)
+
 ### Expected Flist structure
 
 An `Zmachine` will be considered a `VM` if it contains an `/image.raw` file.
@@ -36,82 +199,74 @@ to take the full disk size allocated in the deployment.
 Note if the `image.raw` size is larger than the allocated disk. the workload for the VM
 will fail.
 
-## Container
-
-A container is meant to host `microservice`. The `microservice` architecture generally
-dictates that each service should be run in it's own container (therefore providing
-a level of isolation), and communicate with other containers it depends on over the
-network.
-
-In Zos, a container is actually also run in a virtualized environment. This is in
-contract of the usual approach of running containers on the host. Similar to containers,
-some setup is done on behalf of the user. After this is done, the users `entrypoint`
-is started. It should be noted that a container has no control over the kernel
-used to run it, if this is required, a `VM` should be used instead. Furthermore,
-a container should ideally only have 1 process running. A container can be a single
-binary, or a complete filesystem. In general, the first should be preferred, and
-if you need the latter, it might be an indication that you actually want a `VM`.
-
-For containers, the network setup will be created for you. Your init process can
-assume that it will be fully set up (according to the config you provided) by the
-time it is started. Mountpoints will also be setup for you. The environment variables
-passed will be available inside the container.
-
 ### Expected Flist structure
 
 Any Flist will boot as a container, **UNLESS** is has a `/image.raw` file. There is
 no need to specify a kernel yourself (it will be provided).
 
 ### Known issues
+
 - We need to do proper performance testing for `virtio-fs`. There seems to be some
     suboptimal performance right now.
 - It's not currently possible to get container logs.
 - TODO: more testing
 
 ## Creating VM image
+
 This is a simple tutorial on how to create your own VM image
 > Note: Please consider checking the official vm images repo on the hub before building your own
-image. this can save you a lot of time (and network traffice) here https://hub.grid.tf/tf-official-vms
+image. this can save you a lot of time (and network traffice) here <https://hub.grid.tf/tf-official-vms>
 
 ### Use one of ubuntu cloud-images
+
 If the ubuntu images in the official repo are not enough, you can simply upload one of the official images as follows
 
-- Visit https://cloud-images.ubuntu.com/
+- Visit <https://cloud-images.ubuntu.com/>
 - Select the version you want (let's assume bionic)
 - Go to bionic, then click on current
-- download the amd64.img file like this one https://cloud-images.ubuntu.com/bionic/current/bionic-server-cloudimg-amd64.img
+- download the amd64.img file like this one <https://cloud-images.ubuntu.com/bionic/current/bionic-server-cloudimg-amd64.img>
 - This is a `Qcow2` image, this is not supported by zos. So we need to convert this to a raw disk image using the following command
+
 ```bash
 qemu-img convert -p -f qcow2 -O raw bionic-server-cloudimg-amd64.img image.raw
 ```
+
 - now we have the raw image (image.raw) time to compress and upload to the hub
+
 ```bash
 tar -czf ubuntu-18.04-lts.tar.gz image.raw
 ```
-- now visit the hub https://hub.grid.tf/ and login or create your own account, then click on upload my file button
+
+- now visit the hub <https://hub.grid.tf/> and login or create your own account, then click on upload my file button
 - Select the newly created tar.gz file
 - Now you should be able to use this flist to create Zmachine workloads
 
 ### Create an image from scratch
+
 This is an advanced scenario and you will require some prior knowledge of how to create local VMs and how to prepare the installation medium,
 and installing your OS of choice.
 
 Before we continue you need to have some hypervisor that you can use locally. Libvirt/Qemu are good choices. Hence we skip on what you need to do to install and configure your system correctly not how to create the VM
 
 #### VM Requirements
+
 Create a VM with enough CPU and Memory to handle the installation process note that this does not relate on what your choices for CPU and Memory are going to be for the actual VM running on the grid.
 
 We going to install arch linux image. So we will have to create a VM with
+
 - Disk of about 2GB (note this also is not related to the final VM running on the grid, on installation the OS image will expand to use the entire allocated disk attached to the VM eventually). The smaller the disk is better this can be different for each OS.
 - Add the arch installation iso or any other installation medium
 
 #### Boot the VM (locally)
+
 Boot the VM to start installation. The boot must support EFI booting because ZOS only support images with esp partition. So make sure that both your hypervisor and boot/installation medium supports this.
 
 For example in Libvirt Manager make sure you are using the right firmware (UEFI)
 
 #### Installation
+
 We going to follow the installation manual for Arch linux but with slight tweaks:
+
 - Make sure VM is booted with UEFI, run `efivar -l` command see if you get any output. Otherwise the machine is probably booted in BIOS mode.
 - With `parted` create 2 partitions
   - an esp (boot) partition of 100M
@@ -136,6 +291,7 @@ parted $DISK print
 ```
 
 We need to format the partitions as follows:
+
 ```bash
 # this one has to be vfat of size 32 as follows
 mkfs.vfat -F 32 /dev/vda1
@@ -146,6 +302,7 @@ mkfs.ext4 -L cloud-root /dev/vda2
 Note the label assigned to the /dev/vda2 (root) partition this can be anything but it's needed to configure the boot later when installing the boot loader. Otherwise you can use the partition UUID.
 
 Next, we need to mount the disks
+
 ```bash
 mount /dev/vda2 /mnt
 mkdir /mnt/boot
@@ -153,6 +310,7 @@ mount /dev/vda1 /mnt/boot
 ```
 
 After disks are mounted as above, we need to start the installation
+
 ```bash
 pacstrap /mnt base linux linux-firmware vim openssh cloud-init cloud-guest-utils
 ```
@@ -160,6 +318,7 @@ pacstrap /mnt base linux linux-firmware vim openssh cloud-init cloud-guest-utils
 This will install basic arch linux but will also include cloud-init, cloud-guest-utils, openssh, and vim for convenience.
 
 Following the installation guid to generate fstab file
+
 ```
 genfstab -U /mnt >> /mnt/etc/fstab
 ```
@@ -168,11 +327,13 @@ And arch-chroot into /mnt `arch-chroot /mnt` to continue the setup. please follo
 
 - You don't have to set the hostname, this will be setup later on zos when the VM is deployed via cloud-init
 - let's drop the root password all together since login to the VM over ssh will require key authentication only, you can do this by running
+
 ```bash
 passwd -d root
 ```
 
 We make sure required services are enabled
+
 ```bash
 systemctl enable sshd
 systemctl enable systemd-networkd
@@ -191,40 +352,50 @@ Finally installing the boot loader as follows
 ```bash
 pacman -S grub
 ```
+
 Then we need to install grub
+
 ```
 grub-install --target=x86_64-efi --efi-directory=esp --removable
 ```
 
 Change default values as follows
+
 ```
 vim /etc/default/grub
 ```
+
 And make sure to change `GRUB_CMDLINE_LINUX_DEFAULT` as follows
 
 ```
 GRUB_CMDLINE_LINUX_DEFAULT="loglevel=3 console=tty console=ttyS0"
 ```
+
 > Note: we removed the `quiet` and add the console flags.
 
 Also set the `GRUB_TIMEOUT` to 0 for a faster boot
+
 ```
 GRUB_TIMEOUT=0
 ```
 
 Then finally generating the config
+
 ```
 grub-mkconfig -o /boot/grub/grub.cfg
 ```
 
 Last thing we need to do is clean up
+
 - pacman cache by running `rm -rf /var/cache/pacman/pkg`
 - cloud-init state by running `cloud-init clean`
 
 Click `Ctrl+D` to exit the change root, then power off by running `poweroff` command.
 
 > NOTE: if you booted the machine again you always need to do `cloud-init clean` as long as it's not yet deployed on ZOS this to make sure the image has a clean state
+>
 #### Converting the disk
+
 Based on your hypervisor of choice you might need to convert the disk to a `raw` image same way we did with ubuntu image.
 
 ```bash
@@ -233,6 +404,7 @@ qemu-img convert -p -f qcow2 -O raw /path/to/vm/disk.img image.raw
 ```
 
 Compress and tar the image.raw as before, and upload to the hub.
+
 ```
 tar -czf arch-linux.tar.gz image.raw
 ```

--- a/docs/manual/zmachine/zmachine.md
+++ b/docs/manual/zmachine/zmachine.md
@@ -215,7 +215,7 @@ no need to specify a kernel yourself (it will be provided).
 
 This is a simple tutorial on how to create your own VM image
 > Note: Please consider checking the official vm images repo on the hub before building your own
-image. this can save you a lot of time (and network traffice) here <https://hub.grid.tf/tf-official-vms>
+image. this can save you a lot of time (and network traffic) here <https://hub.grid.tf/tf-official-vms>
 
 ### Use one of ubuntu cloud-images
 

--- a/pkg/primitives/vm/utils.go
+++ b/pkg/primitives/vm/utils.go
@@ -36,23 +36,21 @@ func (p *Manager) prepVirtualMachine(
 	deployment *gridtypes.Deployment,
 	wl *gridtypes.WorkloadWithID,
 ) error {
-	var (
-		storage = stubs.NewStorageModuleStub(p.zbus)
-	)
+
+	var storage = stubs.NewStorageModuleStub(p.zbus)
 	// if a VM the vm has to have at least one mount
 	if len(config.Mounts) == 0 {
 		return fmt.Errorf("at least one mount has to be attached for Vm mode")
 	}
 
 	machine.KernelImage = filepath.Join(cloudImage, "hypervisor-fw")
-	var disk *gridtypes.WorkloadWithID
 	disk, err := deployment.Get(config.Mounts[0].Name)
 	if err != nil {
 		return err
 	}
 
 	if disk.Type != zos.ZMountType {
-		return fmt.Errorf("mount is not not a valid disk workload")
+		return fmt.Errorf("mount is not a valid disk workload")
 	}
 
 	if disk.Result.State != gridtypes.StateOk {
@@ -77,11 +75,7 @@ func (p *Manager) prepVirtualMachine(
 		Path: info.Path,
 	}
 
-	if err := p.vmMounts(ctx, deployment, config.Mounts[1:], false, machine); err != nil {
-		return err
-	}
-
-	return nil
+	return p.vmMounts(ctx, deployment, config.Mounts[1:], false, machine)
 }
 
 // prepare the machine and fill it up with proper boot flags for a container VM
@@ -356,7 +350,7 @@ func getFlistInfo(flistPath string) (flist FListInfo, err error) {
 			// to a location inside the flist
 			link, err := os.Readlink(path)
 			if err != nil {
-				return flist, errors.Wrapf(err, "failed to link at '%s", rel)
+				return flist, errors.Wrapf(err, "failed to read link at '%s", rel)
 			}
 			// now the link if joined with path, (and cleaned) need to also point
 			// to somewhere under flistPath

--- a/pkg/primitives/vm/utils.go
+++ b/pkg/primitives/vm/utils.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"net"
 	"os"
+	"path/filepath"
 	"strings"
 
 	"github.com/BurntSushi/toml"
@@ -24,6 +25,145 @@ var (
 		Mask: net.IPv4Mask(0xff, 0xff, 0, 0),
 	}
 )
+
+// fill up the VM (machine) object with write boot config for a full virtual machine (with a disk image)
+func (p *Manager) prepVirtualMachine(
+	ctx context.Context,
+	cloudImage string,
+	imageInfo FListInfo,
+	machine *pkg.VM,
+	config *zos.ZMachine,
+	deployment *gridtypes.Deployment,
+	wl *gridtypes.WorkloadWithID,
+) error {
+	var (
+		storage = stubs.NewStorageModuleStub(p.zbus)
+	)
+	// if a VM the vm has to have at least one mount
+	if len(config.Mounts) == 0 {
+		return fmt.Errorf("at least one mount has to be attached for Vm mode")
+	}
+
+	machine.KernelImage = filepath.Join(cloudImage, "hypervisor-fw")
+	var disk *gridtypes.WorkloadWithID
+	disk, err := deployment.Get(config.Mounts[0].Name)
+	if err != nil {
+		return err
+	}
+
+	if disk.Type != zos.ZMountType {
+		return fmt.Errorf("mount is not not a valid disk workload")
+	}
+
+	if disk.Result.State != gridtypes.StateOk {
+		return fmt.Errorf("boot disk was not deployed correctly")
+	}
+
+	info, err := storage.DiskLookup(ctx, disk.ID.String())
+	if err != nil {
+		return errors.Wrap(err, "disk does not exist")
+	}
+
+	//TODO: DiskWrite will not override the disk if it already has a partition table
+	// or a filesystem. this means that if later the disk is assigned to a new VM with
+	// a different flist it will have the same old operating system copied from previous
+	// setup.
+	if err = storage.DiskWrite(ctx, disk.ID.String(), imageInfo.ImagePath); err != nil {
+		return errors.Wrap(err, "failed to write image to disk")
+	}
+
+	machine.Boot = pkg.Boot{
+		Type: pkg.BootDisk,
+		Path: info.Path,
+	}
+
+	if err := p.vmMounts(ctx, deployment, config.Mounts[1:], false, machine); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+// prepare the machine and fill it up with proper boot flags for a container VM
+func (p *Manager) prepContainer(
+	ctx context.Context,
+	cloudImage string,
+	imageInfo FListInfo,
+	machine *pkg.VM,
+	config *zos.ZMachine,
+	deployment *gridtypes.Deployment,
+	wl *gridtypes.WorkloadWithID,
+) error {
+	// - if Container, remount RW
+	// prepare for container
+	var (
+		storage = stubs.NewStorageModuleStub(p.zbus)
+		flist   = stubs.NewFlisterStub(p.zbus)
+	)
+
+	if err := flist.Unmount(ctx, wl.ID.String()); err != nil {
+		return errors.Wrapf(err, "failed to unmount flist: %s", wl.ID.String())
+	}
+	rootfsSize := config.RootSize()
+	// create a persisted volume for the vm. we don't do it automatically
+	// via the flist, so we have control over when to decomission this volume.
+	// remounting in RW mode
+	volName := fmt.Sprintf("rootfs:%s", wl.ID.String())
+	volume, err := storage.VolumeCreate(ctx, volName, rootfsSize)
+	if err != nil {
+		return errors.Wrap(err, "failed to create vm rootfs")
+	}
+
+	defer func() {
+		if err != nil {
+			// vm creation failed,
+			if err := storage.VolumeDelete(ctx, volName); err != nil {
+				log.Error().Err(err).Str("volume", volName).Msg("failed to delete persisted volume")
+			}
+		}
+	}()
+
+	mnt, err := flist.Mount(ctx, wl.ID.String(), config.FList, pkg.MountOptions{
+		ReadOnly:        false,
+		PersistedVolume: volume.Path,
+	})
+
+	if err != nil {
+		return errors.Wrapf(err, "failed to mount flist: %s", wl.ID.String())
+	}
+
+	// inject container kernel and init
+	machine.KernelImage = filepath.Join(cloudImage, "kernel")
+	machine.InitrdImage = filepath.Join(cloudImage, "initramfs-linux.img")
+
+	// can be overridden from the flist itself if exists
+	if len(imageInfo.KernelPath) != 0 {
+		machine.KernelImage = imageInfo.KernelPath
+		machine.InitrdImage = imageInfo.InitrdPath
+	}
+
+	machine.Boot = pkg.Boot{
+		Type: pkg.BootVirtioFS,
+		Path: mnt,
+	}
+
+	if err := fListStartup(config, filepath.Join(mnt, ".startup.toml")); err != nil {
+		return errors.Wrap(err, "failed to apply startup config from flist")
+	}
+
+	machine.Entrypoint = config.Entrypoint
+	if err := p.vmMounts(ctx, deployment, config.Mounts, true, machine); err != nil {
+		return err
+	}
+	if config.Corex {
+		if err := p.copyFile("/usr/bin/corex", filepath.Join(mnt, "corex"), 0755); err != nil {
+			return errors.Wrap(err, "failed to inject corex binary")
+		}
+		machine.Entrypoint = "/corex --ipv6 -d 7 --interface eth0"
+	}
+
+	return nil
+}
 
 func (p *Manager) newYggNetworkInterface(ctx context.Context, wl *gridtypes.WorkloadWithID) (pkg.VMIface, error) {
 	network := stubs.NewNetworkerStub(p.zbus)
@@ -171,18 +311,68 @@ func (p *Manager) newPubNetworkInterface(ctx context.Context, deployment gridtyp
 	}, nil
 }
 
-func getFlistInfo(imagePath string) (FListInfo, error) {
-	image := imagePath + "/image.raw"
-	log.Debug().Str("file", image).Msg("checking image")
-	_, err := os.Stat(image)
+// FListInfo virtual machine details
+type FListInfo struct {
+	ImagePath  string
+	KernelPath string
+	InitrdPath string
+}
 
-	if os.IsNotExist(err) {
-		return FListInfo{}, nil
-	} else if err != nil {
-		return FListInfo{}, errors.Wrap(err, "couldn't stat /image.raw")
+func (t *FListInfo) IsContainer() bool {
+	return len(t.ImagePath) == 0
+}
+
+func getFlistInfo(flistPath string) (flist FListInfo, err error) {
+	files := map[string]*string{
+		"/image.raw":       &flist.ImagePath,
+		"/boot/vmlinuz":    &flist.KernelPath,
+		"/boot/initrd.img": &flist.InitrdPath,
 	}
 
-	return FListInfo{ImagePath: image}, nil
+	for rel, ptr := range files {
+		path := filepath.Join(flistPath, rel)
+		// this path can be a symlink so we need to make sure
+		// the symlink is pointing to only files inside the
+		// flist.
+
+		// but we need to validate
+		stat, err := os.Stat(path)
+		if os.IsNotExist(err) {
+			continue
+		} else if err != nil {
+			return flist, errors.Wrapf(err, "couldn't stat %s", rel)
+		}
+
+		if stat.IsDir() {
+			return flist, fmt.Errorf("path '%s' cannot be a directory", rel)
+		}
+		mod := stat.Mode()
+		switch mod.Type() {
+		case 0:
+			// regular file, do nothing
+		case os.ModeSymlink:
+			// this is a symlink. we
+			// need to make sure it's a safe link
+			// to a location inside the flist
+			link, err := os.Readlink(path)
+			if err != nil {
+				return flist, errors.Wrapf(err, "failed to link at '%s", rel)
+			}
+			// now the link if joined with path, (and cleaned) need to also point
+			// to somewhere under flistPath
+			abs := filepath.Clean(filepath.Join(flistPath, link))
+			if !strings.HasPrefix(abs, flistPath) {
+				return flist, fmt.Errorf("path '%s' points to invalid location", rel)
+			}
+		default:
+			return flist, fmt.Errorf("path '%s' is of invalid type: %s", rel, mod.Type().String())
+		}
+
+		// set the value
+		*ptr = path
+	}
+
+	return flist, nil
 }
 
 type startup struct {

--- a/pkg/primitives/vm/vm.go
+++ b/pkg/primitives/vm/vm.go
@@ -7,7 +7,6 @@ import (
 	"io"
 	"net"
 	"os"
-	"path/filepath"
 
 	"github.com/pkg/errors"
 	"github.com/rs/zerolog/log"
@@ -30,15 +29,6 @@ type ZMachine = zos.ZMachine
 // ZMachineResult type
 type ZMachineResult = zos.ZMachineResult
 
-// FListInfo virtual machine details
-type FListInfo struct {
-	ImagePath string
-}
-
-func (t *FListInfo) IsContainer() bool {
-	return len(t.ImagePath) == 0
-}
-
 var (
 	_ provision.Manager     = (*Manager)(nil)
 	_ provision.Initializer = (*Manager)(nil)
@@ -60,7 +50,7 @@ func (p *Manager) Provision(ctx context.Context, wl *gridtypes.WorkloadWithID) (
 	return p.virtualMachineProvisionImpl(ctx, wl)
 }
 
-func (p *Manager) vmMounts(ctx context.Context, deployment gridtypes.Deployment, mounts []zos.MachineMount, format bool, vm *pkg.VM) error {
+func (p *Manager) vmMounts(ctx context.Context, deployment *gridtypes.Deployment, mounts []zos.MachineMount, format bool, vm *pkg.VM) error {
 	for _, mount := range mounts {
 		wl, err := deployment.Get(mount.Name)
 		if err != nil {
@@ -117,7 +107,6 @@ func (p *Manager) mountQsfs(wl *gridtypes.WorkloadWithID, mount zos.MachineMount
 
 func (p *Manager) virtualMachineProvisionImpl(ctx context.Context, wl *gridtypes.WorkloadWithID) (result zos.ZMachineResult, err error) {
 	var (
-		storage = stubs.NewStorageModuleStub(p.zbus)
 		network = stubs.NewNetworkerStub(p.zbus)
 		flist   = stubs.NewFlisterStub(p.zbus)
 		vm      = stubs.NewVMModuleStub(p.zbus)
@@ -238,13 +227,6 @@ func (p *Manager) virtualMachineProvisionImpl(ctx context.Context, wl *gridtypes
 
 	log.Debug().Msgf("detected flist type: %+v", imageInfo)
 
-	var (
-		boot       pkg.Boot
-		entrypoint string
-		kernel     string
-		initrd     string
-	)
-
 	// mount cloud-container flist (or reuse) which has kernel, initrd and also firmware
 	hash, err := flist.FlistHash(ctx, cloudContainerFlist)
 	if err != nil {
@@ -260,113 +242,19 @@ func (p *Manager) virtualMachineProvisionImpl(ctx context.Context, wl *gridtypes
 	}
 
 	if imageInfo.IsContainer() {
-		// - if Container, remount RW
-		// prepare for container
-		if err := flist.Unmount(ctx, wl.ID.String()); err != nil {
-			return result, errors.Wrapf(err, "failed to unmount flist: %s", wl.ID.String())
-		}
-		rootfsSize := config.RootSize()
-		// create a persisted volume for the vm. we don't do it automatically
-		// via the flist, so we have control over when to decomission this volume.
-		// remounting in RW mode
-		volName := fmt.Sprintf("rootfs:%s", wl.ID.String())
-		volume, err := storage.VolumeCreate(ctx, volName, rootfsSize)
-		if err != nil {
-			return zos.ZMachineResult{}, errors.Wrap(err, "failed to create vm rootfs")
-		}
-
-		defer func() {
-			if err != nil {
-				// vm creation failed,
-				if err := storage.VolumeDelete(ctx, volName); err != nil {
-					log.Error().Err(err).Str("volume", volName).Msg("failed to delete persisted volume")
-				}
-			}
-		}()
-
-		mnt, err = flist.Mount(ctx, wl.ID.String(), config.FList, pkg.MountOptions{
-			ReadOnly:        false,
-			PersistedVolume: volume.Path,
-		})
-
-		if err != nil {
-			return result, errors.Wrapf(err, "failed to mount flist: %s", wl.ID.String())
-		}
-
-		// inject container kernel and init
-		kernel = filepath.Join(cloudImage, "kernel")
-		initrd = filepath.Join(cloudImage, "initramfs-linux.img")
-
-		boot = pkg.Boot{
-			Type: pkg.BootVirtioFS,
-			Path: mnt,
-		}
-
-		if err := fListStartup(&config, filepath.Join(mnt, ".startup.toml")); err != nil {
-			return result, errors.Wrap(err, "failed to apply startup config from flist")
-		}
-
-		entrypoint = config.Entrypoint
-		if err := p.vmMounts(ctx, deployment, config.Mounts, true, &machine); err != nil {
+		if err = p.prepContainer(ctx, cloudImage, imageInfo, &machine, &config, &deployment, wl); err != nil {
 			return result, err
-		}
-		if config.Corex {
-			if err := p.copyFile("/usr/bin/corex", filepath.Join(mnt, "corex"), 0755); err != nil {
-				return result, errors.Wrap(err, "failed to inject corex binary")
-			}
-			entrypoint = "/corex --ipv6 -d 7 --interface eth0"
 		}
 	} else {
-		// if a VM the vm has to have at least one mount
-		if len(config.Mounts) == 0 {
-			err = fmt.Errorf("at least one mount has to be attached for Vm mode")
+		if err = p.prepVirtualMachine(ctx, cloudImage, imageInfo, &machine, &config, &deployment, wl); err != nil {
 			return result, err
 		}
 
-		kernel = filepath.Join(cloudImage, "hypervisor-fw")
-		var disk *gridtypes.WorkloadWithID
-		disk, err = deployment.Get(config.Mounts[0].Name)
-		if err != nil {
-			return result, err
-		}
-
-		if disk.Type != zos.ZMountType {
-			return result, fmt.Errorf("mount is not not a valid disk workload")
-		}
-
-		if disk.Result.State != gridtypes.StateOk {
-			return result, fmt.Errorf("boot disk was not deployed correctly")
-		}
-		var info pkg.VDisk
-		info, err = storage.DiskLookup(ctx, disk.ID.String())
-		if err != nil {
-			return result, errors.Wrap(err, "disk does not exist")
-		}
-
-		//TODO: DiskWrite will not override the disk if it already has a partition table
-		// or a filesystem. this means that if later the disk is assigned to a new VM with
-		// a different flist it will have the same old operating system copied from previous
-		// setup.
-		if err = storage.DiskWrite(ctx, disk.ID.String(), imageInfo.ImagePath); err != nil {
-			return result, errors.Wrap(err, "failed to write image to disk")
-		}
-
-		boot = pkg.Boot{
-			Type: pkg.BootDisk,
-			Path: info.Path,
-		}
-		if err := p.vmMounts(ctx, deployment, config.Mounts[1:], false, &machine); err != nil {
-			return result, err
-		}
 	}
 
 	// - Attach mounts
 	// - boot
 	machine.Network = networkInfo
-	machine.KernelImage = kernel
-	machine.InitrdImage = initrd
-	machine.Boot = boot
-	machine.Entrypoint = entrypoint
 	machine.Environment = config.Env
 	machine.Hostname = wl.Name.String()
 

--- a/pkg/vm/machine.go
+++ b/pkg/vm/machine.go
@@ -13,7 +13,7 @@ import (
 )
 
 const (
-	virtioRootFsTag = "/dev/root"
+	virtioRootFsTag = "vroot"
 )
 
 // Boot config struct

--- a/pkg/vm/manager.go
+++ b/pkg/vm/manager.go
@@ -436,6 +436,7 @@ func (m *Module) Run(vm pkg.VM) (pkg.MachineInfo, error) {
 		// arguments
 		cmdline["root"] = virtioRootFsTag
 		cmdline["rootfstype"] = "virtiofs"
+		cmdline["rootdelay"] = "30"
 
 		// we add the fs for booting.
 		fs = append(fs, VirtioFS{


### PR DESCRIPTION
Fixes #1986

Enable loading custom kernel from the flist. This means that you can run your own custom kernel without the need to use a full vm image. 

The PR includes docs step by step how to build an ubuntu image from scratch