### PR TITLE
Use SSID to identify PCI devices

### DIFF
--- a/cmds/modules/provisiond/api.go
+++ b/cmds/modules/provisiond/api.go
@@ -86,8 +86,8 @@ func setupGPURmb(router rmb.Router, store provision.Storage) {
 		}
 
 		var list []Info
-		for _, device := range devices {
-			id := device.ShortID()
+		for _, pciDevice := range devices {
+			id := pciDevice.ShortID()
 			info := Info{
 				ID:       id,
 				Vendor:   "unknown",
@@ -95,10 +95,15 @@ func setupGPURmb(router rmb.Router, store provision.Storage) {
 				Contract: used[id],
 			}
 
-			vendor, device, ok := device.GetDevice()
+			vendor, device, ok := pciDevice.GetDevice()
 			if ok {
 				info.Vendor = vendor.Name
 				info.Device = device.Name
+			}
+
+			subdevice, ok := pciDevice.GetSubdevice()
+			if ok {
+				info.Device = subdevice.Name
 			}
 
 			list = append(list, info)

--- a/pkg/capacity/pci_test.go
+++ b/pkg/capacity/pci_test.go
@@ -8,22 +8,23 @@ import (
 )
 
 func TestGetDevice(t *testing.T) {
-	t.Run("get GPU without SSID", func(t *testing.T) {
-		vendor, device, ok := GetDevice(0x1002, 0x731f, 0, 0)
+	vendor, device, ok := GetDevice(0x1002, 0x731f)
 
-		require.True(t, ok)
-		require.Equal(t, "Advanced Micro Devices, Inc. [AMD/ATI]", vendor.Name)
-		require.Equal(t, "Navi 10 [Radeon RX 5600 OEM/5600 XT / 5700/5700 XT]", device.Name)
+	require.True(t, ok)
+	require.Equal(t, "Advanced Micro Devices, Inc. [AMD/ATI]", vendor.Name)
+	require.Equal(t, "Navi 10 [Radeon RX 5600 OEM/5600 XT / 5700/5700 XT]", device.Name)
+}
 
-	})
+func TestGetSubdevice(t *testing.T) {
+	subdevice, ok := GetSubdevice(0x10de, 0x1e30, 0x10de, 0x129e)
 
-	t.Run("get GPU with SSID", func(t *testing.T) {
-		vendor, device, ok := GetDevice(0x10de, 0x1e30, 0x10de, 0x129e)
+	require.True(t, ok)
+	require.Equal(t, "Quadro RTX 8000", subdevice.Name)
 
-		require.True(t, ok)
-		require.Equal(t, "NVIDIA Corporation", vendor.Name)
-		require.Equal(t, "Quadro RTX 8000", device.Name)
-	})
+	subdevice, ok = GetSubdevice(0x10de, 0x1e30, 0x10de, 0x12ba)
+
+	require.True(t, ok)
+	require.Equal(t, "Quadro RTX 6000", subdevice.Name)
 }
 
 func TestListPCI(t *testing.T) {

--- a/pkg/capacity/pci_test.go
+++ b/pkg/capacity/pci_test.go
@@ -8,11 +8,22 @@ import (
 )
 
 func TestGetDevice(t *testing.T) {
-	vendor, device, ok := GetDevice(0x1002, 0x731f)
+	t.Run("get GPU without SSID", func(t *testing.T) {
+		vendor, device, ok := GetDevice(0x1002, 0x731f, 0, 0)
 
-	require.True(t, ok)
-	require.Equal(t, "Advanced Micro Devices, Inc. [AMD/ATI]", vendor.Name)
-	require.Equal(t, "Navi 10 [Radeon RX 5600 OEM/5600 XT / 5700/5700 XT]", device.Name)
+		require.True(t, ok)
+		require.Equal(t, "Advanced Micro Devices, Inc. [AMD/ATI]", vendor.Name)
+		require.Equal(t, "Navi 10 [Radeon RX 5600 OEM/5600 XT / 5700/5700 XT]", device.Name)
+
+	})
+
+	t.Run("get GPU with SSID", func(t *testing.T) {
+		vendor, device, ok := GetDevice(0x10de, 0x1e30, 0x10de, 0x129e)
+
+		require.True(t, ok)
+		require.Equal(t, "NVIDIA Corporation", vendor.Name)
+		require.Equal(t, "Quadro RTX 8000", device.Name)
+	})
 }
 
 func TestListPCI(t *testing.T) {


### PR DESCRIPTION
Use SSID to further specify which device is connected to PCI.

Related: #1994 

Notes:
- Some GPUs will still not be identified accurately due to `pci.ids` not having SSID for all devices.