### PR TITLE
update zui service to be after redis in zinit service tree

### DIFF
--- a/etc/zinit/zui.yaml
+++ b/etc/zinit/zui.yaml
@@ -12,3 +12,4 @@ exec: |
   '
 after:
   - quiet
+  - redis


### PR DESCRIPTION
## Related issues:

- #1985 