### PR TITLE
Sort zmount workloads in descending order

### DIFF
--- a/pkg/provision/engine.go
+++ b/pkg/provision/engine.go
@@ -868,30 +868,28 @@ func (e *NativeEngine) uninstallDeployment(ctx context.Context, dl *gridtypes.De
 
 }
 
-func getZmountSize(wl *gridtypes.WorkloadWithID) (gridtypes.Unit, error) {
-	dataI, err := wl.WorkloadData()
+func getZmountSize(wl *gridtypes.Workload) (gridtypes.Unit, error) {
+	data, err := wl.WorkloadData()
 	if err != nil {
 		return 0, err
 	}
-	zmount, ok := dataI.(*zos.ZMount)
+	zmount, ok := data.(*zos.ZMount)
 	if !ok {
-		return 0, fmt.Errorf("failed to get workload data as a zmount '%v'", dataI)
+		return 0, fmt.Errorf("failed to get workload data as a zmount '%v'", data)
 	}
 	return zmount.Size, nil
 }
 
 func sortZmountWorkloads(workloads []*gridtypes.WorkloadWithID) {
 	sort.Slice(workloads, func(i, j int) bool {
-		sizeI, err := getZmountSize(workloads[i])
+		sizeI, err := getZmountSize(workloads[i].Workload)
 		if err != nil {
-			log.Error().Err(err).Stringer("id", workloads[i].ID).Msg("failed to get zmount size")
 			return false
 		}
 
-		sizeJ, err := getZmountSize(workloads[j])
+		sizeJ, err := getZmountSize(workloads[j].Workload)
 		if err != nil {
-			log.Error().Err(err).Stringer("id", workloads[j].ID).Msg("failed to get zmount size")
-			return true
+			return false
 		}
 
 		return sizeI > sizeJ

--- a/pkg/provision/engine_test.go
+++ b/pkg/provision/engine_test.go
@@ -83,21 +83,21 @@ func TestGetZmountSize(t *testing.T) {
 		wl := gridtypes.WorkloadWithID{
 			Workload: &gridtypes.Workload{Type: "invalid"},
 		}
-		_, err := getZmountSize(&wl)
+		_, err := getZmountSize(wl.Workload)
 		assert.Error(t, err)
 	})
 	t.Run("different data type", func(t *testing.T) {
 		wl := gridtypes.WorkloadWithID{
 			Workload: &gridtypes.Workload{Type: zos.ZDBType, Data: json.RawMessage(`{"size": 10}`)},
 		}
-		_, err := getZmountSize(&wl)
+		_, err := getZmountSize(wl.Workload)
 		assert.Error(t, err)
 	})
 	t.Run("valid data", func(t *testing.T) {
 		wl := gridtypes.WorkloadWithID{
 			Workload: &gridtypes.Workload{Type: zos.ZMountType, Data: json.RawMessage(`{"size": 10}`)},
 		}
-		size, err := getZmountSize(&wl)
+		size, err := getZmountSize(wl.Workload)
 		assert.NoError(t, err)
 		assert.Equal(t, size, gridtypes.Unit(10))
 	})

--- a/pkg/provision/engine_test.go
+++ b/pkg/provision/engine_test.go
@@ -1,5 +1,14 @@
 package provision
 
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/threefoldtech/zos/pkg/gridtypes"
+	"github.com/threefoldtech/zos/pkg/gridtypes/zos"
+)
+
 // func TestEngine(t *testing.T) {
 // 	td, err := ioutil.TempDir("", "")
 // 	require.NoError(t, err)
@@ -68,3 +77,29 @@ package provision
 // 	assert.EqualValues(t, 1, workloads.ZDBNamespace)
 // 	assert.EqualValues(t, 0, workloads.K8sVM)
 // }
+
+func TestGetZmountSize(t *testing.T) {
+	t.Run("invalid type", func(t *testing.T) {
+		wl := gridtypes.WorkloadWithID{
+			Workload: &gridtypes.Workload{Type: "invalid"},
+		}
+		_, err := getZmountSize(&wl)
+		assert.Error(t, err)
+	})
+	t.Run("different data type", func(t *testing.T) {
+		wl := gridtypes.WorkloadWithID{
+			Workload: &gridtypes.Workload{Type: zos.ZDBType, Data: json.RawMessage(`{"size": 10}`)},
+		}
+		_, err := getZmountSize(&wl)
+		assert.Error(t, err)
+	})
+	t.Run("valid data", func(t *testing.T) {
+		wl := gridtypes.WorkloadWithID{
+			Workload: &gridtypes.Workload{Type: zos.ZMountType, Data: json.RawMessage(`{"size": 10}`)},
+		}
+		size, err := getZmountSize(&wl)
+		assert.NoError(t, err)
+		assert.Equal(t, size, gridtypes.Unit(10))
+	})
+
+}

--- a/pkg/provision/engine_test.go
+++ b/pkg/provision/engine_test.go
@@ -103,3 +103,38 @@ func TestGetZmountSize(t *testing.T) {
 	})
 
 }
+
+func TestSortZmountWorkloads(t *testing.T) {
+	workloads := []*gridtypes.WorkloadWithID{
+		{Workload: &gridtypes.Workload{
+			Type: zos.ZMountType,
+			Data: json.RawMessage(`{"size": 10}`),
+		}},
+		{Workload: &gridtypes.Workload{
+			Type: zos.ZMountType,
+			Data: json.RawMessage(`{"size": 30}`),
+		}},
+		{Workload: &gridtypes.Workload{
+			Type: zos.ZMountType,
+			Data: json.RawMessage(`{"size": 20}`),
+		}},
+	}
+
+	expectedWorkloads := []*gridtypes.WorkloadWithID{
+		{Workload: &gridtypes.Workload{
+			Type: zos.ZMountType,
+			Data: json.RawMessage(`{"size": 30}`),
+		}},
+		{Workload: &gridtypes.Workload{
+			Type: zos.ZMountType,
+			Data: json.RawMessage(`{"size": 20}`),
+		}},
+		{Workload: &gridtypes.Workload{
+			Type: zos.ZMountType,
+			Data: json.RawMessage(`{"size": 10}`),
+		}},
+	}
+
+	sortZmountWorkloads(workloads)
+	assert.Equal(t, expectedWorkloads, workloads)
+}


### PR DESCRIPTION
Sort zmount workloads so larger disks get assigned first.

Related: #2016 