### PR TITLE
wip: sync power state

### DIFF
--- a/cmds/modules/powerd/main.go
+++ b/cmds/modules/powerd/main.go
@@ -1,6 +1,7 @@
 package powerd
 
 import (
+	"context"
 	"crypto/ed25519"
 
 	"github.com/pkg/errors"
@@ -108,5 +109,9 @@ func action(cli *cli.Context) error {
 		return errors.Wrap(err, "failed to initialize power manager")
 	}
 
-	return power.Start(ctx)
+	if err := power.Start(ctx); err != nil && !errors.Is(err, context.Canceled) {
+		return err
+	}
+
+	return nil
 }

--- a/pkg/events/redis.go
+++ b/pkg/events/redis.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"reflect"
 	"strings"
+	"time"
 
 	"github.com/centrifuge/go-substrate-rpc-client/v4/types"
 	"github.com/gomodule/redigo/redis"
@@ -242,6 +243,12 @@ func (r *RedisConsumer) consumer(ctx context.Context, stream string, ch reflect.
 			messages, err := r.pop(con, group, stream)
 			if err != nil {
 				logger.Error().Err(err).Msg("failed to get events from")
+				select {
+				case <-ctx.Done():
+					return
+				case <-time.After(2 * time.Second):
+					continue
+				}
 			}
 
 			for _, message := range messages {

--- a/pkg/power/power.go
+++ b/pkg/power/power.go
@@ -60,10 +60,6 @@ const (
 	PowerServerPort  = 8039
 )
 
-var (
-	errConnectionError = fmt.Errorf("connection error")
-)
-
 func EnsureWakeOnLan(ctx context.Context) (bool, error) {
 	inf, err := bridge.Get(DefaultWolBridge)
 	if err != nil {
@@ -303,7 +299,7 @@ func (p *PowerServer) recv(ctx context.Context) error {
 func (p *PowerServer) events(ctx context.Context) error {
 	// first thing we need to make sure we are not suppose to be powered
 	// off, so we need to sync with grid
-	// 1) make sure at least one uptime was already sent
+	// make sure at least one uptime was already sent
 	_ = p.ut.Mark.Done(ctx)
 
 	// if the stream loop fails for any reason retry


### PR DESCRIPTION
This to make sure that the state is always synced
even if handling of an event fails!

Also make sure error processing an event is logged

Fixes #2029