### PR TITLE
Fix setting the gateway and caching the request

### DIFF
--- a/pkg/perf/publicip/publicip_task.go
+++ b/pkg/perf/publicip/publicip_task.go
@@ -163,13 +163,11 @@ func (p *publicIPValidationTask) validateIPs(publicIPs []substrate.PublicIP) err
 				State:  InvalidState,
 				Reason: PublicIPDataInvalid,
 			}
-			log.Err(err).Send()
 		} else if err != nil {
 			p.farmIPsReport[publicIP.IP] = IPReport{
 				State:  SkippedState,
 				Reason: FetchRealIPFailed,
 			}
-			log.Err(err).Send()
 		} else if !ip.Equal(realIP) {
 			p.farmIPsReport[publicIP.IP] = IPReport{
 				State:  InvalidState,


### PR DESCRIPTION
## Description

There was an issue with the way the routes was set using the gateway which set the valid public IPs as invalid. Also, http.Get caches the request (or uses the host ns) and actually makes the request when it shouldn't even reach the validation service. So, changed that too.