### PR TITLE
fixes for perf pacakge

### DIFF
--- a/cmds/modules/noded/main.go
+++ b/cmds/modules/noded/main.go
@@ -216,13 +216,16 @@ func action(cli *cli.Context) error {
 		return errors.Wrap(err, "failed to run the scheduler")
 	}
 	bus.WithHandler("zos.perf.get", func(ctx context.Context, payload []byte) (interface{}, error) {
-		var taskName string
-		err := json.Unmarshal(payload, &taskName)
+		type Payload struct {
+			Name string `json:"name"`
+		}
+		var request Payload
+		err := json.Unmarshal(payload, &request)
 		if err != nil {
-			return nil, errors.Wrapf(err, "failed to unmarshal payload: %v", payload)
+			return nil, errors.Wrapf(err, "failed to decode payload: %v", payload)
 		}
 
-		return perfMon.Get(taskName)
+		return perfMon.Get(request.Name)
 	})
 	bus.WithHandler("zos.perf.get_all", func(ctx context.Context, payload []byte) (interface{}, error) {
 		return perfMon.GetAll()

--- a/cmds/modules/noded/main.go
+++ b/cmds/modules/noded/main.go
@@ -217,12 +217,12 @@ func action(cli *cli.Context) error {
 	}
 	bus.WithHandler("zos.perf.get", func(ctx context.Context, payload []byte) (interface{}, error) {
 		type Payload struct {
-			Name string `json:"name"`
+			Name string
 		}
 		var request Payload
 		err := json.Unmarshal(payload, &request)
 		if err != nil {
-			return nil, errors.Wrapf(err, "failed to decode payload: %v", payload)
+			return nil, errors.Wrapf(err, "failed to unmarshal payload: %v", payload)
 		}
 
 		return perfMon.Get(request.Name)

--- a/docs/tasks/README.md
+++ b/docs/tasks/README.md
@@ -24,7 +24,7 @@ Tasks are scheduled using a 6 fields cron format. this format provides flexibili
   - Payload: a payload type that contains the name of the test
     ```go
     type Payload struct {
-      Name string `json:"name"`
+      Name string 
     }
     ```
 
@@ -65,5 +65,3 @@ Notes:
 - [CPU benchmark](./cpubench.md)
 - [IPerf](./iperf.md)
 - To add new task, [check](../../pkg/perf/README.md)
-
-

--- a/docs/tasks/README.md
+++ b/docs/tasks/README.md
@@ -21,13 +21,27 @@ Tasks are scheduled using a 6 fields cron format. this format provides flexibili
 ### RMB commands
 
 - `zos.perf.get`:
-  Payload: string representing the task name.
-  Return: a single task result.
-  Possible Error: `ErrResultNotFound` if no result is stored for the given task.
+  - Payload: a payload type that contains the name of the test
+    ```go
+    type Payload struct {
+      Name string `json:"name"`
+    }
+    ```
+
+    Possible values:
+      - `"public-ip-validation"`
+      - `"cpu-benchmark"`
+      - `"iperf"`
+
+  - Return: a single task result.
+
+  - Possible Error: `ErrResultNotFound` if no result is stored for the given task.
 
 - `zos.perf.get_all`:
-  Return: all stored results
 
+  - Return: all stored results
+
+The rmb direct client can be used to call these commands. check the [example](https://github.com/threefoldtech/tfgrid-sdk-go/blob/development/rmb-sdk-go/examples/client_rpc/main.go)
 ### Caching
 
 Results are stored in a Redis server running on the node.
@@ -37,6 +51,7 @@ The value is an instance of `TaskResult` struct contains:
 
 - Name of the task
 - Timestamp when the task was run
+- A brief description about what the task do
 - The actual returned result from the task
 
 Notes:
@@ -45,7 +60,10 @@ Notes:
 - Storing results prefixed with `perf` eases retrieving all the results stored by this module.
 
 ### Registered tests
+
 - [Public IP validation](./publicips.md)
 - [CPU benchmark](./cpubench.md)
 - [IPerf](./iperf.md)
-- To add new task, [check](../../pkg/perf/README.md) 
+- To add new task, [check](../../pkg/perf/README.md)
+
+

--- a/docs/tasks/cpubench.md
+++ b/docs/tasks/cpubench.md
@@ -6,7 +6,7 @@ The `CPUBenchmark` task is designed to measure the performance of the CPU. it ut
 
 ### Configuration
 
-- Name: `CPUBenchmark`
+- Name: `cpu-benchmark`
 - Schedule: 4 times a day
 
 ### Details
@@ -14,3 +14,18 @@ The `CPUBenchmark` task is designed to measure the performance of the CPU. it ut
 - The benchmark simply runs a `CRC64` computation task, calculates the time spent in the computation and reports it in `seconds`.
 - The computation is performed in both single-threaded and multi-threaded scenarios.
 - Lower time = better performance: for a single threaded benchmark, a lower execution time indicates better performance.
+
+### Result sample
+```json
+{
+  "description": "Measures the performance of the node CPU by reporting the timespent of computing a task in seconds.",
+  "name": "cpu-benchmark",
+  "result": {
+    "multi": 1.105,
+    "single": 1.135,
+    "threads": 1,
+    "workloads": 0
+  },
+  "timestamp": 1700504403
+}
+```

--- a/docs/tasks/iperf.md
+++ b/docs/tasks/iperf.md
@@ -6,7 +6,7 @@ The `iperf` package is designed to facilitate network performance testing using 
 
 ### Configuration
 
-- Name: "IPerf"
+- Name: `iperf`
 - Schedule: 4 times a day
 
 ### Details
@@ -24,3 +24,47 @@ The `iperf` package is designed to facilitate network performance testing using 
     Error: Any error encountered during the test.
     CpuReport: CPU utilization report.
   ```
+
+### Result sample
+
+```json
+ {
+    "description": "Test public nodes network performance with both UDP and TCP over IPv4 and IPv6",
+    "name": "IPerf",
+    "result": [
+      {
+        "cpu_report": {
+          "host_system": 2.4433388913571044,
+          "host_total": 3.542919199613454,
+          "host_user": 1.0996094859359695,
+          "remote_system": 0.24430594945859846,
+          "remote_total": 0.3854457128784448,
+          "remote_user": 0.14115962407747246
+        },
+        "download_speed": 1041274.4792242317,
+        "error": "",
+        "node_id": 124,
+        "node_ip": "88.99.30.200",
+        "test_type": "tcp",
+        "upload_speed": 1048549.3668460822
+      },
+      {
+        "cpu_report": {
+          "host_system": 0,
+          "host_total": 0,
+          "host_user": 0,
+          "remote_system": 0,
+          "remote_total": 0,
+          "remote_user": 0
+        },
+        "download_speed": 0,
+        "error": "unable to connect to server - server may have stopped running or use a different port, firewall issue, etc.: Network unreachable",
+        "node_id": 124,
+        "node_ip": "2a01:4f8:10a:710::2",
+        "test_type": "tcp",
+        "upload_speed": 0
+      },
+    ],
+  "timestamp": 1700507035
+ }
+```

--- a/docs/tasks/iperf.md
+++ b/docs/tasks/iperf.md
@@ -6,7 +6,7 @@ The `iperf` package is designed to facilitate network performance testing using 
 
 ### Configuration
 
-- Name: iperf
+- Name: "IPerf"
 - Schedule: 4 times a day
 
 ### Details

--- a/docs/tasks/publicips.md
+++ b/docs/tasks/publicips.md
@@ -2,13 +2,11 @@
 
 The goal of the task is to make sure public IPs assigned to a farm are valid and can be assigned to deployments.
 
-## Schedule
+### Configuration
 
-The task is scheduled to run 4 times a day.
+- Name: `public-ip-validation`
+- Schedule: 4 times a day
 
-## Task ID
-
-`PublicIPValidation`
 
 ## Task Details
 
@@ -30,3 +28,18 @@ The task only returns a single map of String (IP) to IPReport. The report consis
 
 ### Notes
 - Previously tested ips and marked as `Valid` doesn't get revalidated again.
+
+### Result sample
+```json
+{
+  "description": "Runs on the least NodeID node in a farm to validate all its IPs.",
+  "name": "public-ip-validation",
+  "result": {
+    "185.206.122.29/24": {
+      "reason": "public ip or gateway data are not valid",
+      "state": "invalid"
+    }
+  },
+  "timestamp": 1700504421
+}
+```

--- a/pkg/perf/README.md
+++ b/pkg/perf/README.md
@@ -10,8 +10,8 @@ Perf tests are monitored by `noded` service from zos modules.
 
 ```go
 type LoggingTask struct {
-	taskID   	string
-	schedule 	string // should be in cron syntax with seconds ("* 0 * * * *")
+	taskID      string
+	schedule    string // should be in cron syntax with seconds ("* 0 * * * *")
 	description string
 }
 
@@ -38,8 +38,8 @@ func (t *LoggingTask) Run(ctx context.Context) (interface{}, error) {
 
 ```go
 perfMon.AddTask(&perf.LoggingTask{
-    taskID:      "LoggingTask",
-    schedule:    "* 0 * * * *", // when minutes is 0 (aka: every hour)
-	description: "Simple task that logs the time every hour"
+	taskID:      "LoggingTask",
+	schedule:    "* 0 * * * *", // when minutes is 0 (aka: every hour)
+	description: "Simple task that logs the time every hour",
 })
 ```

--- a/pkg/perf/README.md
+++ b/pkg/perf/README.md
@@ -10,16 +10,21 @@ Perf tests are monitored by `noded` service from zos modules.
 
 ```go
 type LoggingTask struct {
-	TaskID   string
-	Schedule string // should be in cron syntax with seconds ("* 0 * * * *")
+	taskID   	string
+	schedule 	string // should be in cron syntax with seconds ("* 0 * * * *")
+	description string 
 }
 
 func (t *LoggingTask) ID() string {
-	return t.TaskID
+	return t.taskID
 }
 
 func (t *LoggingTask) Cron() string {
-	return t.Schedule
+	return t.schedule
+}
+
+func (t *LoggingTask) Description() string {
+	return t.description
 }
 
 // a simple task that returns a string with the current time
@@ -33,7 +38,8 @@ func (t *LoggingTask) Run(ctx context.Context) (interface{}, error) {
 
 ```go
 perfMon.AddTask(&perf.LoggingTask{
-    TaskID:   "LoggingTask",
-    Schedule: "* 0 * * * *", // when minutes is 0 (aka: every hour)
+    taskID:   "LoggingTask",
+    schedule: "* 0 * * * *", // when minutes is 0 (aka: every hour)
+	description: "Simple task that logs the time every hour"
 })
 ```

--- a/pkg/perf/README.md
+++ b/pkg/perf/README.md
@@ -12,7 +12,7 @@ Perf tests are monitored by `noded` service from zos modules.
 type LoggingTask struct {
 	taskID   	string
 	schedule 	string // should be in cron syntax with seconds ("* 0 * * * *")
-	description string 
+	description string
 }
 
 func (t *LoggingTask) ID() string {
@@ -38,8 +38,8 @@ func (t *LoggingTask) Run(ctx context.Context) (interface{}, error) {
 
 ```go
 perfMon.AddTask(&perf.LoggingTask{
-    taskID:   "LoggingTask",
-    schedule: "* 0 * * * *", // when minutes is 0 (aka: every hour)
+    taskID:      "LoggingTask",
+    schedule:    "* 0 * * * *", // when minutes is 0 (aka: every hour)
 	description: "Simple task that logs the time every hour"
 })
 ```

--- a/pkg/perf/cache.go
+++ b/pkg/perf/cache.go
@@ -19,9 +19,10 @@ var (
 
 // TaskResult the result test schema
 type TaskResult struct {
-	Name      string      `json:"name"`
-	Timestamp uint64      `json:"timestamp"`
-	Result    interface{} `json:"result"`
+	Name        string      `json:"name"`
+	Description string      `json:"description"`
+	Timestamp   uint64      `json:"timestamp"`
+	Result      interface{} `json:"result"`
 }
 
 // generateKey is helper method to add moduleName as prefix for the taskName

--- a/pkg/perf/cpubench/cpubench_task.go
+++ b/pkg/perf/cpubench/cpubench_task.go
@@ -10,8 +10,11 @@ import (
 	"github.com/threefoldtech/zos/pkg/stubs"
 )
 
-const cpuBenchmarkTaskID = "CPUBenchmark"
-const cpuBenchmarkCronSchedule = "0 0 */6 * * *"
+const (
+	cpuBenchmarkTaskID       = "CPUBenchmark"
+	cpuBenchmarkCronSchedule = "0 0 */6 * * *"
+	cpuBenchmarkDescription  = "Measures the performance of the node CPU by reporting the timespent of computing a task in seconds."
+)
 
 // CPUBenchmarkTask defines CPU benchmark task data.
 type CPUBenchmarkTask struct {
@@ -19,6 +22,8 @@ type CPUBenchmarkTask struct {
 	taskID string
 	// schedule is a 6 field cron schedule (unlike unix cron).
 	schedule string
+	// description briefly describe what a task do.
+	description string
 }
 
 // CPUBenchmarkResult holds CPU benchmark results with the workloads number during the benchmark.
@@ -34,8 +39,9 @@ var _ perf.Task = (*CPUBenchmarkTask)(nil)
 // NewCPUBenchmarkTask returns a new CPU benchmark task.
 func NewCPUBenchmarkTask() CPUBenchmarkTask {
 	return CPUBenchmarkTask{
-		taskID:   cpuBenchmarkTaskID,
-		schedule: cpuBenchmarkCronSchedule,
+		taskID:      cpuBenchmarkTaskID,
+		schedule:    cpuBenchmarkCronSchedule,
+		description: cpuBenchmarkDescription,
 	}
 }
 
@@ -47,6 +53,11 @@ func (c *CPUBenchmarkTask) ID() string {
 // Cron returns task cron schedule.
 func (c *CPUBenchmarkTask) Cron() string {
 	return c.schedule
+}
+
+// Description returns task description.
+func (c *CPUBenchmarkTask) Description() string {
+	return c.description
 }
 
 // Run executes the CPU benchmark.

--- a/pkg/perf/cpubench/cpubench_task.go
+++ b/pkg/perf/cpubench/cpubench_task.go
@@ -11,7 +11,7 @@ import (
 )
 
 const (
-	cpuBenchmarkTaskID       = "CPUBenchmark"
+	cpuBenchmarkTaskID       = "cpu-benchmark"
 	cpuBenchmarkCronSchedule = "0 0 */6 * * *"
 	cpuBenchmarkDescription  = "Measures the performance of the node CPU by reporting the timespent of computing a task in seconds."
 )

--- a/pkg/perf/graphql/graphql_nodes.go
+++ b/pkg/perf/graphql/graphql_nodes.go
@@ -9,6 +9,11 @@ import (
 	graphql "github.com/hasura/go-graphql-client"
 )
 
+const (
+	nodeUpStateFactor    = 2                // number of the cycles for the upInterval
+	nodeUpReportInterval = time.Minute * 40 // the interval to report for the up node
+)
+
 // GraphQl for tf graphql client
 type GraphQl struct {
 	client *graphql.Client
@@ -57,8 +62,7 @@ func (g *GraphQl) ListPublicNodes(ctx context.Context, nodesNum int, farmID, exc
 		excludeFarmCond = fmt.Sprintf(", farmID_not_eq: %d", excludeFarmID)
 	}
 
-	nodeUpReportInterval := time.Minute * 40
-	nodeUpInterval := time.Now().Unix() - 2*int64(nodeUpReportInterval.Seconds())
+	nodeUpInterval := time.Now().Unix() - int64(nodeUpStateFactor)*int64(nodeUpReportInterval.Seconds())
 	whereCond := fmt.Sprintf(`where: { updatedAt_gte: %d, AND: {power_isNull: true, OR: {power: {state_eq: Up, target_eq: Up}}}, publicConfig: {%s} %s %s }`, nodeUpInterval, pubCond, farmCond, excludeFarmCond)
 
 	itemCount, err := g.getItemTotalCount(ctx, "nodes", whereCond)
@@ -102,4 +106,21 @@ func (g *GraphQl) getItemTotalCount(ctx context.Context, itemName string, option
 	}
 
 	return res.Items.Count, nil
+}
+
+// GetFarmUpNodes returns a list of up nodes on a farm
+func (g *GraphQl) GetFarmUpNodes(ctx context.Context, farmID uint32) ([]Node, error) {
+	nodeUpInterval := time.Now().Unix() - int64(nodeUpStateFactor)*int64(nodeUpReportInterval.Seconds())
+	upCondition := fmt.Sprintf(`where: {updatedAt_gte: %d, farmID_eq: %d}`, nodeUpInterval, farmID)
+	query := fmt.Sprintf("query{nodes(%s){nodeID}}", upCondition)
+
+	res := struct {
+		Nodes []Node
+	}{}
+
+	if err := g.client.Exec(ctx, query, &res, nil); err != nil {
+		return []Node{}, err
+	}
+
+	return res.Nodes, nil
 }

--- a/pkg/perf/graphql/graphql_nodes.go
+++ b/pkg/perf/graphql/graphql_nodes.go
@@ -37,13 +37,13 @@ type PublicConfig struct {
 	Ipv6 string `graphql:"ipv6"`
 }
 
-// ListPublicNodes returns a list of public nodes
+// GetUpNodes returns a list of public nodes
 // if nodesNum is given the query will use a limit and offset
 // farmID id if not equal 0 will add a condition for it
 // excludeFarmID if not equal 0 will add a condition ro exclude the farm ID
 // ipv4 pool to set a condition for non empty ipv4
 // ipv6 pool to set a condition for non empty ipv6
-func (g *GraphQl) ListPublicNodes(ctx context.Context, nodesNum int, farmID, excludeFarmID uint32, ipv4, ipv6 bool) ([]Node, error) {
+func (g *GraphQl) GetUpNodes(ctx context.Context, nodesNum int, farmID, excludeFarmID uint32, ipv4, ipv6 bool) ([]Node, error) {
 	var pubCond string
 	if ipv4 {
 		pubCond = `ipv4_isNull: false, ipv4_not_eq: ""`
@@ -106,21 +106,4 @@ func (g *GraphQl) getItemTotalCount(ctx context.Context, itemName string, option
 	}
 
 	return res.Items.Count, nil
-}
-
-// GetFarmUpNodes returns a list of up nodes on a farm
-func (g *GraphQl) GetFarmUpNodes(ctx context.Context, farmID uint32) ([]Node, error) {
-	nodeUpInterval := time.Now().Unix() - int64(nodeUpStateFactor)*int64(nodeUpReportInterval.Seconds())
-	upCondition := fmt.Sprintf(`where: {updatedAt_gte: %d, farmID_eq: %d}`, nodeUpInterval, farmID)
-	query := fmt.Sprintf("query{nodes(%s){nodeID}}", upCondition)
-
-	res := struct {
-		Nodes []Node
-	}{}
-
-	if err := g.client.Exec(ctx, query, &res, nil); err != nil {
-		return []Node{}, err
-	}
-
-	return res.Nodes, nil
 }

--- a/pkg/perf/iperf/iperf_task.go
+++ b/pkg/perf/iperf/iperf_task.go
@@ -70,13 +70,13 @@ func (t *IperfTest) Run(ctx context.Context) (interface{}, error) {
 	env := environment.MustGet()
 	g := graphql.NewGraphQl(env.GraphQL)
 
-	// get nodes
-	freeFarmNodes, err := g.ListPublicNodes(ctx, 0, 1, 0, true, true)
+	// get public up nodes
+	freeFarmNodes, err := g.GetUpNodes(ctx, 0, 1, 0, true, true)
 	if err != nil {
 		return nil, errors.Wrap(err, "failed to list freefarm nodes from graphql")
 	}
 
-	nodes, err := g.ListPublicNodes(ctx, 12, 0, 1, true, true)
+	nodes, err := g.GetUpNodes(ctx, 12, 0, 1, true, true)
 	if err != nil {
 		return nil, errors.Wrap(err, "failed to list random nodes from graphql")
 	}

--- a/pkg/perf/iperf/iperf_task.go
+++ b/pkg/perf/iperf/iperf_task.go
@@ -44,7 +44,7 @@ func NewTask() perf.Task {
 		os.RemoveAll(match)
 	}
 	return &IperfTest{
-		taskID:      "IPerf",
+		taskID:      "iperf",
 		schedule:    "0 0 */6 * * *",
 		description: "Test public nodes network performance with both UDP and TCP over IPv4 and IPv6",
 	}

--- a/pkg/perf/iperf/iperf_task.go
+++ b/pkg/perf/iperf/iperf_task.go
@@ -19,8 +19,9 @@ import (
 
 // IperfTest for iperf tcp/udp tests
 type IperfTest struct {
-	taskID   string
-	schedule string
+	taskID      string
+	schedule    string
+	description string
 }
 
 // IperfResult for iperf test results
@@ -42,7 +43,11 @@ func NewTask() perf.Task {
 	for _, match := range matches {
 		os.RemoveAll(match)
 	}
-	return &IperfTest{taskID: "iperf", schedule: "0 0 */6 * * *"}
+	return &IperfTest{
+		taskID:      "IPerf",
+		schedule:    "0 0 */6 * * *",
+		description: "Test public nodes network performance with both UDP and TCP over IPv4 and IPv6",
+	}
 }
 
 // ID returns the ID of the tcp task
@@ -53,6 +58,11 @@ func (t *IperfTest) ID() string {
 // Cron returns the schedule for the tcp task
 func (t *IperfTest) Cron() string {
 	return t.schedule
+}
+
+// Description returns the task description
+func (t *IperfTest) Description() string {
+	return t.description
 }
 
 // Run runs the tcp test and returns the result

--- a/pkg/perf/monitor.go
+++ b/pkg/perf/monitor.go
@@ -55,9 +55,10 @@ func (pm *PerformanceMonitor) runTask(ctx context.Context, task Task) error {
 	}
 
 	err = pm.setCache(ctx, TaskResult{
-		Name:      task.ID(),
-		Timestamp: uint64(time.Now().Unix()),
-		Result:    res,
+		Name:        task.ID(),
+		Timestamp:   uint64(time.Now().Unix()),
+		Description: task.Description(),
+		Result:      res,
 	})
 	if err != nil {
 		return errors.Wrap(err, "failed to set cache")

--- a/pkg/perf/publicip/publicip_task.go
+++ b/pkg/perf/publicip/publicip_task.go
@@ -32,8 +32,9 @@ const (
 	IPIsUsed            = "ip is already assigned to a contract"
 	FetchRealIPFailed   = "failed to get real public IP to the node"
 
-	taskSchedule = "0 0 */6 * * *"
-	taskID       = "PublicIPValidation"
+	taskSchedule    = "0 0 */6 * * *"
+	taskID          = "PublicIPValidation"
+	taskDescription = "Runs on the least NodeID node in a farm to validate all its IPs."
 )
 
 var errPublicIPLookup = errors.New("failed to reach public ip service")
@@ -44,6 +45,7 @@ const testNamespace = "pubtestns"
 type publicIPValidationTask struct {
 	taskID        string
 	schedule      string
+	description   string
 	farmIPsReport map[string]IPReport
 }
 
@@ -58,6 +60,7 @@ func NewTask() perf.Task {
 	return &publicIPValidationTask{
 		taskID:        taskID,
 		schedule:      taskSchedule,
+		description:   taskDescription,
 		farmIPsReport: make(map[string]IPReport),
 	}
 }
@@ -68,6 +71,10 @@ func (p *publicIPValidationTask) ID() string {
 
 func (p *publicIPValidationTask) Cron() string {
 	return p.schedule
+}
+
+func (p *publicIPValidationTask) Description() string {
+	return p.description
 }
 
 func (p *publicIPValidationTask) Run(ctx context.Context) (interface{}, error) {

--- a/pkg/perf/publicip/publicip_task.go
+++ b/pkg/perf/publicip/publicip_task.go
@@ -212,7 +212,7 @@ func isLeastValidNode(ctx context.Context, farmID uint32, sub *substrate.Substra
 	env := environment.MustGet()
 	gql := graphql.NewGraphQl(env.GraphQL)
 
-	nodes, err := gql.GetFarmUpNodes(ctx, uint32(farmID))
+	nodes, err := gql.GetUpNodes(ctx, 0, farmID, 0, false, false)
 	if err != nil {
 		return false, fmt.Errorf("failed to get farm %d nodes: %w", farmID, err)
 	}

--- a/pkg/perf/publicip/publicip_task.go
+++ b/pkg/perf/publicip/publicip_task.go
@@ -34,7 +34,7 @@ const (
 	FetchRealIPFailed   = "failed to get real public IP to the node"
 
 	taskSchedule    = "0 0 */6 * * *"
-	taskID          = "PublicIPValidation"
+	taskID          = "public-ip-validation"
 	taskDescription = "Runs on the least NodeID node in a farm to validate all its IPs."
 )
 

--- a/pkg/perf/tasks.go
+++ b/pkg/perf/tasks.go
@@ -7,5 +7,6 @@ import (
 type Task interface {
 	ID() string
 	Cron() string
+	Description() string
 	Run(ctx context.Context) (interface{}, error)
 }


### PR DESCRIPTION
### Description
- add a description field in the task report
- use graphql instead of substrate to decide the node status
- define payload type for `perf.get` call
- unify tasks names to kabab case

### related issues
- https://github.com/threefoldtech/zos/issues/2112
- https://github.com/threefoldtech/zos/issues/2114
- https://github.com/threefoldtech/zos/issues/2115