### PR TITLE
revalidate already marked valid ips

### DIFF
--- a/docs/tasks/publicips.md
+++ b/docs/tasks/publicips.md
@@ -26,9 +26,6 @@ The goal of the task is to make sure public IPs assigned to a farm are valid and
 
 The task only returns a single map of String (IP) to IPReport. The report consists of the IP state (valid, invalid or skipped) and the reason for the state.
 
-### Notes
-- Previously tested ips and marked as `Valid` doesn't get revalidated again.
-
 ### Result sample
 ```json
 {


### PR DESCRIPTION
### Description

change puplicip task to check for all existing IPs in the farm and don't skip the already marked valid IPs

### Changes

- stopped skipping the marked valid IPs
- created a new report every time the task run instead of deleting old IPs then changing the already existing one, which will be all overridden anyways

### Related Issues

- #2125 
