### PR TITLE
Add healthcheck to report to zui for errors

### DIFF
--- a/cmds/modules/noded/main.go
+++ b/cmds/modules/noded/main.go
@@ -22,6 +22,7 @@ import (
 	"github.com/threefoldtech/zos/pkg/monitord"
 	"github.com/threefoldtech/zos/pkg/perf"
 	"github.com/threefoldtech/zos/pkg/perf/cpubench"
+	"github.com/threefoldtech/zos/pkg/perf/healthcheck"
 	"github.com/threefoldtech/zos/pkg/perf/iperf"
 	"github.com/threefoldtech/zos/pkg/perf/publicip"
 	"github.com/threefoldtech/zos/pkg/registrar"
@@ -211,6 +212,7 @@ func action(cli *cli.Context) error {
 	perfMon.AddTask(&cpuBenchmarkTask)
 
 	perfMon.AddTask(publicip.NewTask())
+	perfMon.AddTask(healthcheck.NewTask())
 
 	if err = perfMon.Run(ctx); err != nil {
 		return errors.Wrap(err, "failed to run the scheduler")

--- a/cmds/modules/zui/header.go
+++ b/cmds/modules/zui/header.go
@@ -76,7 +76,7 @@ func headerRenderer(ctx context.Context, c zbus.Client, h *widgets.Paragraph, r 
 			}
 
 			cache := green("OK")
-			if app.CheckFlag(app.LimitedCache) {
+			if app.CheckFlag(app.LimitedCache) || app.CheckFlag(app.ReadonlyCache) {
 				cache = red("no ssd disks detected")
 			}
 

--- a/cmds/modules/zui/header.go
+++ b/cmds/modules/zui/header.go
@@ -76,8 +76,10 @@ func headerRenderer(ctx context.Context, c zbus.Client, h *widgets.Paragraph, r 
 			}
 
 			cache := green("OK")
-			if app.CheckFlag(app.LimitedCache) || app.CheckFlag(app.ReadonlyCache) {
+			if app.CheckFlag(app.LimitedCache) {
 				cache = red("no ssd disks detected")
+			} else if app.CheckFlag(app.ReadonlyCache) {
+				cache = red("cache is read-only")
 			}
 
 			var utsname syscall.Utsname

--- a/cmds/modules/zui/main.go
+++ b/cmds/modules/zui/main.go
@@ -1,6 +1,7 @@
 package zui
 
 import (
+	"context"
 	"sync/atomic"
 	"time"
 
@@ -9,8 +10,11 @@ import (
 	"github.com/pkg/errors"
 	"github.com/rs/zerolog/log"
 	"github.com/threefoldtech/zbus"
+	"github.com/threefoldtech/zos/pkg/zui"
 	"github.com/urfave/cli/v2"
 )
+
+const module string = "zui"
 
 func trimFloat64(a []float64, size int) []float64 {
 	if len(a) > size {
@@ -42,6 +46,11 @@ var Module cli.Command = cli.Command{
 			Usage: "connection string to the message broker",
 			Value: "unix:///var/run/redis.sock",
 		},
+		&cli.UintFlag{
+			Name:  "workers",
+			Usage: "number of workers `N`",
+			Value: 1,
+		},
 	},
 
 	Action: action,
@@ -50,11 +59,17 @@ var Module cli.Command = cli.Command{
 func action(ctx *cli.Context) error {
 	var (
 		msgBrokerCon string = ctx.String("broker")
+		workerNr     uint   = ctx.Uint("workers")
 	)
 
 	client, err := zbus.NewRedisClient(msgBrokerCon)
 	if err != nil {
 		return errors.Wrap(err, "failed to connect to zbus")
+	}
+
+	server, err := zbus.NewRedisServer(module, msgBrokerCon, workerNr)
+	if err != nil {
+		return errors.Wrap(err, "fail to connect to message broker server")
 	}
 
 	if err := ui.Init(); err != nil {
@@ -78,6 +93,10 @@ func action(ctx *cli.Context) error {
 	resources.SetRect(0, 14, width, 22)
 	resources.Border = false
 
+	errorsGrid := ui.NewGrid()
+	errorsGrid.Title = "Provision"
+	errorsGrid.SetRect(0, 22, width, 26)
+
 	var flag signalFlag
 
 	if err := headerRenderer(ctx.Context, client, header, &flag); err != nil {
@@ -92,8 +111,19 @@ func action(ctx *cli.Context) error {
 		log.Error().Err(err).Msg("failed to start resources renderer")
 	}
 
+	mod := zui.New(ctx.Context, errorsGrid, &flag)
+
+	server.Register(zbus.ObjectID{Name: module, Version: "0.0.1"}, mod)
+
+	go func() {
+		if err := server.Run(ctx.Context); err != nil && err != context.Canceled {
+			log.Error().Err(err).Msg("unexpected error")
+		}
+
+	}()
+
 	render := func() {
-		ui.Render(header, netgrid, resources)
+		ui.Render(header, netgrid, resources, errorsGrid)
 	}
 
 	render()

--- a/cmds/modules/zui/main.go
+++ b/cmds/modules/zui/main.go
@@ -94,7 +94,7 @@ func action(ctx *cli.Context) error {
 	resources.Border = false
 
 	errorsGrid := ui.NewGrid()
-	errorsGrid.Title = "Provision"
+	errorsGrid.Title = "Errors"
 	errorsGrid.SetRect(0, 22, width, 26)
 
 	var flag signalFlag

--- a/cmds/modules/zui/main.go
+++ b/cmds/modules/zui/main.go
@@ -93,9 +93,11 @@ func action(ctx *cli.Context) error {
 	resources.SetRect(0, 14, width, 22)
 	resources.Border = false
 
-	errorsGrid := ui.NewGrid()
-	errorsGrid.Title = "Errors"
-	errorsGrid.SetRect(0, 22, width, 26)
+	errorsParagraph := widgets.NewParagraph()
+	errorsParagraph.Title = "Errors"
+	errorsParagraph.SetRect(0, 22, width, 26)
+	errorsParagraph.Border = true
+	errorsParagraph.WrapText = true
 
 	var flag signalFlag
 
@@ -111,7 +113,7 @@ func action(ctx *cli.Context) error {
 		log.Error().Err(err).Msg("failed to start resources renderer")
 	}
 
-	mod := zui.New(ctx.Context, errorsGrid, &flag)
+	mod := zui.New(ctx.Context, errorsParagraph, &flag)
 
 	server.Register(zbus.ObjectID{Name: module, Version: "0.0.1"}, mod)
 
@@ -123,7 +125,7 @@ func action(ctx *cli.Context) error {
 	}()
 
 	render := func() {
-		ui.Render(header, netgrid, resources, errorsGrid)
+		ui.Render(header, netgrid, resources, errorsParagraph)
 	}
 
 	render()
@@ -138,6 +140,7 @@ func action(ctx *cli.Context) error {
 			case "<Resize>":
 				payload := e.Payload.(ui.Resize)
 				header.SetRect(0, 0, payload.Width, 3)
+				errorsParagraph.SetRect(0, 22, payload.Width, 26)
 				// grid.SetRect(0, 3, payload.Width, payload.Height)
 				ui.Clear()
 				render()

--- a/docs/architecture/decisions/0008-skipping-uptime-reports.md
+++ b/docs/architecture/decisions/0008-skipping-uptime-reports.md
@@ -1,0 +1,19 @@
+# 1. Skipping Uptime Reports
+
+Date: 2023-11-24
+
+## Status
+
+Accepted
+
+## Context
+
+Skip uptime reports for unhealthy nodes.
+
+## Decision
+
+Nodes will not be sending uptime reports if the node is in an unusable state to reduce minting for unhealthy nodes. The decision for a node to be unhealthy is based on multiple checks on the node modules and the capacity reported by the node.
+
+## Consequences
+
+Farmers will need to make sure the nodes are in a healthy state and the capacity reported are valid in order for the minting to go through.

--- a/docs/tasks/healthcheck.md
+++ b/docs/tasks/healthcheck.md
@@ -1,0 +1,29 @@
+# HealthCheck
+
+## Overview
+
+Health check task executes some checks over ZOS components to determine if the node is in a usable state or not and set flags for the Power Daemon to stop uptime reports if the node is unusable.
+
+## Configuration
+
+- Name: `healthcheck`
+- Schedule: Every 20 mins.
+
+## Details
+
+- Check if the node cache disk is usable or not by trying to write some data to it. If it failed, it set the Readonly flag.
+
+## Result Sample
+
+```json
+{
+   "description": "health check task runs multiple checks to ensure the node is in a usable state and set flags for the power daemon to stop reporting uptime if it is not usable",
+   "name": "healthcheck",
+   "result": {
+      "cache": [
+         "failed to write to cache: open /var/cache/healthcheck: operation not permitted"
+      ]
+   },
+   "timestamp": 1701599580
+}
+```

--- a/go.mod
+++ b/go.mod
@@ -70,6 +70,7 @@ require (
 	github.com/coreos/go-iptables v0.6.0 // indirect
 	github.com/cosmos/go-bip39 v1.0.0 // indirect
 	github.com/cpuguy83/go-md2man/v2 v2.0.2 // indirect
+	github.com/dave/jennifer v1.3.0 // indirect
 	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/decred/dcrd/crypto/blake256 v1.0.1 // indirect
 	github.com/decred/dcrd/dcrec/secp256k1/v3 v3.0.0 // indirect

--- a/go.mod
+++ b/go.mod
@@ -70,7 +70,6 @@ require (
 	github.com/coreos/go-iptables v0.6.0 // indirect
 	github.com/cosmos/go-bip39 v1.0.0 // indirect
 	github.com/cpuguy83/go-md2man/v2 v2.0.2 // indirect
-	github.com/dave/jennifer v1.3.0 // indirect
 	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/decred/dcrd/crypto/blake256 v1.0.1 // indirect
 	github.com/decred/dcrd/dcrec/secp256k1/v3 v3.0.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -106,6 +106,7 @@ github.com/d2g/dhcp4 v0.0.0-20170904100407-a1d1b6c41b1c/go.mod h1:Ct2BUK8SB0YC1S
 github.com/d2g/dhcp4client v1.0.0/go.mod h1:j0hNfjhrt2SxUOw55nL0ATM/z4Yt3t2Kd1mW34z5W5s=
 github.com/d2g/dhcp4server v0.0.0-20181031114812-7d4a0a7f59a5/go.mod h1:Eo87+Kg/IX2hfWJfwxMzLyuSZyxSoAug2nGa1G2QAi8=
 github.com/d2g/hardwareaddr v0.0.0-20190221164911-e7d9fbe030e4/go.mod h1:bMl4RjIciD2oAxI7DmWRx6gbeqrkoLqv3MV0vzNad+I=
+github.com/dave/jennifer v1.3.0 h1:p3tl41zjjCZTNBytMwrUuiAnherNUZktlhPTKoF/sEk=
 github.com/dave/jennifer v1.3.0/go.mod h1:fIb+770HOpJ2fmN9EPPKOqm1vMGhB+TwXKMZhrIygKg=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=

--- a/go.sum
+++ b/go.sum
@@ -106,8 +106,6 @@ github.com/d2g/dhcp4 v0.0.0-20170904100407-a1d1b6c41b1c/go.mod h1:Ct2BUK8SB0YC1S
 github.com/d2g/dhcp4client v1.0.0/go.mod h1:j0hNfjhrt2SxUOw55nL0ATM/z4Yt3t2Kd1mW34z5W5s=
 github.com/d2g/dhcp4server v0.0.0-20181031114812-7d4a0a7f59a5/go.mod h1:Eo87+Kg/IX2hfWJfwxMzLyuSZyxSoAug2nGa1G2QAi8=
 github.com/d2g/hardwareaddr v0.0.0-20190221164911-e7d9fbe030e4/go.mod h1:bMl4RjIciD2oAxI7DmWRx6gbeqrkoLqv3MV0vzNad+I=
-github.com/dave/jennifer v1.3.0 h1:p3tl41zjjCZTNBytMwrUuiAnherNUZktlhPTKoF/sEk=
-github.com/dave/jennifer v1.3.0/go.mod h1:fIb+770HOpJ2fmN9EPPKOqm1vMGhB+TwXKMZhrIygKg=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=

--- a/pkg/app/flag.go
+++ b/pkg/app/flag.go
@@ -12,6 +12,8 @@ const (
 	flagsDir = "/tmp/flags"
 	// LimitedCache represent the flag cache couldn't mount on ssd or hdd
 	LimitedCache = "limited-cache"
+	// ReadonlyCache represents the flag for cache is read only
+	ReadonlyCache = "readonly-cache"
 )
 
 // SetFlag is used when the /var/cache cannot be mounted on a SSD or HDD,

--- a/pkg/perf/healthcheck/healthcheck.go
+++ b/pkg/perf/healthcheck/healthcheck.go
@@ -82,15 +82,15 @@ func (h *healthcheckTask) Run(ctx context.Context) (interface{}, error) {
 }
 
 func errorsToStrings(errs []error) []string {
-	s := make([]string, len(errs))
-	for i, err := range errs {
-		s[i] = err.Error()
+	s := make([]string, 0, len(errs))
+	for _, err := range errs {
+		s = append(s, err.Error())
 	}
 	return s
 }
 
 func cacheCheck(ctx context.Context) []error {
-	errors := make([]error, 0)
+	var errors []error
 	if err := readonlyCheck(ctx); err != nil {
 		errors = append(errors, err)
 	}

--- a/pkg/perf/healthcheck/healthcheck.go
+++ b/pkg/perf/healthcheck/healthcheck.go
@@ -13,7 +13,7 @@ import (
 
 const (
 	id          = "healthcheck"
-	schedule    = "*/30 * * * * *"
+	schedule    = "0 */20 * * * *"
 	description = "health check task runs multiple checks to ensure the node is in a usable state and set flags for the power daemon to stop reporting uptime if it is not usable"
 )
 

--- a/pkg/perf/healthcheck/healthcheck.go
+++ b/pkg/perf/healthcheck/healthcheck.go
@@ -1,0 +1,95 @@
+package healthcheck
+
+import (
+	"context"
+	"fmt"
+	"os"
+
+	"github.com/rs/zerolog/log"
+	"github.com/threefoldtech/zos/pkg/app"
+	"github.com/threefoldtech/zos/pkg/perf"
+	"github.com/threefoldtech/zos/pkg/stubs"
+)
+
+const (
+	id          = "healthcheck"
+	schedule    = "*/30 * * * * *"
+	description = "health check task runs multiple checks to ensure the node is in a usable state and set flags for the power daemon to stop reporting uptime if it is not usable"
+)
+
+// NewTask returns a new health check task.
+func NewTask() perf.Task {
+	checks := []checkFunc{
+		cacheCheck,
+	}
+	return &healthcheckTask{
+		checks: checks,
+		errors: make(map[string][]string),
+	}
+}
+
+type checkFunc func(context.Context) (string, error)
+
+type healthcheckTask struct {
+	checks []checkFunc
+	errors map[string][]string
+}
+
+var _ perf.Task = (*healthcheckTask)(nil)
+
+// ID returns task ID.
+func (h *healthcheckTask) ID() string {
+	return id
+}
+
+// Cron returns task cron schedule.
+func (h *healthcheckTask) Cron() string {
+	return schedule
+}
+
+// Description returns task description.
+func (h *healthcheckTask) Description() string {
+	return description
+}
+
+// Run executes the health checks.
+func (h *healthcheckTask) Run(ctx context.Context) (interface{}, error) {
+	log.Debug().Msg("starting health check task")
+	for k := range h.errors {
+		// reset errors on each run
+		h.errors[k] = make([]string, 0)
+	}
+
+	for _, check := range h.checks {
+		label, err := check(ctx)
+		if err == nil {
+			continue
+		}
+		h.errors[label] = append(h.errors[label], err.Error())
+	}
+
+	cl := perf.GetZbusClient(ctx)
+	zui := stubs.NewZUIStub(cl)
+
+	for label, data := range h.errors {
+		zui.PushErrors(ctx, label, data)
+	}
+	return h.errors, nil
+}
+
+func cacheCheck(ctx context.Context) (string, error) {
+	const label = "cache"
+	_, err := os.Create("/var/cache/healthcheck")
+	if err != nil {
+		if err := app.SetFlag(app.ReadonlyCache); err != nil {
+			log.Error().Err(err).Msg("failed to set readonly flag")
+		}
+		return label, fmt.Errorf("failed to write to cache: %w", err)
+	}
+	defer os.Remove("/var/cache/healthcheck")
+
+	if err := app.DeleteFlag(app.ReadonlyCache); err != nil {
+		log.Error().Err(err).Msg("failed to delete readonly flag")
+	}
+	return label, nil
+}

--- a/pkg/perf/healthcheck/healthcheck.go
+++ b/pkg/perf/healthcheck/healthcheck.go
@@ -79,14 +79,16 @@ func (h *healthcheckTask) Run(ctx context.Context) (interface{}, error) {
 
 func cacheCheck(ctx context.Context) (string, error) {
 	const label = "cache"
-	_, err := os.Create("/var/cache/healthcheck")
+	const checkFile = "/var/cache/healthcheck"
+
+	_, err := os.Create(checkFile)
 	if err != nil {
 		if err := app.SetFlag(app.ReadonlyCache); err != nil {
 			log.Error().Err(err).Msg("failed to set readonly flag")
 		}
 		return label, fmt.Errorf("failed to write to cache: %w", err)
 	}
-	defer os.Remove("/var/cache/healthcheck")
+	defer os.Remove(checkFile)
 
 	if err := app.DeleteFlag(app.ReadonlyCache); err != nil {
 		log.Error().Err(err).Msg("failed to delete readonly flag")

--- a/pkg/stubs/zui_stub.go
+++ b/pkg/stubs/zui_stub.go
@@ -1,0 +1,41 @@
+// GENERATED CODE
+// --------------
+// please do not edit manually instead use the "zbusc" to regenerate
+
+package stubs
+
+import (
+	"context"
+	zbus "github.com/threefoldtech/zbus"
+)
+
+type ZUIStub struct {
+	client zbus.Client
+	module string
+	object zbus.ObjectID
+}
+
+func NewZUIStub(client zbus.Client) *ZUIStub {
+	return &ZUIStub{
+		client: client,
+		module: "zui",
+		object: zbus.ObjectID{
+			Name:    "zui",
+			Version: "0.0.1",
+		},
+	}
+}
+
+func (s *ZUIStub) PushErrors(ctx context.Context, arg0 string, arg1 []string) {
+	args := []interface{}{arg0, arg1}
+	result, err := s.client.RequestContext(ctx, s.module, s.object, "PushErrors", args...)
+	if err != nil {
+		panic(err)
+	}
+	result.PanicOnError()
+	loader := zbus.Loader{}
+	if err := result.Unmarshal(&loader); err != nil {
+		panic(err)
+	}
+	return
+}

--- a/pkg/stubs/zui_stub.go
+++ b/pkg/stubs/zui_stub.go
@@ -26,13 +26,14 @@ func NewZUIStub(client zbus.Client) *ZUIStub {
 	}
 }
 
-func (s *ZUIStub) PushErrors(ctx context.Context, arg0 string, arg1 []string) {
+func (s *ZUIStub) PushErrors(ctx context.Context, arg0 string, arg1 []string) (ret0 error) {
 	args := []interface{}{arg0, arg1}
 	result, err := s.client.RequestContext(ctx, s.module, s.object, "PushErrors", args...)
 	if err != nil {
 		panic(err)
 	}
 	result.PanicOnError()
+	ret0 = result.CallError()
 	loader := zbus.Loader{}
 	if err := result.Unmarshal(&loader); err != nil {
 		panic(err)

--- a/pkg/zui.go
+++ b/pkg/zui.go
@@ -1,0 +1,7 @@
+package pkg
+
+//go:generate zbusc -module zui -version 0.0.1 -name zui -package stubs github.com/threefoldtech/zos/pkg+ZUI stubs/zui_stub.go
+
+type ZUI interface {
+	PushErrors(label string, errors []string)
+}

--- a/pkg/zui.go
+++ b/pkg/zui.go
@@ -3,5 +3,5 @@ package pkg
 //go:generate zbusc -module zui -version 0.0.1 -name zui -package stubs github.com/threefoldtech/zos/pkg+ZUI stubs/zui_stub.go
 
 type ZUI interface {
-	PushErrors(label string, errors []string)
+	PushErrors(label string, errors []string) error
 }

--- a/pkg/zui/zui.go
+++ b/pkg/zui/zui.go
@@ -1,0 +1,101 @@
+package zui
+
+import (
+	"context"
+	"fmt"
+	"sync"
+	"time"
+
+	ui "github.com/gizak/termui/v3"
+	"github.com/gizak/termui/v3/widgets"
+	"github.com/threefoldtech/zos/pkg"
+)
+
+type module struct {
+	grid   *ui.Grid
+	render Signaler
+	labels []labelData
+	table  *widgets.Table
+	mu     *sync.Mutex
+}
+
+type Signaler interface {
+	Signal()
+}
+
+type labelData struct {
+	label  string
+	errors []string
+}
+
+func New(ctx context.Context, grid *ui.Grid, render Signaler) pkg.ZUI {
+	table := widgets.NewTable()
+	grid.Set(
+		ui.NewRow(1.0, table),
+	)
+	table.Title = "Errors"
+	table.FillRow = true
+	table.RowSeparator = false
+
+	table.Rows = [][]string{
+		{"[No Errors!](fg:green)"},
+	}
+
+	zuiModule := &module{
+		grid:   grid,
+		render: render,
+		table:  table,
+		labels: make([]labelData, 0),
+		mu:     &sync.Mutex{},
+	}
+	go zuiModule.renderErrors(ctx)
+	return zuiModule
+}
+
+var _ pkg.ZUI = (*module)(nil)
+
+func (m *module) PushErrors(label string, errors []string) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	for i, data := range m.labels {
+		if data.label == label {
+			m.labels[i].errors = errors
+			return
+		}
+	}
+	m.labels = append(m.labels, labelData{label, errors})
+}
+
+func (m *module) renderErrors(ctx context.Context) {
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		default:
+			m.mu.Lock()
+			labels := make([]labelData, len(m.labels))
+			copy(labels, m.labels)
+			m.mu.Unlock()
+			display(labels, m.table, m.render)
+			// in case nothing got displayed
+			<-time.After(2 * time.Second)
+		}
+	}
+}
+
+func display(labels []labelData, table *widgets.Table, render Signaler) {
+	table.Rows = [][]string{
+		{"[No Errors!](fg:green)"},
+	}
+	for _, label := range labels {
+		for _, e := range label.errors {
+			table.Rows = [][]string{
+				{fmt.Sprintf("%s: [%s](fg:red)", label.label, e)},
+			}
+			render.Signal()
+			<-time.After(2 * time.Second)
+		}
+	}
+
+	render.Signal()
+}


### PR DESCRIPTION
### Description

Add healthcheck task to execute multiple checks (only cache for now) and report to zui for errors. It also set flags that can be checked by Power daemon to stop uptime reports.

### Changes

- Add and register zui module on zbus to allow other modules to set some errors in the ui.
- Add healthcheck Task that perform checks on the node to make sure everything is OK.
- Add another part in the ui to display errors with the node state.
- Stop uptime reports if cache is unusable (readonly or limited).

### Related Issues

- https://github.com/threefoldtech/zos/issues/2134

### Checklist

- [ ] Tests included
- [x] Build pass
- [x] Documentation
- [x] Code format and docstring
