### PR TITLE
add jitter for the task

### DIFF
--- a/cmds/modules/noded/main.go
+++ b/cmds/modules/noded/main.go
@@ -206,10 +206,7 @@ func action(cli *cli.Context) error {
 	}
 
 	perfMon.AddTask(iperf.NewTask())
-
-	cpuBenchmarkTask := cpubench.NewCPUBenchmarkTask()
-	perfMon.AddTask(&cpuBenchmarkTask)
-
+	perfMon.AddTask(cpubench.NewTask())
 	perfMon.AddTask(publicip.NewTask())
 
 	if err = perfMon.Run(ctx); err != nil {

--- a/docs/tasks/README.md
+++ b/docs/tasks/README.md
@@ -16,7 +16,9 @@ To ensure that the node always has a test result available, a check is performed
 
 ### Scheduling
 
-Tasks are scheduled using a 6 fields cron format. this format provides flexibility to define time, allowing running tasks periodically or at specific time.
+- Tasks are scheduled using a 6 fields cron format. this format provides flexibility to define time, allowing running tasks periodically or at specific time.
+
+- Each task have a jitter which is the max number of seconds the task could sleep before it runs, this happens to prevent all tests ending up running at exactly the same time. so for example if a task scheduled to run at `06:00` and it is jitter is `10` it is expected to run any when between `06:00` to `06:10`
 
 ### RMB commands
 

--- a/docs/tasks/README.md
+++ b/docs/tasks/README.md
@@ -23,17 +23,20 @@ To ensure that the node always has a test result available, a check is performed
 ### RMB commands
 
 - `zos.perf.get`:
+
   - Payload: a payload type that contains the name of the test
+
     ```go
     type Payload struct {
-      Name string 
+      Name string
     }
     ```
 
     Possible values:
-      - `"public-ip-validation"`
-      - `"cpu-benchmark"`
-      - `"iperf"`
+
+    - `"public-ip-validation"`
+    - `"cpu-benchmark"`
+    - `"iperf"`
 
   - Return: a single task result.
 
@@ -44,6 +47,7 @@ To ensure that the node always has a test result available, a check is performed
   - Return: all stored results
 
 The rmb direct client can be used to call these commands. check the [example](https://github.com/threefoldtech/tfgrid-sdk-go/blob/development/rmb-sdk-go/examples/client_rpc/main.go)
+
 ### Caching
 
 Results are stored in a Redis server running on the node.
@@ -66,4 +70,3 @@ Notes:
 - [Public IP validation](./publicips.md)
 - [CPU benchmark](./cpubench.md)
 - [IPerf](./iperf.md)
-- To add new task, [check](../../pkg/perf/README.md)

--- a/docs/tasks/cpubench.md
+++ b/docs/tasks/cpubench.md
@@ -8,6 +8,7 @@ The `CPUBenchmark` task is designed to measure the performance of the CPU. it ut
 
 - Name: `cpu-benchmark`
 - Schedule: 4 times a day
+- Jitter: 10 min
 
 ### Details
 

--- a/docs/tasks/cpubench.md
+++ b/docs/tasks/cpubench.md
@@ -8,7 +8,7 @@ The `CPUBenchmark` task is designed to measure the performance of the CPU. it ut
 
 - Name: `cpu-benchmark`
 - Schedule: 4 times a day
-- Jitter: 10 min
+- Jitter: 0
 
 ### Details
 
@@ -17,6 +17,7 @@ The `CPUBenchmark` task is designed to measure the performance of the CPU. it ut
 - Lower time = better performance: for a single threaded benchmark, a lower execution time indicates better performance.
 
 ### Result sample
+
 ```json
 {
   "description": "Measures the performance of the node CPU by reporting the timespent of computing a task in seconds.",
@@ -30,3 +31,45 @@ The `CPUBenchmark` task is designed to measure the performance of the CPU. it ut
   "timestamp": 1700504403
 }
 ```
+
+### Result explanation
+
+The best way to know what's a good or bad value is by testing and comparing different hardware.
+Here are some example:
+
+**1x Intel(R) Xeon(R) W-2145 CPU @ 3.70GHz** (Q3'2017)
+
+```
+Single thread score: 0.777
+Multi threads score: 13.345 [16 threads]
+```
+
+**1x Intel(R) Pentium(R) CPU G4400 @ 3.30GHz** (Q3'2015)
+
+```
+Single thread score: 1.028
+Multi threads score: 2.089 [2 threads]
+```
+
+**1x Intel(R) Core(TM) i5-3570 CPU @ 3.40GHz** (Q2'2012)
+
+```
+Single thread score: 2.943
+Multi threads score: 12.956 [4 threads]
+```
+
+**2x Intel(R) Xeon(R) CPU E5-2630 v3 @ 2.40GHz** (Q1'2012)
+
+```
+Single thread score: 1.298
+Multi threads score: 44.090 [32 threads]
+```
+
+**2x Intel(R) Xeon(R) CPU L5640 @ 2.27GHz** (Q1'2010)
+
+```
+Single thread score: 2.504
+Multi threads score: 72.452 [24 threads]
+```
+
+As you can see, the more recent the CPU is, the faster it is, but for a same launch period, you can see Xeon way better than regular/desktop CPU. You have to take in account the amount of threads and the time per threads.

--- a/docs/tasks/iperf.md
+++ b/docs/tasks/iperf.md
@@ -8,7 +8,7 @@ The `iperf` package is designed to facilitate network performance testing using 
 
 - Name: `iperf`
 - Schedule: 4 times a day
-- Jitter: 10 min
+- Jitter: 20 min
 
 ### Details
 
@@ -29,43 +29,43 @@ The `iperf` package is designed to facilitate network performance testing using 
 ### Result sample
 
 ```json
- {
-    "description": "Test public nodes network performance with both UDP and TCP over IPv4 and IPv6",
-    "name": "IPerf",
-    "result": [
-      {
-        "cpu_report": {
-          "host_system": 2.4433388913571044,
-          "host_total": 3.542919199613454,
-          "host_user": 1.0996094859359695,
-          "remote_system": 0.24430594945859846,
-          "remote_total": 0.3854457128784448,
-          "remote_user": 0.14115962407747246
-        },
-        "download_speed": 1041274.4792242317,
-        "error": "",
-        "node_id": 124,
-        "node_ip": "88.99.30.200",
-        "test_type": "tcp",
-        "upload_speed": 1048549.3668460822
+{
+  "description": "Test public nodes network performance with both UDP and TCP over IPv4 and IPv6",
+  "name": "iperf",
+  "result": [
+    {
+      "cpu_report": {
+        "host_system": 2.4433388913571044,
+        "host_total": 3.542919199613454,
+        "host_user": 1.0996094859359695,
+        "remote_system": 0.24430594945859846,
+        "remote_total": 0.3854457128784448,
+        "remote_user": 0.14115962407747246
       },
-      {
-        "cpu_report": {
-          "host_system": 0,
-          "host_total": 0,
-          "host_user": 0,
-          "remote_system": 0,
-          "remote_total": 0,
-          "remote_user": 0
-        },
-        "download_speed": 0,
-        "error": "unable to connect to server - server may have stopped running or use a different port, firewall issue, etc.: Network unreachable",
-        "node_id": 124,
-        "node_ip": "2a01:4f8:10a:710::2",
-        "test_type": "tcp",
-        "upload_speed": 0
+      "download_speed": 1041274.4792242317,
+      "error": "",
+      "node_id": 124,
+      "node_ip": "88.99.30.200",
+      "test_type": "tcp",
+      "upload_speed": 1048549.3668460822
+    },
+    {
+      "cpu_report": {
+        "host_system": 0,
+        "host_total": 0,
+        "host_user": 0,
+        "remote_system": 0,
+        "remote_total": 0,
+        "remote_user": 0
       },
-    ],
+      "download_speed": 0,
+      "error": "unable to connect to server - server may have stopped running or use a different port, firewall issue, etc.: Network unreachable",
+      "node_id": 124,
+      "node_ip": "2a01:4f8:10a:710::2",
+      "test_type": "tcp",
+      "upload_speed": 0
+    }
+  ],
   "timestamp": 1700507035
- }
+}
 ```

--- a/docs/tasks/iperf.md
+++ b/docs/tasks/iperf.md
@@ -8,6 +8,7 @@ The `iperf` package is designed to facilitate network performance testing using 
 
 - Name: `iperf`
 - Schedule: 4 times a day
+- Jitter: 10 min
 
 ### Details
 

--- a/docs/tasks/publicips.md
+++ b/docs/tasks/publicips.md
@@ -8,7 +8,6 @@ The goal of the task is to make sure public IPs assigned to a farm are valid and
 - Schedule: 4 times a day
 - Jitter: 10 min
 
-
 ## Task Details
 
 - The task depends on `Networkd` ensuring the proper test network setup is correct and will fail if it wasn't setup properly. The network setup consists of a test Namespace and a MacVLAN as part of it. All steps are done inside the test Namespace.
@@ -28,6 +27,7 @@ The goal of the task is to make sure public IPs assigned to a farm are valid and
 The task only returns a single map of String (IP) to IPReport. The report consists of the IP state (valid, invalid or skipped) and the reason for the state.
 
 ### Result sample
+
 ```json
 {
   "description": "Runs on the least NodeID node in a farm to validate all its IPs.",

--- a/docs/tasks/publicips.md
+++ b/docs/tasks/publicips.md
@@ -6,6 +6,7 @@ The goal of the task is to make sure public IPs assigned to a farm are valid and
 
 - Name: `public-ip-validation`
 - Schedule: 4 times a day
+- Jitter: 10 min
 
 
 ## Task Details

--- a/pkg/perf/README.md
+++ b/pkg/perf/README.md
@@ -4,42 +4,4 @@ Perf is a performance test module that is scheduled to run and cache those tests
 
 Perf tests are monitored by `noded` service from zos modules.
 
-### Usage Example
-
-1. Create a task that implement `Task` interface
-
-```go
-type LoggingTask struct {
-	taskID      string
-	schedule    string // should be in cron syntax with seconds ("* 0 * * * *")
-	description string
-}
-
-func (t *LoggingTask) ID() string {
-	return t.taskID
-}
-
-func (t *LoggingTask) Cron() string {
-	return t.schedule
-}
-
-func (t *LoggingTask) Description() string {
-	return t.description
-}
-
-// a simple task that returns a string with the current time
-func (t *LoggingTask) Run(ctx context.Context) (interface{}, error) {
-	result := fmt.Sprintf("time is: %v", time.Now())
-	return result, nil
-}
-```
-
-2. Add the created task to scheduler
-
-```go
-perfMon.AddTask(&perf.LoggingTask{
-	taskID:      "LoggingTask",
-	schedule:    "* 0 * * * *", // when minutes is 0 (aka: every hour)
-	description: "Simple task that logs the time every hour",
-})
-```
+Check the [docs](../../docs/tasks/README.md)

--- a/pkg/perf/cpubench/cpubench_task.go
+++ b/pkg/perf/cpubench/cpubench_task.go
@@ -10,23 +10,8 @@ import (
 	"github.com/threefoldtech/zos/pkg/stubs"
 )
 
-const (
-	cpuBenchmarkTaskID       = "cpu-benchmark"
-	cpuBenchmarkCronSchedule = "0 0 */6 * * *"
-	cpuBenchmarkDescription  = "Measures the performance of the node CPU by reporting the timespent of computing a task in seconds."
-)
-
-// CPUBenchmarkTask defines CPU benchmark task data.
-type CPUBenchmarkTask struct {
-	// taskID is a unique string ID for the task.
-	taskID string
-	// schedule is a 6 field cron schedule (unlike unix cron).
-	schedule string
-	// description briefly describe what a task do.
-	description string
-	// jitter is max number of seconds the job can sleep before actual execution.
-	jitter uint32
-}
+// CPUBenchmarkTask defines CPU benchmark task.
+type CPUBenchmarkTask struct{}
 
 // CPUBenchmarkResult holds CPU benchmark results with the workloads number during the benchmark.
 type CPUBenchmarkResult struct {
@@ -38,34 +23,29 @@ type CPUBenchmarkResult struct {
 
 var _ perf.Task = (*CPUBenchmarkTask)(nil)
 
-// NewCPUBenchmarkTask returns a new CPU benchmark task.
-func NewCPUBenchmarkTask() CPUBenchmarkTask {
-	return CPUBenchmarkTask{
-		taskID:      cpuBenchmarkTaskID,
-		schedule:    cpuBenchmarkCronSchedule,
-		description: cpuBenchmarkDescription,
-		jitter:      10 * 60,
-	}
+// NewTask returns a new CPU benchmark task.
+func NewTask() perf.Task {
+	return &CPUBenchmarkTask{}
 }
 
 // ID returns task ID.
 func (c *CPUBenchmarkTask) ID() string {
-	return c.taskID
+	return "cpu-benchmark"
 }
 
 // Cron returns task cron schedule.
 func (c *CPUBenchmarkTask) Cron() string {
-	return c.schedule
+	return "0 0 */6 * * *"
 }
 
 // Description returns task description.
 func (c *CPUBenchmarkTask) Description() string {
-	return c.description
+	return "Measures the performance of the node CPU by reporting the timespent of computing a task in seconds."
 }
 
 // Jitter returns the max number of seconds the job can sleep before actual execution.
 func (c *CPUBenchmarkTask) Jitter() uint32 {
-	return c.jitter
+	return 0
 }
 
 // Run executes the CPU benchmark.

--- a/pkg/perf/cpubench/cpubench_task.go
+++ b/pkg/perf/cpubench/cpubench_task.go
@@ -4,9 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"math/rand"
 	"os/exec"
-	"time"
 
 	"github.com/threefoldtech/zos/pkg/perf"
 	"github.com/threefoldtech/zos/pkg/stubs"
@@ -65,15 +63,13 @@ func (c *CPUBenchmarkTask) Description() string {
 	return c.description
 }
 
-// Jitter returns the duration the task will sleep for before running.
-func (c *CPUBenchmarkTask) Jitter() time.Duration {
-	jitter := time.Duration(rand.Int31n(int32(c.jitter))) * time.Second
-	return jitter
+// Jitter returns the max number of seconds the job can sleep before actual execution.
+func (c *CPUBenchmarkTask) Jitter() uint32 {
+	return c.jitter
 }
 
 // Run executes the CPU benchmark.
 func (c *CPUBenchmarkTask) Run(ctx context.Context) (interface{}, error) {
-	time.Sleep(c.Jitter())
 	cpubenchOut, err := exec.CommandContext(ctx, "cpubench", "-j").CombinedOutput()
 	if err != nil {
 		return nil, fmt.Errorf("failed to execute cpubench command: %w", err)

--- a/pkg/perf/iperf/iperf_task.go
+++ b/pkg/perf/iperf/iperf_task.go
@@ -18,12 +18,7 @@ import (
 )
 
 // IperfTest for iperf tcp/udp tests
-type IperfTest struct {
-	taskID      string
-	schedule    string
-	description string
-	jitter      uint32
-}
+type IperfTest struct{}
 
 // IperfResult for iperf test results
 type IperfResult struct {
@@ -44,32 +39,27 @@ func NewTask() perf.Task {
 	for _, match := range matches {
 		os.RemoveAll(match)
 	}
-	return &IperfTest{
-		taskID:      "iperf",
-		schedule:    "0 0 */6 * * *",
-		description: "Test public nodes network performance with both UDP and TCP over IPv4 and IPv6",
-		jitter:      10 * 60,
-	}
+	return &IperfTest{}
 }
 
 // ID returns the ID of the tcp task
 func (t *IperfTest) ID() string {
-	return t.taskID
+	return "iperf"
 }
 
 // Cron returns the schedule for the tcp task
 func (t *IperfTest) Cron() string {
-	return t.schedule
+	return "0 0 */6 * * *"
 }
 
 // Description returns the task description
 func (t *IperfTest) Description() string {
-	return t.description
+	return "Test public nodes network performance with both UDP and TCP over IPv4 and IPv6"
 }
 
 // Jitter returns the max number of seconds the job can sleep before actual execution.
 func (t *IperfTest) Jitter() uint32 {
-	return t.jitter
+	return 20 * 60
 }
 
 // Run runs the tcp test and returns the result

--- a/pkg/perf/iperf/iperf_task.go
+++ b/pkg/perf/iperf/iperf_task.go
@@ -4,12 +4,10 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"math/rand"
 	"net"
 	"os"
 	"os/exec"
 	"path/filepath"
-	"time"
 
 	"github.com/pkg/errors"
 	"github.com/rs/zerolog/log"
@@ -69,15 +67,13 @@ func (t *IperfTest) Description() string {
 	return t.description
 }
 
-// Jitter returns the duration the task will sleep for before running.
-func (t *IperfTest) Jitter() time.Duration {
-	jitter := time.Duration(rand.Int31n(int32(t.jitter))) * time.Second
-	return jitter
+// Jitter returns the max number of seconds the job can sleep before actual execution.
+func (t *IperfTest) Jitter() uint32 {
+	return t.jitter
 }
 
 // Run runs the tcp test and returns the result
 func (t *IperfTest) Run(ctx context.Context) (interface{}, error) {
-	time.Sleep(t.Jitter())
 	env := environment.MustGet()
 	g := graphql.NewGraphQl(env.GraphQL)
 

--- a/pkg/perf/monitor.go
+++ b/pkg/perf/monitor.go
@@ -2,6 +2,7 @@ package perf
 
 import (
 	"context"
+	"math/rand"
 	"time"
 
 	"github.com/go-co-op/gocron"
@@ -49,6 +50,9 @@ func (pm *PerformanceMonitor) AddTask(task Task) {
 
 // runTask runs the task and store its result
 func (pm *PerformanceMonitor) runTask(ctx context.Context, task Task) error {
+	sleepInterval := time.Duration(rand.Int31n(int32(task.Jitter()))) * time.Second
+	time.Sleep(sleepInterval)
+
 	res, err := task.Run(ctx)
 	if err != nil {
 		return errors.Wrapf(err, "failed to run task: %s", task.ID())

--- a/pkg/perf/monitor.go
+++ b/pkg/perf/monitor.go
@@ -50,8 +50,10 @@ func (pm *PerformanceMonitor) AddTask(task Task) {
 
 // runTask runs the task and store its result
 func (pm *PerformanceMonitor) runTask(ctx context.Context, task Task) error {
-	sleepInterval := time.Duration(rand.Int31n(int32(task.Jitter()))) * time.Second
-	time.Sleep(sleepInterval)
+	if task.Jitter() != 0 {
+		sleepInterval := time.Duration(rand.Int31n(int32(task.Jitter()))) * time.Second
+		time.Sleep(sleepInterval)
+	}
 
 	res, err := task.Run(ctx)
 	if err != nil {

--- a/pkg/perf/publicip/publicip_task.go
+++ b/pkg/perf/publicip/publicip_task.go
@@ -32,10 +32,6 @@ const (
 	PublicIPDataInvalid = "public ip or gateway data are not valid"
 	IPIsUsed            = "ip is already assigned to a contract"
 	FetchRealIPFailed   = "failed to get real public IP to the node"
-
-	taskSchedule    = "0 0 */6 * * *"
-	taskID          = "public-ip-validation"
-	taskDescription = "Runs on the least NodeID node in a farm to validate all its IPs."
 )
 
 var errPublicIPLookup = errors.New("failed to reach public ip service")
@@ -44,12 +40,7 @@ var errSkippedValidating = errors.New("skipped, there is a node with less ID ava
 const testMacvlan = "pub"
 const testNamespace = "pubtestns"
 
-type publicIPValidationTask struct {
-	taskID      string
-	schedule    string
-	description string
-	jitter      uint32
-}
+type publicIPValidationTask struct{}
 
 type IPReport struct {
 	State  string `json:"state"`
@@ -59,28 +50,23 @@ type IPReport struct {
 var _ perf.Task = (*publicIPValidationTask)(nil)
 
 func NewTask() perf.Task {
-	return &publicIPValidationTask{
-		taskID:      taskID,
-		schedule:    taskSchedule,
-		description: taskDescription,
-		jitter:      10 * 60,
-	}
+	return &publicIPValidationTask{}
 }
 
 func (p *publicIPValidationTask) ID() string {
-	return p.taskID
+	return "public-ip-validation"
 }
 
 func (p *publicIPValidationTask) Cron() string {
-	return p.schedule
+	return "0 0 */6 * * *"
 }
 
 func (p *publicIPValidationTask) Description() string {
-	return p.description
+	return "Runs on the least NodeID node in a farm to validate all its IPs."
 }
 
 func (p *publicIPValidationTask) Jitter() uint32 {
-	return p.jitter
+	return 10 * 60
 }
 
 func (p *publicIPValidationTask) Run(ctx context.Context) (interface{}, error) {

--- a/pkg/perf/publicip/publicip_task.go
+++ b/pkg/perf/publicip/publicip_task.go
@@ -5,7 +5,6 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"math/rand"
 	"net"
 	"net/http"
 	"os/exec"
@@ -46,11 +45,10 @@ const testMacvlan = "pub"
 const testNamespace = "pubtestns"
 
 type publicIPValidationTask struct {
-	taskID        string
-	schedule      string
-	description   string
-	jitter        uint32
-	farmIPsReport map[string]IPReport
+	taskID      string
+	schedule    string
+	description string
+	jitter      uint32
 }
 
 type IPReport struct {
@@ -62,11 +60,10 @@ var _ perf.Task = (*publicIPValidationTask)(nil)
 
 func NewTask() perf.Task {
 	return &publicIPValidationTask{
-		taskID:        taskID,
-		schedule:      taskSchedule,
-		description:   taskDescription,
-		jitter:        10 * 60,
-		farmIPsReport: make(map[string]IPReport),
+		taskID:      taskID,
+		schedule:    taskSchedule,
+		description: taskDescription,
+		jitter:      10 * 60,
 	}
 }
 
@@ -82,14 +79,11 @@ func (p *publicIPValidationTask) Description() string {
 	return p.description
 }
 
-func (p *publicIPValidationTask) Jitter() time.Duration {
-	jitter := time.Duration(rand.Int31n(int32(p.jitter))) * time.Second
-	return jitter
+func (p *publicIPValidationTask) Jitter() uint32 {
+	return p.jitter
 }
 
 func (p *publicIPValidationTask) Run(ctx context.Context) (interface{}, error) {
-	time.Sleep(p.Jitter())
-
 	netNS, err := namespace.GetByName(testNamespace)
 	if err != nil {
 		return nil, fmt.Errorf("failed to get namespace %s: %w", testNamespace, err)

--- a/pkg/perf/tasks.go
+++ b/pkg/perf/tasks.go
@@ -2,11 +2,13 @@ package perf
 
 import (
 	"context"
+	"time"
 )
 
 type Task interface {
 	ID() string
 	Cron() string
 	Description() string
+	Jitter() time.Duration
 	Run(ctx context.Context) (interface{}, error)
 }

--- a/pkg/perf/tasks.go
+++ b/pkg/perf/tasks.go
@@ -2,13 +2,12 @@ package perf
 
 import (
 	"context"
-	"time"
 )
 
 type Task interface {
 	ID() string
 	Cron() string
 	Description() string
-	Jitter() time.Duration
+	Jitter() uint32
 	Run(ctx context.Context) (interface{}, error)
 }


### PR DESCRIPTION
### Description
- jitter is the maximum number of seconds a task can wait before actually running.
- remove the task struct fields and return the constant values directly from the methods
- update docs

### Related Issues
- https://github.com/threefoldtech/zos/issues/2139
- https://github.com/threefoldtech/zos/issues/2142

### Checklist

- [ ] Tests included
- [ ] Build pass
- [ ] Documentation
- [ ] Code format and docstring
