### PR TITLE
use latest cloud-container

### DIFF
--- a/pkg/primitives/vm/vm.go
+++ b/pkg/primitives/vm/vm.go
@@ -19,7 +19,7 @@ import (
 )
 
 const (
-	cloudContainerFlist = "https://hub.grid.tf/tf-autobuilder/cloud-container-8730b6f.flist"
+	cloudContainerFlist = "https://hub.grid.tf/tf-autobuilder/cloud-container-32b445e.flist"
 	cloudContainerName  = "cloud-container"
 )
 


### PR DESCRIPTION
### Description

Using this new cloud-container flist, the VMs will auto generate host keys if they don't exist on the image.

### Changes

Update cloud-container to latest build

### Related Issues

https://github.com/threefoldtech/zos/issues/2109
