### PR TITLE
add rmb diagnostics call

### DIFF
--- a/client/node.go
+++ b/client/node.go
@@ -77,6 +77,7 @@ import (
 	"net"
 
 	"github.com/threefoldtech/tfgrid-sdk-go/rmb-sdk-go"
+	"github.com/threefoldtech/zbus"
 	"github.com/threefoldtech/zos/pkg"
 	"github.com/threefoldtech/zos/pkg/capacity/dmi"
 	"github.com/threefoldtech/zos/pkg/gridtypes"
@@ -96,6 +97,19 @@ type Version struct {
 type Interface struct {
 	IPs []string `json:"ips"`
 	Mac string   `json:"mac"`
+}
+
+type moduleStatus struct {
+	Status zbus.Status `json:"status,omitempty"`
+	Err    error       `json:"error,omitempty"`
+}
+
+// Diagnostics show the health of zbus modules
+type Diagnostics struct {
+	// SystemStatusOk is the overall system status
+	SystemStatusOk bool `json:"system_status_ok"`
+	// Modules is a list of modules with their objects and workers
+	Modules map[string]moduleStatus `json:"modules"`
 }
 
 type ExitDevice struct {
@@ -325,5 +339,11 @@ func (n *NodeClient) SystemHypervisor(ctx context.Context) (result string, err e
 		return
 	}
 
+	return
+}
+
+func (n *NodeClient) SystemDiagnostics(ctx context.Context) (result Diagnostics, err error) {
+	const cmd = "zos.system.diagnostics"
+	err = n.bus.Call(ctx, n.nodeTwin, cmd, nil, &result)
 	return
 }

--- a/client/node.go
+++ b/client/node.go
@@ -77,9 +77,9 @@ import (
 	"net"
 
 	"github.com/threefoldtech/tfgrid-sdk-go/rmb-sdk-go"
-	"github.com/threefoldtech/zbus"
 	"github.com/threefoldtech/zos/pkg"
 	"github.com/threefoldtech/zos/pkg/capacity/dmi"
+	"github.com/threefoldtech/zos/pkg/diagnostics"
 	"github.com/threefoldtech/zos/pkg/gridtypes"
 )
 
@@ -97,19 +97,6 @@ type Version struct {
 type Interface struct {
 	IPs []string `json:"ips"`
 	Mac string   `json:"mac"`
-}
-
-type moduleStatus struct {
-	Status zbus.Status `json:"status,omitempty"`
-	Err    error       `json:"error,omitempty"`
-}
-
-// Diagnostics show the health of zbus modules
-type Diagnostics struct {
-	// SystemStatusOk is the overall system status
-	SystemStatusOk bool `json:"system_status_ok"`
-	// Modules is a list of modules with their objects and workers
-	Modules map[string]moduleStatus `json:"modules"`
 }
 
 type ExitDevice struct {
@@ -342,7 +329,7 @@ func (n *NodeClient) SystemHypervisor(ctx context.Context) (result string, err e
 	return
 }
 
-func (n *NodeClient) SystemDiagnostics(ctx context.Context) (result Diagnostics, err error) {
+func (n *NodeClient) SystemDiagnostics(ctx context.Context) (result diagnostics.Diagnostics, err error) {
 	const cmd = "zos.system.diagnostics"
 	err = n.bus.Call(ctx, n.nodeTwin, cmd, nil, &result)
 	return

--- a/cmds/modules/noded/main.go
+++ b/cmds/modules/noded/main.go
@@ -193,8 +193,12 @@ func action(cli *cli.Context) error {
 		return version, nil
 	})
 
+	diagnosticsMgr, err := diagnostics.NewDiagnosticsManager(msgBrokerCon, redis)
+	if err != nil {
+		return errors.Wrap(err, "failed to create a new Diagnostics manager")
+	}
 	bus.WithHandler("zos.system.diagnostics", func(ctx context.Context, payload []byte) (interface{}, error) {
-		return diagnostics.GetSystemDiagnostics(ctx, redis, msgBrokerCon)
+		return diagnosticsMgr.GetSystemDiagnostics(ctx)
 	})
 
 	bus.WithHandler("zos.system.dmi", func(ctx context.Context, payload []byte) (interface{}, error) {

--- a/cmds/modules/noded/main.go
+++ b/cmds/modules/noded/main.go
@@ -206,23 +206,20 @@ func action(cli *cli.Context) error {
 		}
 
 		for module := range zbusdebug.PossibleModules {
+			ctx, cancel := context.WithTimeout(ctx, 3*time.Second)
+
 			status, err := redis.Status(ctx, module)
+			if err != nil {
+				results.SystemStatusOk = false
+			}
+
 			moduleStatus := moduleStatus{
 				Status: status,
 				Err:    err,
 			}
-
-			if err != nil {
-				results.SystemStatusOk = false
-			} else {
-				for _, worker := range status.Workers {
-					if worker.State != zbus.WorkerFree {
-						results.SystemStatusOk = false
-					}
-				}
-			}
-
 			results.Modules[module] = moduleStatus
+
+			cancel()
 		}
 
 		return results, nil

--- a/cmds/modules/noded/main.go
+++ b/cmds/modules/noded/main.go
@@ -25,6 +25,7 @@ import (
 	"github.com/threefoldtech/zos/pkg/perf/cpubench"
 	"github.com/threefoldtech/zos/pkg/perf/healthcheck"
 	"github.com/threefoldtech/zos/pkg/perf/iperf"
+	"github.com/threefoldtech/zos/pkg/perf/networkhealth"
 	"github.com/threefoldtech/zos/pkg/perf/publicip"
 	"github.com/threefoldtech/zos/pkg/registrar"
 	"github.com/threefoldtech/zos/pkg/stubs"
@@ -193,7 +194,7 @@ func action(cli *cli.Context) error {
 	})
 
 	bus.WithHandler("zos.system.diagnostics", func(ctx context.Context, payload []byte) (interface{}, error) {
-		return diagnostics.GetSystemDiagnostics(ctx, redis)
+		return diagnostics.GetSystemDiagnostics(ctx, msgBrokerCon)
 	})
 
 	bus.WithHandler("zos.system.dmi", func(ctx context.Context, payload []byte) (interface{}, error) {
@@ -215,6 +216,7 @@ func action(cli *cli.Context) error {
 	perfMon.AddTask(cpubench.NewTask())
 	perfMon.AddTask(publicip.NewTask())
 	perfMon.AddTask(healthcheck.NewTask())
+	perfMon.AddTask(networkhealth.NewTask())
 
 	if err = perfMon.Run(ctx); err != nil {
 		return errors.Wrap(err, "failed to run the scheduler")

--- a/cmds/modules/noded/main.go
+++ b/cmds/modules/noded/main.go
@@ -194,7 +194,7 @@ func action(cli *cli.Context) error {
 	})
 
 	bus.WithHandler("zos.system.diagnostics", func(ctx context.Context, payload []byte) (interface{}, error) {
-		return diagnostics.GetSystemDiagnostics(ctx, msgBrokerCon)
+		return diagnostics.GetSystemDiagnostics(ctx, redis, msgBrokerCon)
 	})
 
 	bus.WithHandler("zos.system.dmi", func(ctx context.Context, payload []byte) (interface{}, error) {

--- a/pkg/diagnostics/diagnostics.go
+++ b/pkg/diagnostics/diagnostics.go
@@ -30,9 +30,12 @@ var Modules = []string{
 	"qsfsd",
 }
 
-type moduleStatus struct {
+// ModuleStatus represents the status of a module or shows if error
+type ModuleStatus struct {
+	// Status holds the status of the module
 	Status zbus.Status `json:"status,omitempty"`
-	Err    error       `json:"error,omitempty"`
+	// Err contains any error related to the module
+	Err error `json:"error,omitempty"`
 }
 
 // Diagnostics show the health of zbus modules
@@ -40,7 +43,7 @@ type Diagnostics struct {
 	// SystemStatusOk is the overall system status
 	SystemStatusOk bool `json:"system_status_ok"`
 	// ZosModules is a list of modules with their objects and workers
-	ZosModules map[string]moduleStatus `json:"modules"`
+	ZosModules map[string]ModuleStatus `json:"modules"`
 	// Online is the state of the grid services reachable from the node
 	Online bool `json:"online"`
 }
@@ -48,7 +51,7 @@ type Diagnostics struct {
 func GetSystemDiagnostics(ctx context.Context, busClient zbus.Client, msgBrokerCon string) (Diagnostics, error) {
 	results := Diagnostics{
 		SystemStatusOk: true,
-		ZosModules:     make(map[string]moduleStatus),
+		ZosModules:     make(map[string]ModuleStatus),
 	}
 
 	var wg sync.WaitGroup
@@ -75,12 +78,12 @@ func GetSystemDiagnostics(ctx context.Context, busClient zbus.Client, msgBrokerC
 
 }
 
-func getModuleStatus(ctx context.Context, busClient zbus.Client, module string) moduleStatus {
+func getModuleStatus(ctx context.Context, busClient zbus.Client, module string) ModuleStatus {
 	ctx, cancel := context.WithTimeout(ctx, callTimeout)
 	defer cancel()
 
 	status, err := busClient.Status(ctx, module)
-	return moduleStatus{
+	return ModuleStatus{
 		Status: status,
 		Err:    err,
 	}

--- a/pkg/diagnostics/diagnostics.go
+++ b/pkg/diagnostics/diagnostics.go
@@ -1,0 +1,77 @@
+package diagnostics
+
+import (
+	"context"
+	"sync"
+	"time"
+
+	"github.com/threefoldtech/zbus"
+)
+
+const callTimeout = 3 * time.Second
+
+// Modules is all the registered modules on zbus
+var Modules = []string{
+	"storage",
+	"node",
+	"identityd",
+	"vmd",
+	"flist",
+	"network",
+	"container",
+	"provision",
+	"gateway",
+	"qsfsd",
+}
+
+type moduleStatus struct {
+	Status zbus.Status `json:"status,omitempty"`
+	Err    error       `json:"error,omitempty"`
+}
+
+// Diagnostics show the health of zbus modules
+type Diagnostics struct {
+	// SystemStatusOk is the overall system status
+	SystemStatusOk bool `json:"system_status_ok"`
+	// Modules is a list of modules with their objects and workers
+	Modules map[string]moduleStatus `json:"modules"`
+}
+
+func GetSystemDiagnostics(ctx context.Context, busClient zbus.Client) (Diagnostics, error) {
+	results := Diagnostics{
+		SystemStatusOk: true,
+		Modules:        make(map[string]moduleStatus),
+	}
+
+	var wg sync.WaitGroup
+	for _, module := range Modules {
+
+		wg.Add(1)
+		go func(module string) {
+			defer wg.Done()
+			report := getModuleStatus(ctx, busClient, module)
+			results.Modules[module] = report
+
+			if report.Err != nil {
+				results.SystemStatusOk = false
+			}
+		}(module)
+
+	}
+
+	wg.Wait()
+
+	return results, nil
+
+}
+
+func getModuleStatus(ctx context.Context, busClient zbus.Client, module string) moduleStatus {
+	ctx, cancel := context.WithTimeout(ctx, callTimeout)
+	defer cancel()
+
+	status, err := busClient.Status(ctx, module)
+	return moduleStatus{
+		Status: status,
+		Err:    err,
+	}
+}

--- a/pkg/diagnostics/diagnostics.go
+++ b/pkg/diagnostics/diagnostics.go
@@ -2,13 +2,21 @@ package diagnostics
 
 import (
 	"context"
+	"encoding/json"
 	"sync"
 	"time"
 
+	"github.com/go-redis/redis"
+	"github.com/pkg/errors"
 	"github.com/threefoldtech/zbus"
+	"github.com/threefoldtech/zos/pkg/perf"
+	"github.com/threefoldtech/zos/pkg/perf/networkhealth"
 )
 
-const callTimeout = 3 * time.Second
+const (
+	callTimeout    = 3 * time.Second
+	testNetworkKey = "perf.network-health"
+)
 
 // Modules is all the registered modules on zbus
 var Modules = []string{
@@ -33,14 +41,21 @@ type moduleStatus struct {
 type Diagnostics struct {
 	// SystemStatusOk is the overall system status
 	SystemStatusOk bool `json:"system_status_ok"`
-	// Modules is a list of modules with their objects and workers
-	Modules map[string]moduleStatus `json:"modules"`
+	// ZosModules is a list of modules with their objects and workers
+	ZosModules map[string]moduleStatus `json:"modules"`
+	// Online is the state of the grid services reachable from the node
+	Online bool `json:"online"`
 }
 
-func GetSystemDiagnostics(ctx context.Context, busClient zbus.Client) (Diagnostics, error) {
+func GetSystemDiagnostics(ctx context.Context, msgBrokerCon string) (Diagnostics, error) {
+	busClient, err := zbus.NewRedisClient(msgBrokerCon)
+	if err != nil {
+		return Diagnostics{}, errors.Wrap(err, "fail to connect to message broker server")
+	}
+
 	results := Diagnostics{
 		SystemStatusOk: true,
-		Modules:        make(map[string]moduleStatus),
+		ZosModules:     make(map[string]moduleStatus),
 	}
 
 	var wg sync.WaitGroup
@@ -50,7 +65,7 @@ func GetSystemDiagnostics(ctx context.Context, busClient zbus.Client) (Diagnosti
 		go func(module string) {
 			defer wg.Done()
 			report := getModuleStatus(ctx, busClient, module)
-			results.Modules[module] = report
+			results.ZosModules[module] = report
 
 			if report.Err != nil {
 				results.SystemStatusOk = false
@@ -60,6 +75,9 @@ func GetSystemDiagnostics(ctx context.Context, busClient zbus.Client) (Diagnosti
 	}
 
 	wg.Wait()
+
+	client := redis.NewClient(&redis.Options{Addr: msgBrokerCon})
+	results.Online = isOnline(ctx, client)
 
 	return results, nil
 
@@ -74,4 +92,24 @@ func getModuleStatus(ctx context.Context, busClient zbus.Client, module string) 
 		Status: status,
 		Err:    err,
 	}
+}
+
+func isOnline(ctx context.Context, client *redis.Client) bool {
+	res, err := client.Get(testNetworkKey).Result()
+	if err != nil {
+		return false
+	}
+
+	var result perf.TaskResult
+	if err := json.Unmarshal([]byte(res), &result); err != nil {
+		return false
+	}
+
+	for _, service := range result.Result.([]networkhealth.ServiceStatus) {
+		if !service.IsReachable {
+			return false
+		}
+	}
+
+	return true
 }

--- a/pkg/perf/networkhealth/networkhealth.go
+++ b/pkg/perf/networkhealth/networkhealth.go
@@ -1,0 +1,99 @@
+package networkhealth
+
+import (
+	"context"
+	"net/http"
+	"strings"
+
+	"github.com/go-redis/redis"
+	"github.com/threefoldtech/zos/pkg/environment"
+	"github.com/threefoldtech/zos/pkg/perf"
+)
+
+type NetworkHealthTask struct{}
+
+type ServiceStatus struct {
+	Name        string
+	IsReachable bool
+	Err         error `json:"err,omitempty"`
+}
+
+var _ perf.Task = (*NetworkHealthTask)(nil)
+
+func NewTask() *NetworkHealthTask {
+	return &NetworkHealthTask{}
+}
+
+func (t *NetworkHealthTask) ID() string {
+	return "network-health"
+}
+
+func (t *NetworkHealthTask) Description() string {
+	return "Network health check runs periodically to check the connection to most of grid services."
+}
+
+func (t *NetworkHealthTask) Cron() string {
+	return "0 */5 * * * *"
+}
+
+func (t *NetworkHealthTask) Jitter() uint32 {
+	return 0
+}
+
+func (t *NetworkHealthTask) Run(ctx context.Context) (interface{}, error) {
+	var err error
+	result := []ServiceStatus{}
+
+	env := environment.MustGet()
+
+	status := pingHttp("activation-service", env.ActivationURL)
+	result = append(result, status)
+
+	status = pingHttp("graphql-gateway", env.GraphQL)
+	result = append(result, status)
+
+	status = pingRedis("hub", env.FlistURL)
+	result = append(result, status)
+
+	return result, err
+}
+
+func pingHttp(name, url string) ServiceStatus {
+	report := ServiceStatus{
+		Name:        name,
+		IsReachable: true,
+	}
+
+	res, err := http.Get(url)
+	if err != nil || res.StatusCode != http.StatusOK {
+		report.IsReachable = false
+		report.Err = err
+	}
+	defer res.Body.Close()
+
+	return report
+}
+
+func pingRedis(name, url string) ServiceStatus {
+	report := ServiceStatus{
+		Name:        name,
+		IsReachable: true,
+	}
+
+	addressSlice := strings.Split(url, "://")
+	addr := ""
+	if len(addr) == 1 {
+		addr = addressSlice[0]
+	} else {
+		addr = addressSlice[1]
+	}
+
+	redis := redis.NewClient(&redis.Options{Addr: addr})
+	res := redis.Ping()
+	if res.Err() != nil {
+		report.IsReachable = false
+		report.Err = res.Err()
+	}
+
+	return report
+}

--- a/pkg/perf/networkhealth/networkhealth.go
+++ b/pkg/perf/networkhealth/networkhealth.go
@@ -13,7 +13,7 @@ import (
 	"github.com/threefoldtech/zos/pkg/perf"
 )
 
-const requestTimeout = 5 * time.Second
+const defaultRequestTimeout = 5 * time.Second
 
 type NetworkHealthTask struct{}
 
@@ -49,8 +49,7 @@ func (t *NetworkHealthTask) Run(ctx context.Context) (interface{}, error) {
 	servicesUrl := []string{
 		env.ActivationURL, env.GraphQL, env.FlistURL,
 	}
-	servicesUrl = append(servicesUrl, env.SubstrateURL...)
-	servicesUrl = append(servicesUrl, env.RelayURL...)
+	servicesUrl = append(append(servicesUrl, env.SubstrateURL...), env.RelayURL...)
 
 	reports := []ServiceStatus{}
 
@@ -69,7 +68,7 @@ func (t *NetworkHealthTask) Run(ctx context.Context) (interface{}, error) {
 }
 
 func getNetworkReport(ctx context.Context, serviceUrl string) ServiceStatus {
-	ctx, cancel := context.WithTimeout(ctx, requestTimeout)
+	ctx, cancel := context.WithTimeout(ctx, defaultRequestTimeout)
 	defer cancel()
 
 	report := ServiceStatus{
@@ -101,7 +100,7 @@ func parseUrl(serviceUrl string) string {
 }
 
 func isReachable(ctx context.Context, address string) error {
-	d := net.Dialer{Timeout: requestTimeout}
+	d := net.Dialer{Timeout: defaultRequestTimeout}
 	conn, err := d.DialContext(ctx, "tcp", address)
 	if err != nil {
 		return fmt.Errorf("failed to connect: %w", err)

--- a/pkg/perf/networkhealth/networkhealth.go
+++ b/pkg/perf/networkhealth/networkhealth.go
@@ -77,8 +77,8 @@ func getNetworkReport(ctx context.Context, serviceUrl string) ServiceStatus {
 		IsReachable: true,
 	}
 
-	parsedUrl := parseUrl(serviceUrl)
-	err := isReachable(ctx, parsedUrl)
+	address := parseUrl(serviceUrl)
+	err := isReachable(ctx, address)
 	if err != nil {
 		report.IsReachable = false
 	}
@@ -100,9 +100,9 @@ func parseUrl(serviceUrl string) string {
 	return host
 }
 
-func isReachable(ctx context.Context, serviceUrl string) error {
+func isReachable(ctx context.Context, address string) error {
 	d := net.Dialer{Timeout: requestTimeout}
-	conn, err := d.DialContext(ctx, "tcp", serviceUrl)
+	conn, err := d.DialContext(ctx, "tcp", address)
 	if err != nil {
 		return fmt.Errorf("failed to connect: %w", err)
 	}

--- a/pkg/utils/redis_test.go
+++ b/pkg/utils/redis_test.go
@@ -1,0 +1,59 @@
+package utils
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestParseRedisAddress(t *testing.T) {
+	tests := []struct {
+		name        string
+		address     string
+		expected    RedisDialParams
+		expectedErr error
+	}{
+		{
+			name:    "tcp scheme",
+			address: "tcp://localhost:6379",
+			expected: RedisDialParams{
+				Scheme: "tcp",
+				Host:   "localhost:6379",
+			},
+		},
+		{
+			name:    "unix scheme",
+			address: "unix:///var/run/redis.sock",
+			expected: RedisDialParams{
+				Scheme: "unix",
+				Host:   "/var/run/redis.sock",
+			},
+		},
+		{
+			name:    "redis scheme",
+			address: "redis://localhost:6379",
+			expected: RedisDialParams{
+				Scheme: "tcp",
+				Host:   "localhost:6379",
+			},
+		},
+		{
+			name:        "missing scheme",
+			address:     "localhost",
+			expectedErr: fmt.Errorf("unknown scheme '' expecting tcp or unix"),
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			params, err := parseRedisAddress(test.address)
+			require.Equal(t, test.expectedErr, err)
+
+			if err == nil {
+				require.Equal(t, test.expected.Scheme, params.Scheme)
+				require.Equal(t, test.expected.Host, params.Host)
+			}
+		})
+	}
+}


### PR DESCRIPTION
### Description
- add new rmb call `zos.system.diagnostics` returns the output of `zbusdebug` command
- add new perf task to check the node reaches for grid services

### Related Issues
- https://github.com/threefoldtech/zos/issues/2153
- https://github.com/threefoldtech/zos/issues/2163

### Checklist

- [ ] Tests included
- [ ] Build pass
- [ ] Documentation
- [ ] Code format and docstring
