### PR TITLE
add compatibility to still support ygg_ip for old workloads

### DIFF
--- a/pkg/gridtypes/zos/zmachine.go
+++ b/pkg/gridtypes/zos/zmachine.go
@@ -350,3 +350,27 @@ type ZMachineResult struct {
 	PlanetaryIP string `json:"planetary_ip"`
 	ConsoleURL  string `json:"console_url"`
 }
+
+func (r *ZMachineResult) UnmarshalJSON(data []byte) error {
+	var deprecated struct {
+		ID          string `json:"id"`
+		IP          string `json:"ip"`
+		YggIP       string `json:"ygg_ip"`
+		PlanetaryIP string `json:"planetary_ip"`
+		ConsoleURL  string `json:"console_url"`
+	}
+
+	if err := json.Unmarshal(data, &deprecated); err != nil {
+		return err
+	}
+
+	r.ID = deprecated.ID
+	r.IP = deprecated.IP
+	r.PlanetaryIP = deprecated.PlanetaryIP
+	if deprecated.YggIP != "" {
+		r.PlanetaryIP = deprecated.YggIP
+	}
+	r.ConsoleURL = deprecated.ConsoleURL
+
+	return nil
+}

--- a/pkg/gridtypes/zos/zmachine_test.go
+++ b/pkg/gridtypes/zos/zmachine_test.go
@@ -1,6 +1,7 @@
 package zos
 
 import (
+	"encoding/json"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -93,4 +94,25 @@ func TestZMachineSRU(t *testing.T) {
 			require.Equal(t, expected, vm.RootSize())
 		})
 	}
+}
+
+func TestResultDeprecated(t *testing.T) {
+	raw := ` {
+		"id": "192-74881-testing2",
+		"ip": "10.20.2.2",
+		"ygg_ip": "32b:8310:9b03:5529:ff0f:37cd:de80:b322",
+		"console_url": "10.20.2.0:20002"
+	  }`
+
+	var result ZMachineResult
+
+	err := json.Unmarshal([]byte(raw), &result)
+	require.NoError(t, err)
+
+	require.EqualValues(t, ZMachineResult{
+		ID:          "192-74881-testing2",
+		IP:          "10.20.2.2",
+		PlanetaryIP: "32b:8310:9b03:5529:ff0f:37cd:de80:b322",
+		ConsoleURL:  "10.20.2.0:20002",
+	}, result)
 }


### PR DESCRIPTION
### Description

Old worklaods can still have `ygg_ip` instead of `planetary_ip` so we need to be backward compatible
