### PR TITLE
Update cloud-container to latest

### DIFF
--- a/pkg/primitives/vm/vm.go
+++ b/pkg/primitives/vm/vm.go
@@ -19,7 +19,7 @@ import (
 )
 
 const (
-	cloudContainerFlist = "https://hub.grid.tf/tf-autobuilder/cloud-container-32b445e.flist"
+	cloudContainerFlist = "https://hub.grid.tf/tf-autobuilder/cloud-container-6fb64bb.flist"
 	cloudContainerName  = "cloud-container"
 )
 


### PR DESCRIPTION
### Description

Update cloud-container to latest which includes the fix for resolv.conf file not being set when an error during network setup happens.
It was tested by duplicating the routes entries [here](https://github.com/threefoldtech/zos/blob/main/pkg/vm/manager.go#L227-L230) and it logged the errors and continued the rest of the configuration so resolv.conf had entries.
```
found device with mac: 
found device with mac: 6a:9d:df:5f:9d:e2
found device with mac: aa:84:90:f9:d1:a7
setting up (6a:9d:df:5f:9d:e2)
failed to set route 10.20.0.0/16 via 10.20.2.1 on interface 6a:9d:df:5f:9d:e2: file exists
failed to set route 100.64.0.0/16 via 10.20.2.1 on interface 6a:9d:df:5f:9d:e2: file exists
setting up (aa:84:90:f9:d1:a7)
failed to set route 200::/7 via 301:8afa:1b85:5b6e::1 on interface aa:84:90:f9:d1:a7: file exists
generating host ssh keys
PING 8.8.8.8 (8.8.8.8): 56 data bytes
64 bytes from 8.8.8.8: seq=0 ttl=114 time=43.415 ms
```

### Changes

- latest cloud-container flist will be used

### Related Issues

- #2177 

### Checklist

- [ ] Tests included
- [x] Build pass
- [ ] Documentation
- [x] Code format and docstring
