### PR TITLE
Assign ipv6 and gw6 to vm via config

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -70,6 +70,7 @@ require (
 	github.com/coreos/go-iptables v0.6.0 // indirect
 	github.com/cosmos/go-bip39 v1.0.0 // indirect
 	github.com/cpuguy83/go-md2man/v2 v2.0.2 // indirect
+	github.com/dave/jennifer v1.3.0 // indirect
 	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/decred/dcrd/crypto/blake256 v1.0.1 // indirect
 	github.com/decred/dcrd/dcrec/secp256k1/v3 v3.0.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -106,6 +106,7 @@ github.com/d2g/dhcp4 v0.0.0-20170904100407-a1d1b6c41b1c/go.mod h1:Ct2BUK8SB0YC1S
 github.com/d2g/dhcp4client v1.0.0/go.mod h1:j0hNfjhrt2SxUOw55nL0ATM/z4Yt3t2Kd1mW34z5W5s=
 github.com/d2g/dhcp4server v0.0.0-20181031114812-7d4a0a7f59a5/go.mod h1:Eo87+Kg/IX2hfWJfwxMzLyuSZyxSoAug2nGa1G2QAi8=
 github.com/d2g/hardwareaddr v0.0.0-20190221164911-e7d9fbe030e4/go.mod h1:bMl4RjIciD2oAxI7DmWRx6gbeqrkoLqv3MV0vzNad+I=
+github.com/dave/jennifer v1.3.0 h1:p3tl41zjjCZTNBytMwrUuiAnherNUZktlhPTKoF/sEk=
 github.com/dave/jennifer v1.3.0/go.mod h1:fIb+770HOpJ2fmN9EPPKOqm1vMGhB+TwXKMZhrIygKg=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=

--- a/pkg/network.go
+++ b/pkg/network.go
@@ -162,6 +162,10 @@ type Networker interface {
 	// GetPublicIPv6Subnet returns the IPv6 prefix op the public subnet of the host
 	GetPublicIPv6Subnet() (net.IPNet, error)
 
+	// GetPublicIPV6Gateway gets the gateway for public IPv6 that can be used
+	// by the VMs
+	GetPublicIPV6Gateway() (net.IP, error)
+
 	// GetDefaultGwIP returns the IPs of the default gateways inside the network
 	// resource identified by the network ID on the local node, for IPv4 and IPv6
 	// respectively

--- a/pkg/network/ndmz/ndmz.go
+++ b/pkg/network/ndmz/ndmz.go
@@ -31,6 +31,10 @@ type DMZ interface {
 	// GetIP gets ndmz public ips from ndmz
 	GetIP(family int) ([]net.IPNet, error)
 
+	// Get gateway to given destination ip
+	GetDefaultGateway(destination net.IP) (net.IP, error)
+
+	// GetIPFor get the ip of an
 	GetIPFor(inf string) ([]net.IPNet, error)
 	//GetIP(family netlink.FAM)
 	// SupportsPubIPv4 indicates if the node supports public ipv4 addresses for

--- a/pkg/network/networker.go
+++ b/pkg/network/networker.go
@@ -638,6 +638,12 @@ func (n *networker) GetPublicIPv6Subnet() (net.IPNet, error) {
 	return net.IPNet{}, fmt.Errorf("no public ipv6 found")
 }
 
+func (n *networker) GetPublicIPV6Gateway() (net.IP, error) {
+	// simply find the default gw for a well known public ip. in this case
+	// we use the public google dns service
+	return n.ndmz.GetDefaultGateway(net.ParseIP("2001:4860:4860::8888"))
+}
+
 // GetSubnet of a local network resource identified by the network ID, ipv4 and ipv6
 // subnet respectively
 func (n *networker) GetSubnet(networkID pkg.NetID) (net.IPNet, error) {

--- a/pkg/primitives/pubip/public_ip.go
+++ b/pkg/primitives/pubip/public_ip.go
@@ -150,7 +150,7 @@ func (p *Manager) publicIPProvisionImpl(ctx context.Context, wl *gridtypes.Workl
 
 	var ipv6 gridtypes.IPNet
 	var ipv4 gridtypes.IPNet
-	var gw net.IP
+	var gw4 net.IP
 
 	mac := ifaceutil.HardwareAddrFromInputBytes([]byte(tapName))
 	if config.V6 {
@@ -166,7 +166,7 @@ func (p *Manager) publicIPProvisionImpl(ctx context.Context, wl *gridtypes.Workl
 	}
 
 	if config.V4 {
-		ipv4, gw, err = p.getAssignedPublicIP(ctx, wl)
+		ipv4, gw4, err = p.getAssignedPublicIP(ctx, wl)
 		if err != nil {
 			return zos.PublicIPResult{}, err
 		}
@@ -174,7 +174,7 @@ func (p *Manager) publicIPProvisionImpl(ctx context.Context, wl *gridtypes.Workl
 
 	result.IP = ipv4
 	result.IPv6 = ipv6
-	result.Gateway = gw
+	result.Gateway = gw4
 
 	ifName := fmt.Sprintf("p-%s", tapName) // TODO: clean this up, needs to come form networkd
 	err = network.SetupPubIPFilter(ctx, fName, ifName, ipv4.IP, ipv6.IP, mac.String())

--- a/pkg/primitives/vm/vm.go
+++ b/pkg/primitives/vm/vm.go
@@ -19,7 +19,7 @@ import (
 )
 
 const (
-	cloudContainerFlist = "https://hub.grid.tf/tf-autobuilder/cloud-container-6fb64bb.flist"
+	cloudContainerFlist = "https://hub.grid.tf/tf-autobuilder/cloud-container-9dba60e.flist"
 	cloudContainerName  = "cloud-container"
 )
 

--- a/pkg/stubs/network_stub.go
+++ b/pkg/stubs/network_stub.go
@@ -205,6 +205,23 @@ func (s *NetworkerStub) GetPublicExitDevice(ctx context.Context) (ret0 pkg.ExitD
 	return
 }
 
+func (s *NetworkerStub) GetPublicIPV6Gateway(ctx context.Context) (ret0 []uint8, ret1 error) {
+	args := []interface{}{}
+	result, err := s.client.RequestContext(ctx, s.module, s.object, "GetPublicIPV6Gateway", args...)
+	if err != nil {
+		panic(err)
+	}
+	result.PanicOnError()
+	ret1 = result.CallError()
+	loader := zbus.Loader{
+		&ret0,
+	}
+	if err := result.Unmarshal(&loader); err != nil {
+		panic(err)
+	}
+	return
+}
+
 func (s *NetworkerStub) GetPublicIPv6Subnet(ctx context.Context) (ret0 net.IPNet, ret1 error) {
 	args := []interface{}{}
 	result, err := s.client.RequestContext(ctx, s.module, s.object, "GetPublicIPv6Subnet", args...)


### PR DESCRIPTION
### Description

Instead of relying on slaac to give ipv6 to VMs now it's done explicitly via cidata (cloud init data) provided to the vm

This means cloud-container now also disable router advertisment on interfaces.

This also mean ipv6 is not provided unless requested in the workload. This was a problem before because it was conflicting with other configurable routes for ipv6

### Changes

- Use recent cloud-container that auto disable router advertisement on all nics
- Make sure that assigned IPv6 and gateway are passed to machine via cidata (cloud-init data)
