### PR TITLE
Add list and list_private_ips rmb calls

### DIFF
--- a/client/node.go
+++ b/client/node.go
@@ -146,9 +146,9 @@ func (n *NodeClient) DeploymentGet(ctx context.Context, contractID uint64) (dl g
 	return dl, nil
 }
 
-// DeploymentGetAll gets all deployments for a twin
-func (n *NodeClient) DeploymentGetAll(ctx context.Context) (dls []gridtypes.Deployment, err error) {
-	const cmd = "zos.deployment.get_all"
+// DeploymentList gets all deployments for a twin
+func (n *NodeClient) DeploymentList(ctx context.Context) (dls []gridtypes.Deployment, err error) {
+	const cmd = "zos.deployment.list"
 
 	err = n.bus.Call(ctx, n.nodeTwin, cmd, nil, &dls)
 	return

--- a/client/node.go
+++ b/client/node.go
@@ -146,6 +146,14 @@ func (n *NodeClient) DeploymentGet(ctx context.Context, contractID uint64) (dl g
 	return dl, nil
 }
 
+// DeploymentGetAll gets all deployments for a twin
+func (n *NodeClient) DeploymentGetAll(ctx context.Context) (dls []gridtypes.Deployment, err error) {
+	const cmd = "zos.deployment.get_all"
+
+	err = n.bus.Call(ctx, n.nodeTwin, cmd, nil, &dls)
+	return
+}
+
 // DeploymentGet gets a deployment via contract ID
 func (n *NodeClient) DeploymentChanges(ctx context.Context, contractID uint64) (changes []gridtypes.Workload, err error) {
 	const cmd = "zos.deployment.changes"
@@ -284,6 +292,21 @@ func (n *NodeClient) NetworkListPublicIPs(ctx context.Context) ([]string, error)
 	var result []string
 
 	if err := n.bus.Call(ctx, n.nodeTwin, cmd, nil, &result); err != nil {
+		return nil, err
+	}
+
+	return result, nil
+}
+
+// NetworkListPrivateIPs list private ips reserved for a network
+func (n *NodeClient) NetworkListPrivateIPs(ctx context.Context, networkName string) ([]string, error) {
+	const cmd = "zos.network.list_private_ips"
+	var result []string
+	in := args{
+		"network_name": networkName,
+	}
+
+	if err := n.bus.Call(ctx, n.nodeTwin, cmd, in, &result); err != nil {
 		return nil, err
 	}
 

--- a/pkg/provision/mbus/api.go
+++ b/pkg/provision/mbus/api.go
@@ -36,7 +36,7 @@ func (d *Deployments) setup(router rmb.Router) {
 	sub.WithHandler("update", d.updateHandler)
 	sub.WithHandler("delete", d.deleteHandler)
 	sub.WithHandler("get", d.getHandler)
-	sub.WithHandler("get_all", d.getAllHandler)
+	sub.WithHandler("list", d.listHandler)
 	sub.WithHandler("changes", d.changesHandler)
 
 	net := router.Subroute("network")
@@ -88,21 +88,21 @@ func (n *Deployments) listPublicIps(ctx context.Context, _ []byte) (interface{},
 	return ips, nil
 }
 
-type nameArgs struct {
+type listPrivateIpsArgs struct {
 	NetworkName string `json:"network_name"`
 }
 
 func (d *Deployments) listPrivateIps(ctx context.Context, payload []byte) (interface{}, error) {
-	var args nameArgs
+	var args listPrivateIpsArgs
 	if err := json.Unmarshal(payload, &args); err != nil {
 		return nil, err
 	}
-	deployments, err := d.getAll(ctx, payload)
+	deployments, err := d.list(ctx, payload)
 	if err != nil {
 		return nil, err.Err()
 	}
 	dls := deployments.([]gridtypes.Deployment)
-	ips := make([]string, 0)
+	var ips []string
 	for _, deployment := range dls {
 		vms := deployment.ByType(zos.ZMachineType)
 		for _, vm := range vms {
@@ -168,8 +168,8 @@ func (d *Deployments) changesHandler(ctx context.Context, payload []byte) (inter
 	return data, nil
 }
 
-func (d *Deployments) getAllHandler(ctx context.Context, payload []byte) (interface{}, error) {
-	data, err := d.getAll(ctx, payload)
+func (d *Deployments) listHandler(ctx context.Context, payload []byte) (interface{}, error) {
+	data, err := d.list(ctx, payload)
 	if err != nil {
 		return nil, err.Err()
 	}

--- a/pkg/provision/mbus/api.go
+++ b/pkg/provision/mbus/api.go
@@ -89,7 +89,7 @@ func (n *Deployments) listPublicIps(ctx context.Context, _ []byte) (interface{},
 }
 
 type listPrivateIpsArgs struct {
-	NetworkName string `json:"network_name"`
+	NetworkName gridtypes.Name `json:"network_name"`
 }
 
 func (d *Deployments) listPrivateIps(ctx context.Context, payload []byte) (interface{}, error) {
@@ -114,7 +114,7 @@ func (d *Deployments) listPrivateIps(ctx context.Context, payload []byte) (inter
 			}
 			zmachine := data.(*zos.ZMachine)
 			for _, inf := range zmachine.Network.Interfaces {
-				if inf.Network == gridtypes.Name(args.NetworkName) {
+				if inf.Network == args.NetworkName {
 					ips = append(ips, inf.IP.String())
 				}
 			}
@@ -168,9 +168,5 @@ func (d *Deployments) changesHandler(ctx context.Context, payload []byte) (inter
 }
 
 func (d *Deployments) listHandler(ctx context.Context, payload []byte) (interface{}, error) {
-	data, err := d.list(ctx, payload)
-	if err != nil {
-		return nil, err
-	}
-	return data, nil
+	return d.list(ctx, payload)
 }

--- a/pkg/provision/mbus/api.go
+++ b/pkg/provision/mbus/api.go
@@ -99,11 +99,10 @@ func (d *Deployments) listPrivateIps(ctx context.Context, payload []byte) (inter
 	}
 	deployments, err := d.list(ctx, payload)
 	if err != nil {
-		return nil, err.Err()
+		return nil, err
 	}
-	dls := deployments.([]gridtypes.Deployment)
 	var ips []string
-	for _, deployment := range dls {
+	for _, deployment := range deployments {
 		vms := deployment.ByType(zos.ZMachineType)
 		for _, vm := range vms {
 			if vm.Result.State.IsAny(gridtypes.StateDeleted, gridtypes.StateError) {
@@ -171,7 +170,7 @@ func (d *Deployments) changesHandler(ctx context.Context, payload []byte) (inter
 func (d *Deployments) listHandler(ctx context.Context, payload []byte) (interface{}, error) {
 	data, err := d.list(ctx, payload)
 	if err != nil {
-		return nil, err.Err()
+		return nil, err
 	}
 	return data, nil
 }

--- a/pkg/provision/mbus/api.go
+++ b/pkg/provision/mbus/api.go
@@ -101,7 +101,7 @@ func (d *Deployments) listPrivateIps(ctx context.Context, payload []byte) (inter
 	if err != nil {
 		return nil, err
 	}
-	var ips []string
+	ips := make([]string, 0)
 	for _, deployment := range deployments {
 		vms := deployment.ByType(zos.ZMachineType)
 		for _, vm := range vms {

--- a/pkg/provision/mbus/reservation.go
+++ b/pkg/provision/mbus/reservation.go
@@ -80,6 +80,25 @@ func (d *Deployments) get(ctx context.Context, payload []byte) (interface{}, mw.
 	return deployment, nil
 }
 
+func (d *Deployments) getAll(ctx context.Context, payload []byte) (interface{}, mw.Response) {
+	deploymentIDs, err := d.engine.Storage().ByTwin(rmb.GetTwinID(ctx))
+	if err != nil {
+		return nil, mw.Error(err)
+	}
+	deployments := make([]gridtypes.Deployment, 0)
+	for _, id := range deploymentIDs {
+		deployment, err := d.engine.Storage().Get(rmb.GetTwinID(ctx), id)
+		if err != nil {
+			return nil, mw.Error(err)
+		}
+		if !deployment.IsActive() {
+			continue
+		}
+		deployments = append(deployments, deployment)
+	}
+	return deployments, nil
+}
+
 func (d *Deployments) changes(ctx context.Context, payload []byte) (interface{}, mw.Response) {
 	var args idArgs
 	err := json.Unmarshal(payload, &args)

--- a/pkg/provision/mbus/reservation.go
+++ b/pkg/provision/mbus/reservation.go
@@ -80,7 +80,7 @@ func (d *Deployments) get(ctx context.Context, payload []byte) (interface{}, mw.
 	return deployment, nil
 }
 
-func (d *Deployments) getAll(ctx context.Context, payload []byte) (interface{}, mw.Response) {
+func (d *Deployments) list(ctx context.Context, payload []byte) (interface{}, mw.Response) {
 	deploymentIDs, err := d.engine.Storage().ByTwin(rmb.GetTwinID(ctx))
 	if err != nil {
 		return nil, mw.Error(err)

--- a/pkg/provision/mbus/reservation.go
+++ b/pkg/provision/mbus/reservation.go
@@ -80,16 +80,16 @@ func (d *Deployments) get(ctx context.Context, payload []byte) (interface{}, mw.
 	return deployment, nil
 }
 
-func (d *Deployments) list(ctx context.Context, payload []byte) (interface{}, mw.Response) {
+func (d *Deployments) list(ctx context.Context, payload []byte) ([]gridtypes.Deployment, error) {
 	deploymentIDs, err := d.engine.Storage().ByTwin(rmb.GetTwinID(ctx))
 	if err != nil {
-		return nil, mw.Error(err)
+		return nil, err
 	}
 	deployments := make([]gridtypes.Deployment, 0)
 	for _, id := range deploymentIDs {
 		deployment, err := d.engine.Storage().Get(rmb.GetTwinID(ctx), id)
 		if err != nil {
-			return nil, mw.Error(err)
+			return nil, err
 		}
 		if !deployment.IsActive() {
 			continue


### PR DESCRIPTION
### Description

Add RMB calls to get all deployments for a twin and get private ips reserved in a network

### Changes

- `zos.deployment.list` RMB call to get all deployments.
- `zos.network.list_private_ips` to get private IPs reserved for a given network.

### Related Issues

- #2204
- #2205

### Checklist

- [ ] Tests included
- [x] Build pass
- [x] Documentation
- [x] Code format and docstring
