### PR TITLE
support both mycelium + yggdrasil

### DIFF
--- a/bins/packages/mycelium/mycelium.sh
+++ b/bins/packages/mycelium/mycelium.sh
@@ -1,5 +1,5 @@
-MYCELIUM_VERSION="0.3.0"
-MYCELIUM_CHECKSUM="68ac250b23057a18f351a9aa4bc0ef6d"
+MYCELIUM_VERSION="0.4.0"
+MYCELIUM_CHECKSUM="b8be89c10d5a25d2796740fd78c6e9c9"
 MYCELIUM_LINK="https://github.com/threefoldtech/mycelium/releases/download/v${MYCELIUM_VERSION}/mycelium-x86_64-unknown-linux-musl.tar.gz"
 
 download_mycelium() {

--- a/pkg/gridtypes/zos/zmachine.go
+++ b/pkg/gridtypes/zos/zmachine.go
@@ -352,6 +352,7 @@ type ZMachineResult struct {
 	ID          string `json:"id"`
 	IP          string `json:"ip"`
 	PlanetaryIP string `json:"planetary_ip"`
+	MyceliumIP  string `json:"mycelium_ip"`
 	ConsoleURL  string `json:"console_url"`
 }
 

--- a/pkg/primitives/vm/utils.go
+++ b/pkg/primitives/vm/utils.go
@@ -195,7 +195,7 @@ func (p *Manager) newMyceliumNetworkInterface(ctx context.Context, dl gridtypes.
 		Routes: []pkg.Route{
 			{
 				Net: net.IPNet{
-					IP:   net.ParseIP("200::"),
+					IP:   net.ParseIP("400::"),
 					Mask: net.CIDRMask(7, 128),
 				},
 				Gateway: iface.Gateway.IP,

--- a/pkg/primitives/vm/vm.go
+++ b/pkg/primitives/vm/vm.go
@@ -200,24 +200,25 @@ func (p *Manager) virtualMachineProvisionImpl(ctx context.Context, wl *gridtypes
 	}
 
 	if config.Network.Planetary {
-		var inf pkg.VMIface
-		if config.Network.Mycelium == nil {
-			inf, err = p.newYggNetworkInterface(ctx, wl)
-			if err != nil {
-				return result, err
-			}
-			ifs = append(ifs, wl.ID.Unique("ygg"))
-		} else {
-			inf, err = p.newMyceliumNetworkInterface(ctx, deployment, wl, config.Network.Mycelium)
-			if err != nil {
-				return result, err
-			}
-			ifs = append(ifs, wl.ID.Unique("mycelium"))
+		inf, err := p.newYggNetworkInterface(ctx, wl)
+		if err != nil {
+			return result, err
 		}
+		ifs = append(ifs, wl.ID.Unique("ygg"))
 
 		log.Debug().Msgf("Planetary: %+v", inf)
 		networkInfo.Ifaces = append(networkInfo.Ifaces, inf)
 		result.PlanetaryIP = inf.IPs[0].IP.String()
+	}
+
+	if config.Network.Mycelium != nil {
+		inf, err := p.newMyceliumNetworkInterface(ctx, deployment, wl, config.Network.Mycelium)
+		if err != nil {
+			return result, err
+		}
+		ifs = append(ifs, wl.ID.Unique("mycelium"))
+		networkInfo.Ifaces = append(networkInfo.Ifaces, inf)
+		result.MyceliumIP = inf.IPs[0].IP.String()
 	}
 	// - mount flist RO
 	mnt, err := flist.Mount(ctx, wl.ID.String(), config.FList, pkg.ReadOnlyMountOptions)


### PR DESCRIPTION

### Description
now VMs can has both ygg and mycelium at the same time


### Changes

- Allow both mycelium and ygg by using proper vm workload flags:
  - enable ygg by setting `planetary` to true
  - enable mycelium by passing proper mycelium config
