### PR TITLE
stop sending uptime reports if the node can not reach grid services

### DIFF
--- a/pkg/app/flag.go
+++ b/pkg/app/flag.go
@@ -15,6 +15,8 @@ const (
 	LimitedCache = "limited-cache"
 	// ReadonlyCache represents the flag for cache is read only
 	ReadonlyCache = "readonly-cache"
+	// NotReachable represents the flag when a grid service is not reachable
+	NotReachable = "not-reachable"
 )
 
 // SetFlag is used when the /var/cache cannot be mounted on a SSD or HDD,

--- a/pkg/perf/healthcheck/network.go
+++ b/pkg/perf/healthcheck/network.go
@@ -42,6 +42,12 @@ func networkCheck(ctx context.Context) []error {
 	}
 	wg.Wait()
 
+	if len(errors) == 0 {
+		if err := app.DeleteFlag(app.NotReachable); err != nil {
+			log.Error().Err(err).Msg("failed to delete readonly flag")
+		}
+	}
+
 	return errors
 }
 

--- a/pkg/perf/healthcheck/network.go
+++ b/pkg/perf/healthcheck/network.go
@@ -8,6 +8,8 @@ import (
 	"sync"
 	"time"
 
+	"github.com/rs/zerolog/log"
+	"github.com/threefoldtech/zos/pkg/app"
 	"github.com/threefoldtech/zos/pkg/environment"
 )
 
@@ -50,6 +52,9 @@ func checkService(ctx context.Context, serviceUrl string) error {
 	address := parseUrl(serviceUrl)
 	err := isReachable(ctx, address)
 	if err != nil {
+		if err := app.SetFlag(app.NotReachable); err != nil {
+			log.Error().Err(err).Msg("failed to set not reachable flag")
+		}
 		return fmt.Errorf("%s is not reachable: %w", serviceUrl, err)
 	}
 

--- a/pkg/power/uptime.go
+++ b/pkg/power/uptime.go
@@ -129,5 +129,9 @@ func isNodeHealthy() bool {
 		log.Error().Msg("node is running on limited cache")
 		healthy = false
 	}
+	if app.CheckFlag(app.NotReachable) {
+		log.Error().Msg("node can not reach grid services")
+		healthy = false
+	}
 	return healthy
 }


### PR DESCRIPTION


### Description
stop sending uptime reports if the node can not reach grid services

### Changes
- add new `NotReachable` flag
- set the flag each time fails to resolve a service url, and unset on each new NetworkHealth run

### Related Issues
- https://github.com/threefoldtech/zos/issues/2213

### Checklist

- [ ] Tests included
- [ ] Build pass
- [ ] Documentation
- [ ] Code format and docstring
