### PR TITLE
move the network check to the health check task

### DIFF
--- a/cmds/modules/noded/main.go
+++ b/cmds/modules/noded/main.go
@@ -25,7 +25,6 @@ import (
 	"github.com/threefoldtech/zos/pkg/perf/cpubench"
 	"github.com/threefoldtech/zos/pkg/perf/healthcheck"
 	"github.com/threefoldtech/zos/pkg/perf/iperf"
-	"github.com/threefoldtech/zos/pkg/perf/networkhealth"
 	"github.com/threefoldtech/zos/pkg/perf/publicip"
 	"github.com/threefoldtech/zos/pkg/registrar"
 	"github.com/threefoldtech/zos/pkg/stubs"
@@ -220,7 +219,6 @@ func action(cli *cli.Context) error {
 	perfMon.AddTask(cpubench.NewTask())
 	perfMon.AddTask(publicip.NewTask())
 	perfMon.AddTask(healthcheck.NewTask())
-	perfMon.AddTask(networkhealth.NewTask())
 
 	if err = perfMon.Run(ctx); err != nil {
 		return errors.Wrap(err, "failed to run the scheduler")

--- a/docs/tasks/healthcheck.md
+++ b/docs/tasks/healthcheck.md
@@ -7,11 +7,14 @@ Health check task executes some checks over ZOS components to determine if the n
 ## Configuration
 
 - Name: `healthcheck`
-- Schedule: Every 20 mins.
+- Schedule: Every 15 mins.
 
 ## Details
 
-- Check if the node cache disk is usable or not by trying to write some data to it. If it failed, it set the Readonly flag.
+- `cacheCheck`:
+   Check if the node cache disk is usable or not by trying to write some data to it. If it failed, it set the Readonly flag.
+- `networkCheck`:
+   Check if the node can connect to the grid services chain, relay, hub, graphql, ...
 
 ## Result Sample
 

--- a/pkg/app/flag.go
+++ b/pkg/app/flag.go
@@ -15,6 +15,8 @@ const (
 	LimitedCache = "limited-cache"
 	// ReadonlyCache represents the flag for cache is read only
 	ReadonlyCache = "readonly-cache"
+	// NotReachable represents the flag when a grid service is not reachable
+	NotReachable = "not-reachable"
 )
 
 // SetFlag is used when the /var/cache cannot be mounted on a SSD or HDD,

--- a/pkg/perf/healthcheck/healthcheck.go
+++ b/pkg/perf/healthcheck/healthcheck.go
@@ -13,14 +13,15 @@ import (
 
 const (
 	id          = "healthcheck"
-	schedule    = "0 */20 * * * *"
+	schedule    = "0 */15 * * * *"
 	description = "health check task runs multiple checks to ensure the node is in a usable state and set flags for the power daemon to stop reporting uptime if it is not usable"
 )
 
 // NewTask returns a new health check task.
 func NewTask() perf.Task {
 	checks := map[string]checkFunc{
-		"cache": cacheCheck,
+		"cache":   cacheCheck,
+		"network": networkCheck,
 	}
 	return &healthcheckTask{
 		checks: checks,

--- a/pkg/perf/healthcheck/network.go
+++ b/pkg/perf/healthcheck/network.go
@@ -8,6 +8,8 @@ import (
 	"sync"
 	"time"
 
+	"github.com/rs/zerolog/log"
+	"github.com/threefoldtech/zos/pkg/app"
 	"github.com/threefoldtech/zos/pkg/environment"
 )
 
@@ -40,6 +42,12 @@ func networkCheck(ctx context.Context) []error {
 	}
 	wg.Wait()
 
+	if len(errors) == 0 {
+		if err := app.DeleteFlag(app.NotReachable); err != nil {
+			log.Error().Err(err).Msg("failed to delete readonly flag")
+		}
+	}
+
 	return errors
 }
 
@@ -50,6 +58,9 @@ func checkService(ctx context.Context, serviceUrl string) error {
 	address := parseUrl(serviceUrl)
 	err := isReachable(ctx, address)
 	if err != nil {
+		if err := app.SetFlag(app.NotReachable); err != nil {
+			log.Error().Err(err).Msg("failed to set not reachable flag")
+		}
 		return fmt.Errorf("%s is not reachable: %w", serviceUrl, err)
 	}
 

--- a/pkg/power/uptime.go
+++ b/pkg/power/uptime.go
@@ -129,5 +129,9 @@ func isNodeHealthy() bool {
 		log.Error().Msg("node is running on limited cache")
 		healthy = false
 	}
+	if app.CheckFlag(app.NotReachable) {
+		log.Error().Msg("node can not reach grid services")
+		healthy = false
+	}
 	return healthy
 }


### PR DESCRIPTION
### Description
move the network check to the health check task

### Changes
- remove the standalone perf task network-health and add it as a check in the healthcheck task.
- modify the schedule of the healthcheck to be every 15 instead of 20 mins
- modify the report of the network check to only report the failed services for a better alignment with the other healthcheck
- updated the diagnostics package to check for the healthcheck


### Related Issues

List of related issues

### Checklist

- [ ] Tests included
- [ ] Build pass
- [ ] Documentation
- [ ] Code format and docstring
