### PR TITLE
add the last deployment timestamp to the statistics call response

### DIFF
--- a/pkg/primitives/statistics.go
+++ b/pkg/primitives/statistics.go
@@ -91,26 +91,12 @@ func (s *Statistics) active(exclude ...provision.Exclude) (activeCounters, error
 	}
 	storageCap.Cap.Add(&reserved)
 
-	lastDeploymentTimestamp := getLastDeploymentTimestamp(storageCap.Deployments)
-
 	return activeCounters{
 		storageCap.Cap,
 		len(storageCap.Deployments),
 		storageCap.Workloads,
-		lastDeploymentTimestamp,
+		storageCap.LastDeploymentTimestamp,
 	}, err
-}
-
-func getLastDeploymentTimestamp(deployments []gridtypes.Deployment) gridtypes.Timestamp {
-	lastTimestamp := gridtypes.Timestamp(0)
-	for _, deployment := range deployments {
-		for _, workload := range deployment.Workloads {
-			if workload.Result.Created > lastTimestamp {
-				lastTimestamp = workload.Result.Created
-			}
-		}
-	}
-	return lastTimestamp
 }
 
 // Total returns the node total capacity

--- a/pkg/provision/interface.go
+++ b/pkg/provision/interface.go
@@ -102,6 +102,8 @@ type StorageCapacity struct {
 	Deployments []gridtypes.Deployment
 	// Workloads the total number of all workloads
 	Workloads int
+	// LastDeploymentTimestamp last deployment timestamp
+	LastDeploymentTimestamp gridtypes.Timestamp
 }
 
 // Used with Storage interface to compute capacity, exclude any deployment

--- a/pkg/provision/storage/storage.go
+++ b/pkg/provision/storage/storage.go
@@ -718,6 +718,9 @@ func (b *BoltStorage) Capacity(exclude ...provision.Exclude) (storageCap provisi
 				isActive = true
 				storageCap.Workloads += 1
 				storageCap.Cap.Add(&c)
+				if wl.Result.Created > storageCap.LastDeploymentTimestamp {
+					storageCap.LastDeploymentTimestamp = wl.Result.Created
+				}
 			}
 			if isActive {
 				storageCap.Deployments = append(storageCap.Deployments, deployment)


### PR DESCRIPTION

### Description
add the last deployment timestamp to the statistics call response by picking the last Created field from all workloads in all node deployments


### Related Issues
- https://github.com/threefoldtech/zos/issues/2210

### Checklist

- [ ] Tests included
- [ ] Build pass
- [ ] Documentation
- [ ] Code format and docstring
