### PR TITLE
only run gatewayd after networkd is running

### DIFF
--- a/etc/zinit/gateway.yaml
+++ b/etc/zinit/gateway.yaml
@@ -1,3 +1,4 @@
 exec: gateway --broker unix:///var/run/redis.sock --root /var/cache/modules/gateway
 after:
   - boot
+  - networkd


### PR DESCRIPTION
Fixes #2230

### Description

Make sure that gateway only runs after networkd is fully setup

### Changes

Add networkd as a dependency for gateway

### Related Issues
- #2230

