### PR TITLE
fix issue with console if subnet of network ends with .0

### DIFF
--- a/pkg/primitives/vm/utils.go
+++ b/pkg/primitives/vm/utils.go
@@ -250,8 +250,18 @@ func (p *Manager) newPrivNetworkInterface(ctx context.Context, dl gridtypes.Depl
 		return pkg.VMIface{}, errors.Wrapf(err, "could not get network resource subnet")
 	}
 
+	inf.IP = inf.IP.To4()
+	if inf.IP == nil {
+		return pkg.VMIface{}, fmt.Errorf("invalid IPv4 supplied to wg interface")
+	}
+
 	if !subnet.Contains(inf.IP) {
 		return pkg.VMIface{}, fmt.Errorf("IP %s is not part of local nr subnet %s", inf.IP.String(), subnet.String())
+	}
+
+	// always the .1/24 ip is reserved
+	if inf.IP[3] == 1 {
+		return pkg.VMIface{}, fmt.Errorf("ip %s is reserved", inf.IP.String())
 	}
 
 	privNet, err := network.GetNet(ctx, netID)

--- a/pkg/vm/ch.go
+++ b/pkg/vm/ch.go
@@ -234,7 +234,7 @@ func (m *Machine) Run(ctx context.Context, socket, logs string) (pkg.MachineInfo
 	consoleURL := ""
 	for _, ifc := range m.Interfaces {
 		if ifc.Console != nil {
-			consoleURL, err = m.startCloudConsole(ctx, ifc.Console.Namespace, ifc.Console.NetworkAddr, ifc.Console.IP, vmData.PTYPath, logs)
+			consoleURL, err = m.startCloudConsole(ctx, ifc.Console.Namespace, ifc.Console.ListenAddress, ifc.Console.VmAddress, vmData.PTYPath, logs)
 			if err != nil {
 				log.Error().Err(err).Str("vm", m.ID).Msg("failed to start cloud-console for vm")
 			}

--- a/pkg/vm/machine.go
+++ b/pkg/vm/machine.go
@@ -52,9 +52,9 @@ const (
 )
 
 type Console struct {
-	Namespace   string    `json:"namespace"`
-	NetworkAddr net.IPNet `json:"network_addr"`
-	IP          net.IPNet `json:"ip"`
+	Namespace     string    `json:"namespace"`
+	ListenAddress net.IPNet `json:"network_addr"`
+	VmAddress     net.IPNet `json:"ip"`
 }
 
 // Interface nic struct


### PR DESCRIPTION
Fix regression in code that assumes subnet always ends with .1 while in matter of fact it should be .0 which cause console to fail to start