### PR TITLE
remove cloud-init cidata on deleting vms

### DIFF
--- a/pkg/primitives/vm/vm.go
+++ b/pkg/primitives/vm/vm.go
@@ -7,6 +7,7 @@ import (
 	"io"
 	"net"
 	"os"
+	"path/filepath"
 
 	"github.com/pkg/errors"
 	"github.com/rs/zerolog/log"
@@ -323,6 +324,12 @@ func (p *Manager) Deprovision(ctx context.Context, wl *gridtypes.WorkloadWithID)
 	volName := fmt.Sprintf("rootfs:%s", wl.ID.String())
 	if err := storage.VolumeDelete(ctx, volName); err != nil {
 		log.Error().Err(err).Str("name", volName).Msg("failed to delete rootfs volume")
+	}
+
+	cidataPath := filepath.Join("var", "cache", "modules", "vmd", "cloud-init", wl.ID.String())
+	err := os.RemoveAll(cidataPath)
+	if err != nil {
+		log.Error().Err(err).Str("path", cidataPath).Msg("failed to delete cloud-init cidata seed")
 	}
 
 	for _, inf := range cfg.Network.Interfaces {


### PR DESCRIPTION
### Description

remove cloud-init cidata seed when Vm is deleted

### Related Issues

- #2234 
### Checklist

- [ ] Tests included
- [ ] Build pass
- [ ] Documentation
- [ ] Code format and docstring
