### PR TITLE
delete the whole keys to reset the errors map

### DIFF
--- a/pkg/perf/healthcheck/healthcheck.go
+++ b/pkg/perf/healthcheck/healthcheck.go
@@ -62,7 +62,7 @@ func (h *healthcheckTask) Run(ctx context.Context) (interface{}, error) {
 	log.Debug().Msg("starting health check task")
 	for k := range h.errors {
 		// reset errors on each run
-		h.errors[k] = nil
+		delete(h.errors, k)
 	}
 
 	for label, check := range h.checks {

--- a/pkg/perf/healthcheck/healthcheck.go
+++ b/pkg/perf/healthcheck/healthcheck.go
@@ -65,8 +65,8 @@ func (h *healthcheckTask) Run(ctx context.Context) (interface{}, error) {
 		if len(errors) == 0 {
 			continue
 		}
-		stringErrs := errorsToStrings(errors)
-		errs[label] = append(errs[label], stringErrs...)
+
+		errs[label] = errorsToStrings(errors)
 	}
 
 	cl := perf.GetZbusClient(ctx)

--- a/pkg/perf/healthcheck/healthcheck.go
+++ b/pkg/perf/healthcheck/healthcheck.go
@@ -25,7 +25,6 @@ func NewTask() perf.Task {
 	}
 	return &healthcheckTask{
 		checks: checks,
-		errors: make(map[string][]string),
 	}
 }
 
@@ -33,7 +32,6 @@ type checkFunc func(context.Context) []error
 
 type healthcheckTask struct {
 	checks map[string]checkFunc
-	errors map[string][]string
 }
 
 var _ perf.Task = (*healthcheckTask)(nil)
@@ -60,10 +58,7 @@ func (h *healthcheckTask) Description() string {
 // Run executes the health checks.
 func (h *healthcheckTask) Run(ctx context.Context) (interface{}, error) {
 	log.Debug().Msg("starting health check task")
-	for k := range h.errors {
-		// reset errors on each run
-		delete(h.errors, k)
-	}
+	errs := make(map[string][]string)
 
 	for label, check := range h.checks {
 		errors := check(ctx)
@@ -71,19 +66,19 @@ func (h *healthcheckTask) Run(ctx context.Context) (interface{}, error) {
 			continue
 		}
 		stringErrs := errorsToStrings(errors)
-		h.errors[label] = append(h.errors[label], stringErrs...)
+		errs[label] = append(errs[label], stringErrs...)
 	}
 
 	cl := perf.GetZbusClient(ctx)
 	zui := stubs.NewZUIStub(cl)
 
-	for label, data := range h.errors {
-		err := zui.PushErrors(ctx, label, data)
+	for label := range h.checks {
+		err := zui.PushErrors(ctx, label, errs[label])
 		if err != nil {
 			return nil, err
 		}
 	}
-	return h.errors, nil
+	return errs, nil
 }
 
 func errorsToStrings(errs []error) []string {


### PR DESCRIPTION
### Description
when a diagnostics call is made it checks on the length of the map to report unhealthy if the errors map is not empty.
setting keys to nil leaves the key in the map so it will fail the check

### Changes
delete the whole keys to reset the errors map on each healthcheck run

### Checklist

- [ ] Tests included
- [ ] Build pass
- [ ] Documentation
- [ ] Code format and docstring
