### PR TITLE
add kernel flag to override ntp conf

### DIFF
--- a/pkg/environment/environment.go
+++ b/pkg/environment/environment.go
@@ -62,6 +62,9 @@ type Environment struct {
 
 	// PubMac value from environment
 	PubMac PubMac
+
+	// NTPServer will override the values on /etc/ntp.conf
+	NTPServer *string
 }
 
 // RunMode type
@@ -247,6 +250,12 @@ func getEnvironmentFromParams(params kernel.Params) (Environment, error) {
 	if farmSecret, ok := params.Get("secret"); ok {
 		if len(farmSecret) > 0 {
 			env.FarmSecret = farmSecret[len(farmSecret)-1]
+		}
+	}
+
+	if ntps, ok := params.Get("ntp"); ok {
+		if len(ntps) > 0 {
+			env.NTPServer = &ntps[0]
 		}
 	}
 

--- a/pkg/environment/environment.go
+++ b/pkg/environment/environment.go
@@ -253,10 +253,8 @@ func getEnvironmentFromParams(params kernel.Params) (Environment, error) {
 		}
 	}
 
-	if ntps, ok := params.Get("ntp"); ok {
-		if len(ntps) > 0 {
-			env.NTPServer = &ntps[0]
-		}
+	if ntps, ok := params.GetOne("ntp"); ok {
+		env.NTPServer = &ntps
 	}
 
 	farmerID, found := params.Get("farmer_id")

--- a/qemu/README.md
+++ b/qemu/README.md
@@ -121,6 +121,20 @@ sudo ./vm.sh -n node-01 -c "farmer_id=47 printk.devmsg=on runmode=dev ssh-user=<
 - `farmer_id` is the id of the farm you registered with `tffarmer`
 - `ssh-user` is github username provided if a user need to pass ssh-key to the node
 - `ntp` a comma separated list with ntp servers to override `/etc/ntp.conf`
+  Example: run with zonal ntp pool
+
+  ```bash
+  sudo ./vm.sh -n node-01 -c "farmer_id=47 printk.devmsg=on runmode=dev ssh-user=<github username> ntp=0.africa.pool.ntp.org,1.africa.pool.ntp.org,2.africa.pool.ntp.org"
+  ```
+
+  this override the `/etc/ntp.conf` file to be:
+
+  ```text
+  server 0.africa.pool.ntp.org
+  server 1.africa.pool.ntp.org
+  server 2.africa.pool.ntp.org
+  ```
+
 
 NOTE: it is assumed you get a proper IPv6 address, if not, omit the IPv6 parts
 

--- a/qemu/README.md
+++ b/qemu/README.md
@@ -115,9 +115,12 @@ sudo dnsmasq --strict-order \
 sudo ./vm.sh -n node-01 -c "farmer_id=47 printk.devmsg=on runmode=dev ssh-user=<github username>"
 ```
 
-where `runmode` is one of `dev` , `test`  or `prod`, 
-      `farmer_id` is the id of the farm you registered with `tffarmer`
-      `ssh-user` is github username provided if a user need to pass ssh-key to the node
+### Flags and kernel args:
+
+- `runmode` is one of `dev` , `test`  or `prod`.
+- `farmer_id` is the id of the farm you registered with `tffarmer`
+- `ssh-user` is github username provided if a user need to pass ssh-key to the node
+- `ntp` a comma separated list with ntp servers to override `/etc/ntp.conf`
 
 NOTE: it is assumed you get a proper IPv6 address, if not, omit the IPv6 parts
 


### PR DESCRIPTION

### Description
ntp flag is a comma seperated list of ntp servers, which will override the content in /etc/ntp.conf

### Changes
ntp flag is a comma seperated list of ntp servers, which will override the content in /etc/ntp.conf


### Related Issues
- https://github.com/threefoldtech/zos/issues/2219

### Checklist

- [ ] Tests included
- [ ] Build pass
- [ ] Documentation
- [ ] Code format and docstring
