### PR TITLE
Add volume workload

### DIFF
--- a/cmds/modules/provisiond/main.go
+++ b/cmds/modules/provisiond/main.go
@@ -318,6 +318,7 @@ func action(cli *cli.Context) error {
 		// comes first.
 		provision.WithStartupOrder(
 			zos.ZMountType,
+			zos.VolumeType,
 			zos.QuantumSafeFSType,
 			zos.NetworkType,
 			zos.PublicIPv4Type,

--- a/pkg/gridtypes/zos/types.go
+++ b/pkg/gridtypes/zos/types.go
@@ -16,6 +16,8 @@ const (
 	ZDBType gridtypes.WorkloadType = "zdb"
 	// ZMachineType type
 	ZMachineType gridtypes.WorkloadType = "zmachine"
+	// VolumeType type
+	VolumeType gridtypes.WorkloadType = "volume"
 	//PublicIPv4Type type [deprecated]
 	PublicIPv4Type gridtypes.WorkloadType = "ipv4"
 	//PublicIPType type is the new way to assign public ips
@@ -37,6 +39,7 @@ func init() {
 	// deployments.
 	gridtypes.RegisterSharableType(NetworkType, Network{})
 	gridtypes.RegisterType(ZMountType, ZMount{})
+	gridtypes.RegisterType(VolumeType, Volume{})
 	gridtypes.RegisterType(ZDBType, ZDB{})
 	gridtypes.RegisterType(ZMachineType, ZMachine{})
 	gridtypes.RegisterType(PublicIPv4Type, PublicIP4{})

--- a/pkg/gridtypes/zos/volume.go
+++ b/pkg/gridtypes/zos/volume.go
@@ -1,0 +1,40 @@
+package zos
+
+import (
+	"fmt"
+	"io"
+
+	"github.com/threefoldtech/zos/pkg/gridtypes"
+)
+
+type Volume struct {
+	Size gridtypes.Unit `json:"size"`
+}
+
+var _ gridtypes.WorkloadData = (*Volume)(nil)
+
+func (v Volume) Capacity() (gridtypes.Capacity, error) {
+	return gridtypes.Capacity{
+		SRU: v.Size,
+	}, nil
+}
+
+func (v Volume) Valid(getter gridtypes.WorkloadGetter) error {
+	if v.Size == 0 {
+		return fmt.Errorf("invalid size")
+	}
+
+	return nil
+}
+
+func (v Volume) Challenge(w io.Writer) error {
+	if _, err := fmt.Fprintf(w, "%d", v.Size); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+type VolumeResult struct {
+	ID string `json:"id"`
+}

--- a/pkg/primitives/provisioner.go
+++ b/pkg/primitives/provisioner.go
@@ -9,6 +9,7 @@ import (
 	"github.com/threefoldtech/zos/pkg/primitives/pubip"
 	"github.com/threefoldtech/zos/pkg/primitives/qsfs"
 	"github.com/threefoldtech/zos/pkg/primitives/vm"
+	"github.com/threefoldtech/zos/pkg/primitives/volume"
 	"github.com/threefoldtech/zos/pkg/primitives/zdb"
 	"github.com/threefoldtech/zos/pkg/primitives/zlogs"
 	"github.com/threefoldtech/zos/pkg/primitives/zmount"
@@ -26,6 +27,7 @@ func NewPrimitivesProvisioner(zbus zbus.Client) provision.Provisioner {
 		zos.PublicIPType:         pubip.NewManager(zbus),
 		zos.PublicIPv4Type:       pubip.NewManager(zbus), // backward compatibility
 		zos.ZMachineType:         vm.NewManager(zbus),
+		zos.VolumeType:           volume.NewManager(zbus),
 		zos.GatewayNameProxyType: gateway.NewNameManager(zbus),
 		zos.GatewayFQDNProxyType: gateway.NewFQDNManager(zbus),
 	}

--- a/pkg/primitives/volume/volume.go
+++ b/pkg/primitives/volume/volume.go
@@ -1,0 +1,99 @@
+package volume
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"os"
+
+	"github.com/threefoldtech/zbus"
+	"github.com/threefoldtech/zos/pkg/gridtypes"
+	"github.com/threefoldtech/zos/pkg/gridtypes/zos"
+	"github.com/threefoldtech/zos/pkg/provision"
+	"github.com/threefoldtech/zos/pkg/stubs"
+)
+
+type Volume = zos.Volume
+type VolumeResult = zos.VolumeResult
+
+type Manager struct {
+	client zbus.Client
+}
+
+var (
+	_ provision.Manager = (*Manager)(nil)
+	_ provision.Updater = (*Manager)(nil)
+)
+
+func NewManager(client zbus.Client) Manager {
+	return Manager{client: client}
+}
+
+func (m Manager) Provision(ctx context.Context, wl *gridtypes.WorkloadWithID) (interface{}, error) {
+	storage := stubs.NewStorageModuleStub(m.client)
+
+	var volume Volume
+	if err := json.Unmarshal(wl.Data, &volume); err != nil {
+		return nil, fmt.Errorf("failed to parse workload data as volume: %w", err)
+	}
+	volumeName := wl.ID.String()
+
+	exists, err := storage.VolumeExists(ctx, volumeName)
+	if err != nil {
+		return nil, fmt.Errorf("failed to lookup volume with name %q: %w", volumeName, err)
+	} else if exists {
+		return VolumeResult{ID: volumeName}, provision.ErrNoActionNeeded
+	}
+
+	_, err = storage.VolumeCreate(ctx, volumeName, volume.Size)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create new volume with name %q: %w", volumeName, err)
+	}
+	return VolumeResult{ID: volumeName}, nil
+}
+func (m Manager) Deprovision(ctx context.Context, wl *gridtypes.WorkloadWithID) error {
+	storage := stubs.NewStorageModuleStub(m.client)
+
+	var volume Volume
+	if err := json.Unmarshal(wl.Data, &volume); err != nil {
+		return fmt.Errorf("failed to parse workload data as volume: %w", err)
+	}
+
+	volumeName := wl.ID.String()
+
+	exists, err := storage.VolumeExists(ctx, volumeName)
+	if err != nil {
+		return fmt.Errorf("failed to lookup volume %q: %w", volumeName, err)
+	} else if !exists {
+		return fmt.Errorf("no volume with name %q found: %w", volumeName, err)
+	}
+
+	return storage.VolumeDelete(ctx, volumeName)
+}
+
+func (m Manager) Update(ctx context.Context, wl *gridtypes.WorkloadWithID) (interface{}, error) {
+	storage := stubs.NewStorageModuleStub(m.client)
+
+	var volume Volume
+	if err := json.Unmarshal(wl.Data, &volume); err != nil {
+		return nil, fmt.Errorf("failed to parse workload data as volume: %w", err)
+	}
+	volumeName := wl.ID.String()
+
+	vol, err := storage.VolumeLookup(ctx, volumeName)
+	if errors.Is(err, os.ErrNotExist) {
+		return nil, fmt.Errorf("no volume with name %q found: %w", volumeName, err)
+	} else if err != nil {
+		return nil, fmt.Errorf("failed to lookup volume %q: %w", volumeName, err)
+	}
+
+	if volume.Size < vol.Usage.Used {
+		return nil, fmt.Errorf("cannot shrink volume to be less than used space. used: %d, requested: %d", vol.Usage.Used, volume.Size)
+	}
+
+	if err := storage.VolumeUpdate(ctx, volumeName, volume.Size); err != nil {
+		return nil, fmt.Errorf("failed to update volume %q: %w", volumeName, err)
+	}
+	return VolumeResult{ID: volumeName}, nil
+}

--- a/pkg/provision/engine_test.go
+++ b/pkg/provision/engine_test.go
@@ -78,63 +78,107 @@ import (
 // 	assert.EqualValues(t, 0, workloads.K8sVM)
 // }
 
-func TestGetZmountSize(t *testing.T) {
+func TestGetMountSize(t *testing.T) {
 	t.Run("invalid type", func(t *testing.T) {
 		wl := gridtypes.WorkloadWithID{
 			Workload: &gridtypes.Workload{Type: "invalid"},
 		}
-		_, err := getZmountSize(wl.Workload)
+		_, err := getMountSize(wl.Workload)
 		assert.Error(t, err)
 	})
 	t.Run("different data type", func(t *testing.T) {
 		wl := gridtypes.WorkloadWithID{
 			Workload: &gridtypes.Workload{Type: zos.ZDBType, Data: json.RawMessage(`{"size": 10}`)},
 		}
-		_, err := getZmountSize(wl.Workload)
+		_, err := getMountSize(wl.Workload)
 		assert.Error(t, err)
 	})
 	t.Run("valid data", func(t *testing.T) {
 		wl := gridtypes.WorkloadWithID{
 			Workload: &gridtypes.Workload{Type: zos.ZMountType, Data: json.RawMessage(`{"size": 10}`)},
 		}
-		size, err := getZmountSize(wl.Workload)
+		size, err := getMountSize(wl.Workload)
+		assert.NoError(t, err)
+		assert.Equal(t, size, gridtypes.Unit(10))
+	})
+	t.Run("volumes", func(t *testing.T) {
+		wl := gridtypes.WorkloadWithID{
+			Workload: &gridtypes.Workload{Type: zos.VolumeType, Data: json.RawMessage(`{"size": 10}`)},
+		}
+		size, err := getMountSize(wl.Workload)
 		assert.NoError(t, err)
 		assert.Equal(t, size, gridtypes.Unit(10))
 	})
 
 }
 
-func TestSortZmountWorkloads(t *testing.T) {
-	workloads := []*gridtypes.WorkloadWithID{
-		{Workload: &gridtypes.Workload{
-			Type: zos.ZMountType,
-			Data: json.RawMessage(`{"size": 10}`),
-		}},
-		{Workload: &gridtypes.Workload{
-			Type: zos.ZMountType,
-			Data: json.RawMessage(`{"size": 30}`),
-		}},
-		{Workload: &gridtypes.Workload{
-			Type: zos.ZMountType,
-			Data: json.RawMessage(`{"size": 20}`),
-		}},
-	}
+func TestSortMountWorkloads(t *testing.T) {
+	t.Run("zmounts", func(t *testing.T) {
+		workloads := []*gridtypes.WorkloadWithID{
+			{Workload: &gridtypes.Workload{
+				Type: zos.ZMountType,
+				Data: json.RawMessage(`{"size": 10}`),
+			}},
+			{Workload: &gridtypes.Workload{
+				Type: zos.ZMountType,
+				Data: json.RawMessage(`{"size": 30}`),
+			}},
+			{Workload: &gridtypes.Workload{
+				Type: zos.ZMountType,
+				Data: json.RawMessage(`{"size": 20}`),
+			}},
+		}
 
-	expectedWorkloads := []*gridtypes.WorkloadWithID{
-		{Workload: &gridtypes.Workload{
-			Type: zos.ZMountType,
-			Data: json.RawMessage(`{"size": 30}`),
-		}},
-		{Workload: &gridtypes.Workload{
-			Type: zos.ZMountType,
-			Data: json.RawMessage(`{"size": 20}`),
-		}},
-		{Workload: &gridtypes.Workload{
-			Type: zos.ZMountType,
-			Data: json.RawMessage(`{"size": 10}`),
-		}},
-	}
+		expectedWorkloads := []*gridtypes.WorkloadWithID{
+			{Workload: &gridtypes.Workload{
+				Type: zos.ZMountType,
+				Data: json.RawMessage(`{"size": 30}`),
+			}},
+			{Workload: &gridtypes.Workload{
+				Type: zos.ZMountType,
+				Data: json.RawMessage(`{"size": 20}`),
+			}},
+			{Workload: &gridtypes.Workload{
+				Type: zos.ZMountType,
+				Data: json.RawMessage(`{"size": 10}`),
+			}},
+		}
 
-	sortZmountWorkloads(workloads)
-	assert.Equal(t, expectedWorkloads, workloads)
+		sortMountWorkloads(workloads)
+		assert.Equal(t, expectedWorkloads, workloads)
+	})
+	t.Run("volumes", func(t *testing.T) {
+		workloads := []*gridtypes.WorkloadWithID{
+			{Workload: &gridtypes.Workload{
+				Type: zos.VolumeType,
+				Data: json.RawMessage(`{"size": 10}`),
+			}},
+			{Workload: &gridtypes.Workload{
+				Type: zos.VolumeType,
+				Data: json.RawMessage(`{"size": 30}`),
+			}},
+			{Workload: &gridtypes.Workload{
+				Type: zos.VolumeType,
+				Data: json.RawMessage(`{"size": 20}`),
+			}},
+		}
+
+		expectedWorkloads := []*gridtypes.WorkloadWithID{
+			{Workload: &gridtypes.Workload{
+				Type: zos.VolumeType,
+				Data: json.RawMessage(`{"size": 30}`),
+			}},
+			{Workload: &gridtypes.Workload{
+				Type: zos.VolumeType,
+				Data: json.RawMessage(`{"size": 20}`),
+			}},
+			{Workload: &gridtypes.Workload{
+				Type: zos.VolumeType,
+				Data: json.RawMessage(`{"size": 10}`),
+			}},
+		}
+
+		sortMountWorkloads(workloads)
+		assert.Equal(t, expectedWorkloads, workloads)
+	})
 }


### PR DESCRIPTION
### Description

Add `volume` workload to allow the user to create volumes and attach them to zmachines, it should offer more performance, usability and easier upgrades to `bcachefs`

### Changes

- new `volume` workload
- it supports growing and shrinking the quota while the VM is running

### Related Issues

- #2257 

### Checklist

- [x] Tests included
- [x] Build pass
- [x] Documentation
- [x] Code format and docstring
