### PR TITLE
Make sure to only trigger event if ip actually change

### DIFF
--- a/pkg/network/networker.go
+++ b/pkg/network/networker.go
@@ -1260,7 +1260,7 @@ func (n *networker) PublicAddresses(ctx context.Context) <-chan pkg.OptionPublic
 func (n *networker) ZOSAddresses(ctx context.Context) <-chan pkg.NetlinkAddresses {
 
 	var index int
-	backoff.Retry(func() error {
+	_ = backoff.Retry(func() error {
 		link, err := netlink.LinkByName(types.DefaultBridge)
 		if err != nil {
 			log.Error().Err(err).Msg("can't get defaut bridge")

--- a/pkg/registrar/registrar.go
+++ b/pkg/registrar/registrar.go
@@ -147,6 +147,7 @@ func (r *Registrar) register(ctx context.Context, cl zbus.Client, env environmen
 				log.Error().Err(err).Msg("failed to reactivate account")
 			}
 		case <-addressesUpdate:
+			log.Info().Msg("zos address has changed, re-register")
 			register()
 		}
 	}


### PR DESCRIPTION
I noticed on devnet that the node is continuesly trying to re-register itself on the chain. This happened aftre we add monitoring to changes to zos ip address.

There were some of the flows here:
- We handled changes to ALL ips on the host name space, not limited to the zos interface.
- For some reason, even with the device filter, the event keep happening even with `ip monitor address` command line, u can see events are being triggered all the time, but no actual change (i assume it's slaac since ip6 is what is included in the event)

To fix the previous errors, we did the following:
- Filter only changes on the zos bridge
- Make sure there is actually ip change before triggering the event
