### PR TITLE
update zdb flist

### DIFF
--- a/pkg/primitives/zdb/zdb.go
+++ b/pkg/primitives/zdb/zdb.go
@@ -28,7 +28,7 @@ import (
 const (
 	// https://hub.grid.tf/api/flist/tf-autobuilder/threefoldtech-0-db-development.flist/light
 	// To get the latest symlink pointer
-	zdbFlistURL         = "https://hub.grid.tf/tf-autobuilder/threefoldtech-0-db-release-development-v2-b199b3b1c0.flist"
+	zdbFlistURL         = "https://hub.grid.tf/tf-autobuilder/threefoldtech-0-db-release-v2.0.8-55737c9202.flist"
 	zdbContainerNS      = "zdb"
 	zdbContainerDataMnt = "/zdb"
 	zdbPort             = 9900


### PR DESCRIPTION
### Description

zdb module uses an old flist from 2 years ago

### Changes

update zdb url to be latest https://hub.grid.tf/tf-autobuilder/threefoldtech-0-db-release-v2.0.8-55737c9202.flist

### Related Issues

- #2348 

### Checklist

- [ ] Tests included
- [ ] Build pass
- [ ] Documentation
- [ ] Code format and docstring
