### PR TITLE
Handle phantom public-config change

### DIFF
--- a/cmds/modules/noded/main.go
+++ b/cmds/modules/noded/main.go
@@ -235,7 +235,7 @@ func action(cli *cli.Context) error {
 
 	go func() {
 		for {
-			if err := public(ctx, node, env, redis, consumer); err != nil {
+			if err := public(ctx, node, redis, consumer); err != nil {
 				log.Error().Err(err).Msg("setting public config failed")
 				<-time.After(10 * time.Second)
 			}

--- a/cmds/modules/noded/public.go
+++ b/cmds/modules/noded/public.go
@@ -9,7 +9,6 @@ import (
 	substrate "github.com/threefoldtech/tfchain/clients/tfchain-client-go"
 	"github.com/threefoldtech/zbus"
 	"github.com/threefoldtech/zos/pkg"
-	"github.com/threefoldtech/zos/pkg/environment"
 	"github.com/threefoldtech/zos/pkg/events"
 	"github.com/threefoldtech/zos/pkg/stubs"
 )
@@ -31,7 +30,7 @@ func setPublicConfig(ctx context.Context, cl zbus.Client, cfg *substrate.PublicC
 }
 
 // public sets and watches changes to public config on chain and tries to apply the provided setup
-func public(ctx context.Context, nodeID uint32, env environment.Environment, cl zbus.Client, events *events.RedisConsumer) error {
+func public(ctx context.Context, nodeID uint32, cl zbus.Client, events *events.RedisConsumer) error {
 	ch, err := events.PublicConfig(ctx)
 	if err != nil {
 		return errors.Wrap(err, "failed to subscribe to node events")
@@ -57,8 +56,9 @@ reapply:
 
 		for {
 			select {
+			case <-ctx.Done():
+				return nil
 			case event := <-ch:
-
 				log.Info().Msgf("got a public config update: %+v", event.PublicConfig)
 				var cfg *substrate.PublicConfig
 				if event.PublicConfig.HasValue {

--- a/pkg/events/redis.go
+++ b/pkg/events/redis.go
@@ -265,7 +265,7 @@ func (r *RedisConsumer) consumer(ctx context.Context, stream string, ch reflect.
 					if chosen == 0 {
 						return
 					}
-				} else if err != nil {
+				} else {
 					logger.Error().Err(err).Str("id", message.ID).Msg("failed to handle message")
 				}
 


### PR DESCRIPTION

### Description

Sometimes nodes reboot randomly because they receive phantom public-config changes.

This was a code bug because we didn't handle ctx cancellation which caused the channel to receive a "zero" event which contains no data which causes the node to remove it's public config and then reboot

this happens only with nodes that have public config

Describe the changes introduced by this PR and what does it affect
