### PR TITLE
fixes iperf test results

### DIFF
--- a/pkg/perf/iperf/iperf_task.go
+++ b/pkg/perf/iperf/iperf_task.go
@@ -136,9 +136,10 @@ func (t *IperfTest) runIperfTest(ctx context.Context, clientIP string, tcp bool)
 	opts := make([]string, 0)
 	opts = append(opts,
 		"--client", clientIP,
-		"--bandwidth", "1M",
 		"--port", fmt.Sprint(iperf.IperfPort),
 		"--interval", "20",
+		"--bandwidth", "0", // unlimited because udp limit is set to 1M by default
+		"-R", // doing the test in reverse gives more accurate results
 		"--json",
 	)
 


### PR DESCRIPTION
### Description
fixes iperf test results
### Changes
 - removed the bandwidth limit was set to 1M and make it unlimited
 - do test in reverse this gave more accurate results 

### Related Issues
https://github.com/threefoldtech/zos/issues/2325

results 
before 
![image](https://github.com/threefoldtech/zos/assets/1689456/6749669b-18c5-4241-8cf1-38d24149e1da)
after
![image](https://github.com/threefoldtech/zos/assets/1689456/b79a26e0-87b1-4aeb-9dab-5322b31705ac)
for example  
the upload value in the last line changed from ` upload_speed:999916.0006047958` to `upload_speed:2.5520320909405965e+07` 