### PR TITLE
storage: concurrent disk image write.

### DIFF
--- a/pkg/.golangci.yaml
+++ b/pkg/.golangci.yaml
@@ -1,0 +1,9 @@
+linters-settings:
+  gocyclo:
+    # Minimal code complexity to report.
+    # Default: 30 (but we recommend 10-20)
+    min-complexity: 100
+  staticcheck:
+    # SAxxxx checks in https://staticcheck.io/docs/configuration/options/#checks
+    # Default: ["*"]
+    checks: ["all"]

--- a/pkg/Makefile
+++ b/pkg/Makefile
@@ -5,13 +5,11 @@ all: build
 
 getdeps:
 	@echo "Installing golint" && go install github.com/golangci/golangci-lint/cmd/golangci-lint@v1.55.0
-	@echo "Installing gocyclo" && go install github.com/fzipp/gocyclo/cmd/gocyclo@latest
 	@echo "Installing deadcode" && go install github.com/remyoudompheng/go-misc/deadcode@latest
 	@echo "Installing misspell" && go install github.com/client9/misspell/cmd/misspell@latest
 	@echo "Installing ineffassign" && go install github.com/gordonklaus/ineffassign@latest
-	@echo "Installing staticcheck" && go install honnef.co/go/tools/cmd/staticcheck@latest
 
-verifiers: vet fmt lint cyclo spelling static #deadcode
+verifiers: vet fmt lint spelling#deadcode
 
 vet:
 	@echo "Running $@"
@@ -29,19 +27,12 @@ ineffassign:
 	@echo "Running $@"
 	@${GOPATH}/bin/ineffassign .
 
-cyclo:
-	@echo "Running $@"
-	@${GOPATH}/bin/gocyclo -over 100 .
-
 deadcode:
 	@echo "Running $@"
 	@${GOPATH}/bin/deadcode -test $(shell go list ./...) || true
 
 spelling:
 	@${GOPATH}/bin/misspell -i "monitord,forumla,etherent" -error `find .`
-
-static:
-	@${GOPATH}/bin/staticcheck -- ./...
 
 check: test
 test: verifiers build

--- a/pkg/storage/disk.go
+++ b/pkg/storage/disk.go
@@ -150,19 +150,19 @@ func (s *Module) DiskWrite(name string, image string) error {
 	// the sequential write is slow because the data source is from the remote server.
 	var (
 		// use errgroup because there is no point in continuing if one of the goroutines failed
-		group               = new(errgroup.Group)
-		concurrentNum int   = 5
-		imgSize       int64 = imgStat.Size()
-		chunkSize           = imgSize / int64(concurrentNum)
+		group            = new(errgroup.Group)
+		numWorkers int   = 5
+		imgSize    int64 = imgStat.Size()
+		chunkSize        = imgSize / int64(numWorkers)
 	)
 
-	log.Info().Int("concurrentNum", concurrentNum).Msg("writing image concurrently")
-	for i := 0; i < concurrentNum; i++ {
+	log.Info().Int("numWorkers", numWorkers).Msg("writing image concurrently")
+	for i := 0; i < numWorkers; i++ {
 		index := i
 		group.Go(func() error {
 			start := chunkSize * int64(index)
 			len := chunkSize
-			if index == concurrentNum-1 { //last chunk
+			if index == numWorkers-1 { //last chunk
 				len = imgSize - start
 			}
 			wr := io.NewOffsetWriter(file, start)


### PR DESCRIPTION
Write it concurrently to speed it up from the previous sequential write.

### Description

Change image DiskWrite from sequential to concurrent, to make it faster.

### Changes

- change to concurrent write

### Related Issues

Fixes :
- #2391 
- #2405

### Checklist

- [x] Tests included -> manual test
- [x] Build pass
- [x] Documentation
- [x] Code format and docstring
