### PR TITLE
don't check the passed version if we are in 1st stage

### DIFF
--- a/bootstrap/bootstrap/README.md
+++ b/bootstrap/bootstrap/README.md
@@ -21,3 +21,25 @@ will do a multiple stage bootstrap. Currently this is only two stages:
 - As described above bootstrap run in two stages:
   - The first stage is used to update bootstrap itself, and it is done like that to avoid re-building the image if we only changed the bootstrap code. this update is basically done from `tf-autobuilder` repo in the [hub/tf-autobuilder](https://hub.grid.tf/tf-autobuilder) and download the latest bootstrap flist
   - For the second stage bootstrap will download the flists for that env. bootstrap cares about `runmode` argument that we pass during the start of the node. for example if we passed `runmode=dev` it will get the the tag `development` under [hub/tf-zos](https://hub.grid.tf/tf-zos) each tag is linked to a sub-directory where all flists for this env exists to be downloaded and installed on the node
+
+## Testing in Developer setup
+
+To test bootstrap changes on a local dev-setup you need to do the following
+
+- under zos/qemu `cp -r overlay.normal overlay.custom`
+- build `bootstrap` bin
+- copy the `bootstrap` bin to overlay.custom/sbin/
+- remove dir `overlay.custom/bin`
+- remove all files under `overlay.custom/etc/zinit/`
+- add the file overlay.custom/etc/zinit/bootstrap.yaml with the following content
+
+```
+exec: bootstrap -d
+oneshot: true
+after:
+  - internet
+```
+
+- remove overlay link under `qemu/overlay `
+- create a new link pointing to overlay.custom under zos/qemu `ln -s overlay.custom overlay`
+- boot your vm as normal

--- a/bootstrap/bootstrap/src/config.rs
+++ b/bootstrap/bootstrap/src/config.rs
@@ -119,12 +119,15 @@ impl Config {
         if stage == 0 {
             bail!("invalid stage value 0, stages starting from 1");
         }
-
+        let mut ver = Version::V3;
+        if stage == 2 {
+            ver = version()?
+        }
         Ok(Config {
             stage,
             debug: matches.occurrences_of("debug") > 0,
             runmode: runmode()?,
-            version: version()?,
+            version: ver,
         })
     }
 }


### PR DESCRIPTION
### Description
don't consider version in first stage of bootstrap

### Changes

skip passed version if bootstrap is running in 1st stage

### Related Issues

List of related issues

### Checklist

- [ ] Tests included
- [ ] Build pass
- [ ] Documentation
- [ ] Code format and docstring
