### PR TITLE
zdb network migration

### DIFF
--- a/pkg/network.go
+++ b/pkg/network.go
@@ -96,6 +96,9 @@ type Networker interface {
 	// for zdb is rewind. ns param is the namespace return by the ZDBPrepare
 	ZDBDestroy(ns string) error
 
+	// MigrateZdbMacvlanToVeth migrate the zdb setup to use veth instead of macvlan
+	MigrateZdbMacvlanToVeth() error
+
 	// QSFSNamespace returns the namespace of the qsfs workload
 	QSFSNamespace(id string) string
 

--- a/pkg/network/migrate_macvlan.go
+++ b/pkg/network/migrate_macvlan.go
@@ -1,0 +1,173 @@
+package network
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/containernetworking/plugins/pkg/ns"
+	"github.com/threefoldtech/zos/pkg/network/ifaceutil"
+	"github.com/threefoldtech/zos/pkg/network/namespace"
+	"github.com/threefoldtech/zos/pkg/network/options"
+	"github.com/vishvananda/netlink"
+)
+
+const (
+	zdbNsPrefix = "zdb-ns-"
+	macvlanType = "macvlan"
+)
+
+type Veth struct {
+	name      string // iface name inside the namespace
+	bridgeIdx int    // bridge index on the host
+	addresses []netlink.Addr
+	routes    []netlink.Route
+}
+
+func (n *networker) MigrateZdbMacvlanToVeth() error {
+	netNss, err := namespace.List(zdbNsPrefix)
+	if err != nil {
+		return fmt.Errorf("failed to list namespaces with prefix %q: %w", zdbNsPrefix, err)
+	}
+	if len(netNss) != 1 {
+		return fmt.Errorf("should found only one namespace with prefix %q, found %v", zdbNsPrefix, len(netNss))
+	}
+
+	netNs, err := namespace.GetByName(netNss[0])
+	if err != nil {
+		return fmt.Errorf("failed to get namespace with name %q: %w", netNss[0], err)
+	}
+	defer netNs.Close()
+
+	var veths []Veth
+	if err := netNs.Do(func(_ ns.NetNS) error {
+		veths, err = getOldInterfaces()
+		return err
+	}); err != nil {
+		return fmt.Errorf("failed to get old links from namespace %q: %w", filepath.Base(netNs.Path()), err)
+	}
+
+	for _, veth := range veths {
+		master, err := netlink.LinkByIndex(veth.bridgeIdx)
+		if err != nil {
+			return fmt.Errorf("failed to get master by index %v: %w", veth.bridgeIdx, err)
+		}
+
+		if err := netNs.Do(func(_ ns.NetNS) error {
+			return deleteOldLink(veth.name)
+		}); err != nil {
+			return fmt.Errorf("failed to remove old link in namespace: %w", err)
+		}
+
+		if err := ifaceutil.MakeVethPair(veth.name, master.Attrs().Name, 1500, netNs); err != nil {
+			return fmt.Errorf("failed to attach with veth from %q to master %q : %w", veth.name, master.Attrs().Name, err)
+		}
+
+		if err := netNs.Do(func(_ ns.NetNS) error {
+			return setupNamespace(veth.name, veth.addresses, veth.routes)
+		}); err != nil {
+			return fmt.Errorf("failed to add address in namespace: %w", err)
+		}
+	}
+
+	return nil
+}
+
+// return the macvlan interfaces info to reconstruct as veth
+func getOldInterfaces() ([]Veth, error) {
+	var veths []Veth
+
+	links, err := netlink.LinkList()
+	if err != nil {
+		return veths, fmt.Errorf("failed to list links: %w", err)
+	}
+
+	macvlanLinks := ifaceutil.LinkFilter(links, []string{macvlanType})
+	for _, l := range macvlanLinks {
+		addrs, err := netlink.AddrList(l, netlink.FAMILY_ALL)
+		if err != nil {
+			return veths, fmt.Errorf("failed to list link addresses: %w", err)
+		}
+		routes, err := netlink.RouteList(l, netlink.FAMILY_ALL)
+		if err != nil {
+			return veths, fmt.Errorf("failed to list link routes: %w", err)
+		}
+
+		veths = append(veths, Veth{
+			name:      l.Attrs().Name,
+			bridgeIdx: l.Attrs().ParentIndex,
+			addresses: addrs,
+			routes:    routes,
+		})
+	}
+
+	return veths, nil
+}
+
+func deleteOldLink(name string) error {
+	link, err := netlink.LinkByName(name)
+	if err != nil {
+		return fmt.Errorf("failed to get link by name %q: %w", name, err)
+	}
+
+	if err := netlink.LinkDel(link); err != nil {
+		return fmt.Errorf("failed to delete link by name %q: %w", name, err)
+	}
+
+	return nil
+}
+
+// add addresses and routes to the named link inside namespace
+// also it setup the link up and enable ipv6 forwarding
+func setupNamespace(linkName string, addrs []netlink.Addr, routes []netlink.Route) error {
+	link, err := netlink.LinkByName(linkName)
+	if err != nil {
+		return err
+	}
+
+	for _, addr := range addrs {
+		err = netlink.AddrAdd(link, &addr)
+		if err != nil && !os.IsExist(err) {
+			return fmt.Errorf("failed to add ip address to link: %w", err)
+		}
+	}
+
+	if err := options.SetIPv6Forwarding(true); err != nil {
+		return fmt.Errorf("failed to enable ipv6 forwarding: %w", err)
+	}
+
+	if err := netlink.LinkSetUp(link); err != nil {
+		return fmt.Errorf("failed to set link up %q: %w", link.Attrs().Name, err)
+	}
+
+	for _, route := range routes {
+		route.LinkIndex = link.Attrs().Index // the index for the new created link
+		err := netlink.RouteAdd(&route)
+		if err != nil && !os.IsExist(err) { // skip if the routing rule exists
+			return fmt.Errorf("failed to add route %v: %w", route, err)
+		}
+	}
+
+	return nil
+}
+
+// for debugging
+func (v Veth) String() string {
+	var ips, routes []string
+
+	if v.addresses != nil {
+		for _, ip := range v.addresses {
+			ips = append(ips, ip.String())
+		}
+	}
+
+	if v.routes != nil {
+		for _, route := range v.routes {
+			routes = append(routes, route.String())
+		}
+	}
+
+	return fmt.Sprintf("Veth{Name: %s, BridgeIdx: %d, IPs: [%s], Routes: [%s]}\n\n",
+		v.name, v.bridgeIdx, strings.Join(ips, ", "), strings.Join(routes, ", "))
+}

--- a/pkg/primitives/zdb/zdb.go
+++ b/pkg/primitives/zdb/zdb.go
@@ -831,6 +831,11 @@ func (p *Manager) Initialize(ctx context.Context) error {
 		delete(poolNames, string(container))
 	}
 
+	log.Debug().Msg("running zdb network setup migration")
+	if err := network.MigrateZdbMacvlanToVeth(ctx); err != nil {
+		log.Error().Err(err).Send()
+	}
+
 	// do we still have allocated pools that does not have associated zdbs.
 	for _, device := range poolNames {
 		log.Debug().Str("device", device.Path).Msg("starting zdb")

--- a/pkg/stubs/network_stub.go
+++ b/pkg/stubs/network_stub.go
@@ -307,6 +307,21 @@ func (s *NetworkerStub) Metrics(ctx context.Context) (ret0 pkg.NetResourceMetric
 	return
 }
 
+func (s *NetworkerStub) MigrateZdbMacvlanToVeth(ctx context.Context) (ret0 error) {
+	args := []interface{}{}
+	result, err := s.client.RequestContext(ctx, s.module, s.object, "MigrateZdbMacvlanToVeth", args...)
+	if err != nil {
+		panic(err)
+	}
+	result.PanicOnError()
+	ret0 = result.CallError()
+	loader := zbus.Loader{}
+	if err := result.Unmarshal(&loader); err != nil {
+		panic(err)
+	}
+	return
+}
+
 func (s *NetworkerStub) Namespace(ctx context.Context, arg0 zos.NetID) (ret0 string) {
 	args := []interface{}{arg0}
 	result, err := s.client.RequestContext(ctx, s.module, s.object, "Namespace", args...)


### PR DESCRIPTION
- add a migration script to rewire zdb network setup with veth pairs instead of macvlan
- run the script after the old setup is done
- in case no zdb setup found or it is initialized with veth the migration script should do no modifications
- https://github.com/threefoldtech/zos/issues/2446

### Checklist

- [ ] Tests included
- [ ] Build pass
- [ ] Documentation
- [ ] Code format and docstring
