### PR TITLE
add LiriaFarm as a managed mainnet farm

### DIFF
--- a/cmds/identityd/ssh.go
+++ b/cmds/identityd/ssh.go
@@ -18,7 +18,7 @@ import (
 
 var (
 	mainNetFarms = []pkg.FarmID{
-		1, 79, 77, 76,
+		1, 79, 77, 76, 3997,
 	}
 )
 


### PR DESCRIPTION
### Description

- add LiriaFarm as a managed mainnet farm

### issues
- https://github.com/threefoldtech/zos/issues/2523