### PR TITLE
Zbus Debug test in Zinit services

### DIFF
--- a/bins/packages/containerd/files/containerd.yaml
+++ b/bins/packages/containerd/files/containerd.yaml
@@ -1,5 +1,5 @@
 exec: containerd
-test: sh -c "ctr version && zbusdebug --module container"
+test: ctr version
 after:
   - node-ready
 

--- a/bins/packages/containerd/files/containerd.yaml
+++ b/bins/packages/containerd/files/containerd.yaml
@@ -1,5 +1,5 @@
 exec: containerd
-test: ctr version
+test: sh -c "ctr version && zbusdebug --module container"
 after:
   - node-ready
 

--- a/etc/zinit/contd.yaml
+++ b/etc/zinit/contd.yaml
@@ -1,4 +1,5 @@
 exec: contd --broker unix:///var/run/redis.sock --root /var/cache/modules/contd
+test: zbusdebug --module container
 after:
   - containerd
   - boot

--- a/etc/zinit/flistd.yaml
+++ b/etc/zinit/flistd.yaml
@@ -1,4 +1,5 @@
 exec: flistd --broker unix:///var/run/redis.sock --root /var/cache/modules/flistd
+test: zbusdebug --module flist
 after:
   - boot
   # identityd is added to make sure all binaries are up to date

--- a/etc/zinit/gateway.yaml
+++ b/etc/zinit/gateway.yaml
@@ -1,4 +1,5 @@
 exec: gateway --broker unix:///var/run/redis.sock --root /var/cache/modules/gateway
+test: zbusdebug --module gateway
 after:
   - boot
   - networkd

--- a/etc/zinit/noded.yaml
+++ b/etc/zinit/noded.yaml
@@ -1,4 +1,5 @@
 exec: ip netns exec ndmz noded --broker unix:///var/run/redis.sock
+test: zbusdebug --module node
 after:
   - boot
   - networkd

--- a/etc/zinit/provisiond.yaml
+++ b/etc/zinit/provisiond.yaml
@@ -1,6 +1,7 @@
 # provisind runs inside ndmz. the ndmz has rules to accept connection to
 # provisiond address :2021
 exec: provisiond --broker unix:///var/run/redis.sock --root /var/cache/modules/provisiond
+test: zbusdebug --module provision
 after:
   - boot
   - flistd

--- a/etc/zinit/qsfsd.yaml
+++ b/etc/zinit/qsfsd.yaml
@@ -1,4 +1,5 @@
 exec: qsfsd --broker unix:///var/run/redis.sock --root /var/cache/modules/qsfsd
+test: zbusdebug --module qsfsd
 after:
   - boot
   - contd

--- a/etc/zinit/storaged.yaml
+++ b/etc/zinit/storaged.yaml
@@ -1,5 +1,5 @@
 exec: storaged --broker unix:///var/run/redis.sock
 # we only consider the storaged is running only if the /var/cache is mounted
-test: mountpoint /var/cache
+test: sh -c "mountpoint /var/cache && zbusdebug --module storage"
 after:
   - node-ready

--- a/etc/zinit/vmd.yaml
+++ b/etc/zinit/vmd.yaml
@@ -1,4 +1,5 @@
 exec: vmd --broker unix:///var/run/redis.sock
+test: zbusdebug --module vmd
 after:
   - boot
   - networkd


### PR DESCRIPTION
### Description

Added test to zinit services yaml files to check on the services status using zbusdebug

### Changes

Added `test: zbusdebug --module <module>` to zinit services yaml files

### Related Issues

https://github.com/threefoldtech/zos/issues/2654

### Checklist

- [ ] Tests included
- [ ] Build pass
- [ ] Documentation
- [ ] Code format and docstring
