### PR TITLE
Update download/config URLs after repo renames

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -16,7 +16,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Set up Go 1.23
-        uses: actions/setup-go@v1
+        uses: actions/setup-go@v5
         with:
           go-version: 1.23
         id: go

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -7,7 +7,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Set up Go 1.23
-        uses: actions/setup-go@v1
+        uses: actions/setup-go@v5
         with:
           go-version: 1.23
         id: go

--- a/bins/packages/rfs/rfs.sh
+++ b/bins/packages/rfs/rfs.sh
@@ -2,8 +2,8 @@ RFS_VERSION_V1="1.1.4"
 RFS_VERSION_V2="2.0.6"
 RFS_CHECKSUM_V1="e13b70eae20f1bdf5c205c6252192ef2"
 RFS_CHECKSUM_V2="9e37743dfe94b4577ccf90c573c07638"
-RFS_LINK_V1="https://github.com/threefoldtech/rfs/releases/download/v${RFS_VERSION_V1}/rfs"
-RFS_LINK_V2="https://github.com/threefoldtech/rfs/releases/download/v${RFS_VERSION_V2}/rfs"
+RFS_LINK_V1="https://github.com/threefoldtech/zos_rfs/releases/download/v${RFS_VERSION_V1}/rfs"
+RFS_LINK_V2="https://github.com/threefoldtech/zos_rfs/releases/download/v${RFS_VERSION_V2}/rfs"
 
 download_rfs() {
     download_file ${RFS_LINK_V1} ${RFS_CHECKSUM_V1} rfs-${RFS_VERSION_V1}

--- a/bootstrap/bootstrap/README.md
+++ b/bootstrap/bootstrap/README.md
@@ -16,7 +16,7 @@ will do a multiple stage bootstrap. Currently this is only two stages:
 
 ## How to works
 
-- Bootstrap is used by [0-initramfs](https://github.com/threefoldtech/0-initramfs/blob/development-zos-v3/packages/modules.sh) to basically add `internet` and `bootstrap` services to the base image
+- Bootstrap is used by [0-initramfs](https://github.com/threefoldtech/zos_initramfs/blob/development-zos-v3/packages/modules.sh) to basically add `internet` and `bootstrap` services to the base image
 - After internet service is fully started, bootstrap will start to download flists needed for zos node to work properly
 - As described above bootstrap run in two stages:
   - The first stage is used to update bootstrap itself, and it is done like that to avoid re-building the image if we only changed the bootstrap code. this update is basically done from `tf-autobuilder` repo in the [hub/tf-autobuilder](https://hub.grid.tf/tf-autobuilder) and download the latest bootstrap flist

--- a/bootstrap/bootstrap/src/hub.rs
+++ b/bootstrap/bootstrap/src/hub.rs
@@ -15,7 +15,7 @@ struct ZosConfig {
 }
 
 fn get_hub_urls(runmode: &RunMode) -> Result<Vec<String>> {
-    let base_url = "https://github.com/threefoldtech/zos-config/raw/main/";
+    let base_url = "https://github.com/threefoldtech/zos_config/raw/main/";
     let config_filename = match runmode {
         RunMode::Prod => "production.json",
         RunMode::Dev => "development.json",

--- a/qemu/README.md
+++ b/qemu/README.md
@@ -22,7 +22,7 @@ This will download the latest prebuilt kernel from our server.
 
 In order to use the full power of theses scripts, you'll need in addition:
 
-- A self compiled version of [z-init](https://github.com/threefoldtech/zinit/)
+- A self compiled version of [z-init](https://github.com/threefoldtech/zos_zinit/)
 - All the binaries from this repository compiled
 - A working qemu with ipv6 internet reachability
 

--- a/scripts/debug_image.md
+++ b/scripts/debug_image.md
@@ -53,7 +53,7 @@ NOTE:
 
 - [cloud-hypervisor](https://github.com/cloud-hypervisor/cloud-hypervisor): hypervisor that booting the machine
 - [virtiofsd](https://gitlab.com/muhamad.azmy/virtiofsd/): used to share a host directory for the rootfs. we are using a forked version
-- [rfs v1](https://github.com/threefoldtech/rfs/tree/v1): mounts the flist file into a directory serving as the lower layer of the overlay file system.
+- [rfs v1](https://github.com/threefoldtech/zos_rfs/tree/v1): mounts the flist file into a directory serving as the lower layer of the overlay file system.
 - `overlayfs`: mounts a read-write layer on the rootfs
 
 ## Install dependencies

--- a/scripts/install_deps.sh
+++ b/scripts/install_deps.sh
@@ -6,7 +6,7 @@ CHV_URL="https://github.com/cloud-hypervisor/cloud-hypervisor/releases/download/
 RUSTUP_URL="https://sh.rustup.rs"
 VIRTIOFSD_REPO="https://gitlab.com/muhamad.azmy/virtiofsd/-/jobs/6547244336/artifacts/download?file_type=archive"
 RFS_VERSION="v1.1.1"
-RFS_URL="https://github.com/threefoldtech/rfs/releases/download/${RFS_VERSION}/rfs"
+RFS_URL="https://github.com/threefoldtech/zos_rfs/releases/download/${RFS_VERSION}/rfs"
 
 install_chv() {
     echo "Installing cloud-hypervisor ${CHV_VERSION} ..."


### PR DESCRIPTION
Repoints download/runtime URLs at the new repo names instead of relying on GitHub's non-permanent rename redirects.

**Build/runtime-critical:**
- `rfs` -> `zos_rfs`: `scripts/install_deps.sh`, `bins/packages/rfs/rfs.sh`
- `zos-config` -> `zos_config`: `bootstrap/bootstrap/src/hub.rs` (runtime config fetch)

**Doc links:** `zinit`->`zos_zinit`, `rfs`->`zos_rfs`, `0-initramfs`->`zos_initramfs`

Verified rfs v1.1.1/v1.1.4/v2.0.6 and the zos_config runmode files return 200. No functional change.

Scope: P0 only — Go module deps (zosbase/tfchain/tfgrid-sdk-go) are the separate module-path migration.

Part of the repo-rename migration off GitHub redirects.