### PR TITLE
Revert zinit/rfs URL rename

### DIFF
--- a/bins/packages/rfs/rfs.sh
+++ b/bins/packages/rfs/rfs.sh
@@ -2,8 +2,8 @@ RFS_VERSION_V1="1.1.4"
 RFS_VERSION_V2="2.0.6"
 RFS_CHECKSUM_V1="e13b70eae20f1bdf5c205c6252192ef2"
 RFS_CHECKSUM_V2="9e37743dfe94b4577ccf90c573c07638"
-RFS_LINK_V1="https://github.com/threefoldtech/zos_rfs/releases/download/v${RFS_VERSION_V1}/rfs"
-RFS_LINK_V2="https://github.com/threefoldtech/zos_rfs/releases/download/v${RFS_VERSION_V2}/rfs"
+RFS_LINK_V1="https://github.com/threefoldtech/rfs/releases/download/v${RFS_VERSION_V1}/rfs"
+RFS_LINK_V2="https://github.com/threefoldtech/rfs/releases/download/v${RFS_VERSION_V2}/rfs"
 
 download_rfs() {
     download_file ${RFS_LINK_V1} ${RFS_CHECKSUM_V1} rfs-${RFS_VERSION_V1}

--- a/qemu/README.md
+++ b/qemu/README.md
@@ -22,7 +22,7 @@ This will download the latest prebuilt kernel from our server.
 
 In order to use the full power of theses scripts, you'll need in addition:
 
-- A self compiled version of [z-init](https://github.com/threefoldtech/zos_zinit/)
+- A self compiled version of [z-init](https://github.com/threefoldtech/zinit/)
 - All the binaries from this repository compiled
 - A working qemu with ipv6 internet reachability
 

--- a/scripts/debug_image.md
+++ b/scripts/debug_image.md
@@ -53,7 +53,7 @@ NOTE:
 
 - [cloud-hypervisor](https://github.com/cloud-hypervisor/cloud-hypervisor): hypervisor that booting the machine
 - [virtiofsd](https://gitlab.com/muhamad.azmy/virtiofsd/): used to share a host directory for the rootfs. we are using a forked version
-- [rfs v1](https://github.com/threefoldtech/zos_rfs/tree/v1): mounts the flist file into a directory serving as the lower layer of the overlay file system.
+- [rfs v1](https://github.com/threefoldtech/rfs/tree/v1): mounts the flist file into a directory serving as the lower layer of the overlay file system.
 - `overlayfs`: mounts a read-write layer on the rootfs
 
 ## Install dependencies

--- a/scripts/install_deps.sh
+++ b/scripts/install_deps.sh
@@ -6,7 +6,7 @@ CHV_URL="https://github.com/cloud-hypervisor/cloud-hypervisor/releases/download/
 RUSTUP_URL="https://sh.rustup.rs"
 VIRTIOFSD_REPO="https://gitlab.com/muhamad.azmy/virtiofsd/-/jobs/6547244336/artifacts/download?file_type=archive"
 RFS_VERSION="v1.1.1"
-RFS_URL="https://github.com/threefoldtech/zos_rfs/releases/download/${RFS_VERSION}/rfs"
+RFS_URL="https://github.com/threefoldtech/rfs/releases/download/${RFS_VERSION}/rfs"
 
 install_chv() {
     echo "Installing cloud-hypervisor ${CHV_VERSION} ..."


### PR DESCRIPTION
The zinit and rfs repos were renamed back to their original names. Revert threefoldtech/zos_zinit -> threefoldtech/zinit and threefoldtech/zos_rfs -> threefoldtech/rfs. Other renames (zos_config / zos_sdk_go / zos_initramfs) are left intact.