### PR TITLE
fix(update-worker): hold latest link at GA until safe_to_upgrade

### DIFF
--- a/tools/zos-update-worker/internal/update_worker.go
+++ b/tools/zos-update-worker/internal/update_worker.go
@@ -123,6 +123,15 @@ func (w *Worker) updateZosVersion(network Network, manager client.Manager) error
 		return nil
 	}
 
+	// During a canary rollout (safe_to_upgrade == false) the version is delivered only to
+	// the configured test farms by the node upgrader. Keep the network `latest` symlink
+	// pointing at the last GA version so freshly bootstrapped nodes (and non-canary nodes)
+	// don't pick up the canary version.
+	if !chainVersion.SafeToUpgrade {
+		log.Debug().Msgf("skipping %v latest link update: version %v is not marked safe to upgrade yet", network, chainVersion.Version)
+		return nil
+	}
+
 	log.Debug().Msgf("getting substrate version %v for network %v", chainVersion.Version, network)
 
 	// now we need to find how dst is relative to src


### PR DESCRIPTION
Only advance the per-network `latest` flist symlink when the chain marks the version safe_to_upgrade. During a canary rollout (safe_to_upgrade = false) the symlink stays pinned to the last GA version, so freshly bootstrapped nodes and non-canary nodes keep booting/running GA instead of picking up the canary version.

Canary farms (config test_farms) still receive the canary via the node upgrader, which targets the chain version tag directly. The worker already parsed SafeToUpgrade but never used it.

### Description

Describe the changes introduced by this PR and what does it affect

### Changes

List of changes this PR includes

### Related Issues

List of related issues

### Checklist

- [ ] Tests included
- [ ] Build pass
- [ ] Documentation
- [ ] Code format and docstring
